### PR TITLE
20240813 peer container

### DIFF
--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -631,6 +631,9 @@ impl<X: ToClvm<NodePtr>> Sha256tree for X {
 pub struct Program(pub Vec<u8>);
 
 impl Program {
+    pub fn to_nodeptr(&self, allocator: &mut AllocEncoder) -> Result<NodePtr, Error> {
+        clvmr::serde::node_from_bytes(allocator.allocator(), &self.0).into_gen()
+    }
     pub fn from_nodeptr(allocator: &mut AllocEncoder, n: NodePtr) -> Result<Program, Error> {
         let bytes = clvmr::serde::node_to_bytes(allocator.allocator(), n).into_gen()?;
         Ok(Program(bytes))
@@ -638,6 +641,10 @@ impl Program {
 
     pub fn from_bytes(by: &[u8]) -> Program {
         Program(by.to_vec())
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.0
     }
 
     pub fn to_hex(&self) -> String {

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -734,7 +734,7 @@ impl Timeout {
 impl Add for Timeout {
     type Output = Timeout;
 
-    fn add(mut self, rhs: Self) -> Timeout {
+    fn add(self, rhs: Self) -> Timeout {
         Timeout::new(self.0 + rhs.0)
     }
 }

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -724,6 +724,14 @@ impl Timeout {
     }
 }
 
+impl Add for Timeout {
+    type Output = Timeout;
+
+    fn add(mut self, rhs: Self) -> Timeout {
+        Timeout::new(self.0 + rhs.0)
+    }
+}
+
 impl ToClvm<NodePtr> for Timeout {
     fn to_clvm(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@ pub mod channel_handler;
 mod common;
 mod log;
 pub mod outside;
+/// Provides as simple as possible a full blockchain interface that can be spoken
+/// with via a trait interface that's either local and synchronous or over a pipe.
+pub mod peer_container;
 mod referee;
 
 #[cfg(test)]

--- a/src/outside.rs
+++ b/src/outside.rs
@@ -667,6 +667,7 @@ impl PotatoHandler {
     {
         // Haven't got the channel coin yet.
         if self.waiting_to_start {
+            debug!("waiting to start");
             return Ok(());
         }
 

--- a/src/peer_container.rs
+++ b/src/peer_container.rs
@@ -340,13 +340,13 @@ pub struct SynchronousGameCradle {
 }
 
 pub struct SynchronousGameCradleConfig<'a> {
-    game_types: BTreeMap<GameType, Program>,
-    have_potato: bool,
-    identity: &'a ChiaIdentity,
-    my_contribution: Amount,
-    their_contribution: Amount,
-    channel_timeout: Timeout,
-    reward_puzzle_hash: PuzzleHash,
+    pub game_types: BTreeMap<GameType, Program>,
+    pub have_potato: bool,
+    pub identity: &'a ChiaIdentity,
+    pub my_contribution: Amount,
+    pub their_contribution: Amount,
+    pub channel_timeout: Timeout,
+    pub reward_puzzle_hash: PuzzleHash,
 }
 
 impl SynchronousGameCradle {

--- a/src/peer_container.rs
+++ b/src/peer_container.rs
@@ -1,10 +1,25 @@
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::mem::swap;
 
+use clvm_traits::ToClvm;
 use log::debug;
+use rand::Rng;
+use rand_chacha::ChaCha8Rng;
 
-use crate::channel_handler::types::ReadableMove;
-use crate::common::types::{CoinString, Error, GameID, PuzzleHash, Spend, SpendBundle, Timeout};
-use crate::outside::{GameStart, ToLocalUI};
+use crate::channel_handler::runner::channel_handler_env;
+use crate::channel_handler::types::{ChannelHandlerEnv, ChannelHandlerPrivateKeys, ReadableMove};
+use crate::common::constants::CREATE_COIN;
+use crate::common::standard_coin::{
+    sign_agg_sig_me, solution_for_conditions, standard_solution_partial, ChiaIdentity,
+};
+use crate::common::types::{
+    AllocEncoder, Amount, CoinSpend, CoinString, Error, GameID, IntoErr, Program, PuzzleHash,
+    Sha256tree, Spend, SpendBundle, Timeout, ToQuotedProgram,
+};
+use crate::outside::{
+    BootstrapTowardGame, BootstrapTowardWallet, FromLocalUI, GameStart, GameType, PacketSender,
+    PeerEnv, PeerMessage, PotatoHandler, SpendWalletReceiver, ToLocalUI, WalletSpendInterface,
+};
 
 #[derive(Default)]
 pub struct MessagePipe {
@@ -44,7 +59,7 @@ pub enum WalletBootstrapState {
 pub struct FullCoinSetAdapter {
     current_height: u64,
     watching_coins: HashMap<CoinString, WatchEntry>,
-    current_coins: HashSet<CoinString>
+    current_coins: HashSet<CoinString>,
 }
 
 impl FullCoinSetAdapter {
@@ -134,6 +149,54 @@ struct Pipe {
     bootstrap_state: Option<WalletBootstrapState>,
 }
 
+impl WalletSpendInterface for Pipe {
+    fn spend_transaction_and_add_fee(&mut self, bundle: &Spend) -> Result<(), Error> {
+        todo!();
+    }
+
+    fn register_coin(&mut self, coin_id: &CoinString, timeout: &Timeout) -> Result<(), Error> {
+        todo!();
+    }
+}
+
+impl BootstrapTowardWallet for Pipe {
+    fn channel_puzzle_hash(&mut self, puzzle_hash: &PuzzleHash) -> Result<(), Error> {
+        todo!();
+    }
+
+    fn received_channel_offer(&mut self, bundle: &SpendBundle) -> Result<(), Error> {
+        todo!();
+    }
+    fn received_channel_transaction_completion(
+        &mut self,
+        _bundle: &SpendBundle,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+}
+
+impl ToLocalUI for Pipe {
+    fn opponent_moved(&mut self, id: &GameID, readable: ReadableMove) -> Result<(), Error> {
+        todo!();
+    }
+    fn game_message(&mut self, id: &GameID, readable: &[u8]) -> Result<(), Error> {
+        todo!();
+    }
+    fn game_finished(&mut self, _id: &GameID, _my_share: Amount) -> Result<(), Error> {
+        todo!();
+    }
+    fn game_cancelled(&mut self, _id: &GameID) -> Result<(), Error> {
+        todo!();
+    }
+
+    fn shutdown_complete(&mut self, _reward_coin_string: &CoinString) -> Result<(), Error> {
+        todo!();
+    }
+    fn going_on_chain(&mut self) -> Result<(), Error> {
+        todo!();
+    }
+}
+
 pub struct RegisteredCoinsIterator<'a> {
     internal_iterator: std::collections::btree_map::Iter<'a, CoinString, WatchEntry>,
 }
@@ -142,84 +205,462 @@ impl<'a> Iterator for RegisteredCoinsIterator<'a> {
     type Item = (&'a CoinString, &'a WatchEntry);
 
     fn next(&mut self) -> std::option::Option<<Self as Iterator>::Item> {
-        self.internal_iterator.next().map(|(k,v)| (k,v))
+        self.internal_iterator.next().map(|(k, v)| (k, v))
     }
 }
 
+#[derive(Default, Clone)]
+pub struct IdleResult {
+    pub continue_on: bool,
+    pub outbound_transactions: VecDeque<SpendBundle>,
+    pub outbound_messages: VecDeque<Vec<u8>>,
+    pub opponent_move: Option<(GameID, ReadableMove)>,
+    pub game_finished: Option<(GameID, Amount)>,
+}
+
 pub trait GameCradle {
-    /// Signal game start.  Passes through to FromLocalUI::start_games.
-    fn start_games(
+    /// Tell this cradle to use this coin for funding.
+    fn opening_coin<R: Rng>(
         &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        coin: CoinString,
+    ) -> Result<(), Error>;
+
+    /// Tell the user that handshake has finished.
+    fn handshake_finished(&self) -> bool;
+
+    /// Signal game start.  Passes through to FromLocalUI::start_games.
+    fn start_games<R: Rng>(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
         i_initiated: bool,
-        game: &GameStart
+        game: &GameStart,
     ) -> Result<Vec<GameID>, Error>;
 
     /// Signal making a move.  Forwards to FromLocalUI::make_move.
-    fn make_move(
+    fn make_move<R: Rng>(
         &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
         id: &GameID,
-        readable: Vec<u8>
+        readable: Vec<u8>,
     ) -> Result<(), Error>;
 
     /// Signal accepting a game outcome.  Forwards to FromLocalUI::accept.
     /// Perhaps we should consider reporting the rewards.
-    fn accept(&mut self, id: &GameID) -> Result<(), Error>;
+    fn accept<R: Rng>(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        id: &GameID,
+    ) -> Result<(), Error>;
 
     /// Signal shutdown.  Forwards to FromLocalUI::shut_down.
     /// Perhaps we should consider reporting the reward coins.
     fn shut_down(&mut self) -> Result<(), Error>;
 
-    /// Whether changes were made to the registered coins.
-    fn registered_coins_changed(&self) -> bool;
-
-    /// Tell us the coin list so we can register missing ones ourselves and pick out
-    /// the proper notifications to bubble up.
-    fn get_registered_coins(&self) -> RegisteredCoinsIterator<'_>;
-
     /// Tell the game cradle that a new block arrived, giving a watch report.
-    fn new_block(&mut self, report: &WatchReport) -> Result<(), Error>;
+    fn new_block<'a, R: Rng>(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        height: usize,
+        report: &WatchReport,
+    ) -> Result<(), Error>;
 
     /// Deliver a message from the peer.
     fn deliver_message(&mut self, inbound_message: &[u8]) -> Result<(), Error>;
 
     /// Allow the game to carry out tasks it needs to perform, yielding peer messages that
     /// should be forwarded.  Returns false when no more work is needed.
-    fn idle(
+    fn idle<'a, R: Rng>(
         &mut self,
-        outbound_messages: &mut VecDeque<Vec<u8>>,
-        local_ui: &mut dyn ToLocalUI
-    ) -> Result<bool, Error>;
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        local_ui: &mut dyn ToLocalUI,
+    ) -> Result<IdleResult, Error>;
+}
+
+struct SynchronousGameCradleState {
+    current_height: u64,
+    watching_coins: HashMap<CoinString, WatchEntry>,
+
+    is_initiator: bool,
+    channel_puzzle_hash: Option<PuzzleHash>,
+    funding_coin: Option<CoinString>,
+    unfunded_offer: Option<SpendBundle>,
+    inbound_messages: VecDeque<Vec<u8>>,
+    outbound_messages: VecDeque<Vec<u8>>,
+    outbound_transactions: VecDeque<SpendBundle>,
+    opponent_moves: VecDeque<(GameID, ReadableMove)>,
+    game_messages: VecDeque<(GameID, Vec<u8>)>,
+    game_finished: VecDeque<(GameID, Amount)>,
+    identity: ChiaIdentity,
+}
+
+impl PacketSender for SynchronousGameCradleState {
+    fn send_message(&mut self, msg: &PeerMessage) -> Result<(), Error> {
+        let bson_doc = bson::to_bson(&msg).map_err(|e| Error::StrErr(format!("{e:?}")))?;
+        let msg_data = bson::to_vec(&bson_doc).map_err(|e| Error::StrErr(format!("{e:?}")))?;
+        self.outbound_messages.push_back(msg_data);
+        Ok(())
+    }
+}
+
+impl WalletSpendInterface for SynchronousGameCradleState {
+    /// Enqueue an outbound transaction.
+    fn spend_transaction_and_add_fee(&mut self, bundle: &Spend) -> Result<(), Error> {
+        todo!();
+    }
+    /// Coin should report its lifecycle until it gets spent, then should be
+    /// de-registered.
+    fn register_coin(&mut self, coin_id: &CoinString, timeout: &Timeout) -> Result<(), Error> {
+        self.watching_coins.insert(
+            coin_id.clone(),
+            WatchEntry {
+                timeout_height: timeout.clone() + Timeout::new(self.current_height as u64),
+            },
+        );
+
+        Ok(())
+    }
 }
 
 /// A game cradle that operates synchronously.  It can be composed with a game cradle that
 /// operates message pipes to become asynchronous.
 pub struct SynchronousGameCradle {
-    registrations: BTreeMap<CoinString, WatchEntry>,
+    state: SynchronousGameCradleState,
+    peer: PotatoHandler,
+}
+
+impl SynchronousGameCradle {
+    pub fn new<R: Rng>(
+        rng: &mut R,
+        game_types: BTreeMap<GameType, Program>,
+        have_potato: bool,
+        identity: &ChiaIdentity,
+        my_contribution: Amount,
+        their_contribution: Amount,
+        channel_timeout: Timeout,
+        reward_puzzle_hash: PuzzleHash,
+    ) -> Self {
+        let private_keys: ChannelHandlerPrivateKeys = rng.gen();
+        SynchronousGameCradle {
+            state: SynchronousGameCradleState {
+                is_initiator: have_potato,
+                current_height: 0,
+                watching_coins: HashMap::default(),
+                identity: identity.clone(),
+                inbound_messages: VecDeque::default(),
+                outbound_transactions: VecDeque::default(),
+                outbound_messages: VecDeque::default(),
+                opponent_moves: VecDeque::default(),
+                game_messages: VecDeque::default(),
+                game_finished: VecDeque::default(),
+                channel_puzzle_hash: None,
+                funding_coin: None,
+                unfunded_offer: None,
+            },
+            peer: PotatoHandler::new(
+                have_potato,
+                private_keys,
+                game_types,
+                my_contribution,
+                their_contribution,
+                channel_timeout,
+                reward_puzzle_hash,
+            ),
+        }
+    }
+}
+
+impl BootstrapTowardWallet for SynchronousGameCradleState {
+    fn channel_puzzle_hash(&mut self, puzzle_hash: &PuzzleHash) -> Result<(), Error> {
+        self.channel_puzzle_hash = Some(puzzle_hash.clone());
+        Ok(())
+    }
+
+    fn received_channel_offer(&mut self, bundle: &SpendBundle) -> Result<(), Error> {
+        debug!("received_channel_offer {:?}", self.identity.public_key);
+        self.unfunded_offer = Some(bundle.clone());
+        Ok(())
+    }
+
+    fn received_channel_transaction_completion(
+        &mut self,
+        bundle: &SpendBundle,
+    ) -> Result<(), Error> {
+        todo!();
+    }
+}
+
+impl ToLocalUI for SynchronousGameCradleState {
+    fn opponent_moved(&mut self, id: &GameID, readable: ReadableMove) -> Result<(), Error> {
+        self.opponent_moves.push_back((id.clone(), readable));
+        Ok(())
+    }
+    fn game_message(&mut self, id: &GameID, readable: &[u8]) -> Result<(), Error> {
+        self.game_messages
+            .push_back((id.clone(), readable.to_vec()));
+        Ok(())
+    }
+    fn game_finished(&mut self, id: &GameID, my_share: Amount) -> Result<(), Error> {
+        self.game_finished.push_back((id.clone(), my_share));
+        Ok(())
+    }
+    fn game_cancelled(&mut self, id: &GameID) -> Result<(), Error> {
+        todo!();
+    }
+    fn shutdown_complete(&mut self, reward_coin_string: &CoinString) -> Result<(), Error> {
+        todo!();
+    }
+    fn going_on_chain(&mut self) -> Result<(), Error> {
+        todo!();
+    }
+}
+
+struct SynchronousGamePeerEnv<'a, R: Rng> {
+    env: &'a mut ChannelHandlerEnv<'a, R>,
+    system_interface: &'a mut SynchronousGameCradleState,
+}
+
+impl<'a, R: Rng> PeerEnv<'a, SynchronousGameCradleState, R> for SynchronousGamePeerEnv<'a, R> {
+    fn env(
+        &mut self,
+    ) -> (
+        &mut ChannelHandlerEnv<'a, R>,
+        &mut SynchronousGameCradleState,
+    ) {
+        (self.env, self.system_interface)
+    }
+}
+
+pub fn report_coin_changes_to_peer<'a, G, R: Rng + 'a>(
+    penv: &mut dyn PeerEnv<'a, G, R>,
+    peer: &mut PotatoHandler,
+    watch_report: &WatchReport,
+) -> Result<(), Error>
+where
+    G: ToLocalUI + BootstrapTowardWallet + WalletSpendInterface + PacketSender + 'a,
+{
+    for t in watch_report.timed_out.iter() {
+        debug!("reporting coin timeout: {t:?}");
+        peer.coin_timeout_reached(penv, t)?;
+    }
+
+    // Report deleted coins
+    for d in watch_report.deleted_watched.iter() {
+        debug!("reporting coin deletion: {d:?}");
+        peer.coin_spent(penv, d)?;
+    }
+
+    // Report created coins
+    for c in watch_report.created_watched.iter() {
+        debug!("reporting coin creation: {c:?}");
+        peer.coin_created(penv, c)?;
+    }
+
+    Ok(())
+}
+
+impl SynchronousGameCradle {
+    fn create_partial_spend_for_channel_coin<R: Rng>(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        channel_puzzle_hash: PuzzleHash,
+    ) -> Result<bool, Error> {
+        // Can only create the initial spend if we have the funding coin.
+        let parent = if let Some(parent) = self.state.funding_coin.clone() {
+            parent
+        } else {
+            return Ok(false);
+        };
+
+        // Unset this state trigger.
+        self.state.channel_puzzle_hash = None;
+
+        let ch = self.peer.channel_handler()?;
+        let channel_coin = ch.state_channel_coin();
+        let channel_coin_amt = if let Some((_, _, amt)) = channel_coin.coin_string().to_parts() {
+            amt
+        } else {
+            return Err(Error::StrErr("no channel coin".to_string()));
+        };
+
+        let conditions_clvm = [(
+            CREATE_COIN,
+            (channel_puzzle_hash.clone(), (channel_coin_amt, ())),
+        )]
+        .to_clvm(allocator)
+        .into_gen()?;
+
+        let mut env = channel_handler_env(allocator, rng);
+        let spend = standard_solution_partial(
+            env.allocator,
+            &self.state.identity.synthetic_private_key,
+            &parent.to_coin_id(),
+            conditions_clvm,
+            &self.state.identity.synthetic_public_key,
+            &env.agg_sig_me_additional_data,
+            false,
+        )?;
+
+        let spend_solution_program =
+            Program::from_nodeptr(&mut env.allocator, spend.solution.clone())?;
+
+        let bundle = SpendBundle {
+            spends: vec![CoinSpend {
+                coin: parent.clone(),
+                bundle: Spend {
+                    puzzle: self.state.identity.puzzle.clone(),
+                    solution: spend_solution_program,
+                    signature: spend.signature.clone(),
+                },
+            }],
+        };
+
+        let mut penv: SynchronousGamePeerEnv<R> = SynchronousGamePeerEnv {
+            env: &mut env,
+            system_interface: &mut self.state,
+        };
+        self.peer.channel_offer(&mut penv, bundle)?;
+
+        Ok(true)
+    }
+
+    fn respond_to_unfunded_offer<R: Rng>(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        unfunded_offer: SpendBundle,
+    ) -> Result<bool, Error> {
+        let parent_coin = if let Some(parent) = self.state.funding_coin.clone() {
+            parent
+        } else {
+            return Ok(false);
+        };
+
+        self.state.unfunded_offer = None;
+
+        let mut env = channel_handler_env(allocator, rng);
+        let empty_conditions = ().to_clvm(env.allocator).into_gen()?;
+        let quoted_empty_conditions = empty_conditions.to_quoted_program(env.allocator)?;
+        let solution = solution_for_conditions(env.allocator, empty_conditions)?;
+        let quoted_empty_hash = quoted_empty_conditions.sha256tree(env.allocator);
+
+        let mut spends = unfunded_offer.clone();
+        // Create no coins.  The target is already created in the partially funded
+        // transaction.
+        //
+        // XXX break this code out
+        let signature = sign_agg_sig_me(
+            &self.state.identity.synthetic_private_key,
+            &quoted_empty_hash.bytes(),
+            &parent_coin.to_coin_id(),
+            &env.agg_sig_me_additional_data,
+        );
+        spends.spends.push(CoinSpend {
+            coin: parent_coin.clone(),
+            bundle: Spend {
+                puzzle: self.state.identity.puzzle.clone(),
+                solution: Program::from_nodeptr(env.allocator, solution)?,
+                signature,
+            },
+        });
+
+        self.state.outbound_transactions.push_back(spends);
+
+        {
+            let mut penv: SynchronousGamePeerEnv<R> = SynchronousGamePeerEnv {
+                env: &mut env,
+                system_interface: &mut self.state,
+            };
+            self.peer
+                .channel_transaction_completion(&mut penv, &unfunded_offer)?;
+        }
+
+        Ok(true)
+    }
 }
 
 impl GameCradle for SynchronousGameCradle {
-    /// Signal game start.  Passes through to FromLocalUI::start_games.
-    fn start_games(
+    fn opening_coin<R: Rng>(
         &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        coin: CoinString,
+    ) -> Result<(), Error> {
+        self.state.funding_coin = Some(coin.clone());
+
+        if !self.peer.is_initiator() {
+            return Ok(());
+        }
+
+        let mut env = channel_handler_env(allocator, rng);
+        let mut penv: SynchronousGamePeerEnv<R> = SynchronousGamePeerEnv {
+            env: &mut env,
+            system_interface: &mut self.state,
+        };
+        self.peer.start(&mut penv, coin)?;
+
+        Ok(())
+    }
+
+    fn handshake_finished(&self) -> bool {
+        self.peer.handshake_finished()
+    }
+
+    /// Signal game start.  Passes through to FromLocalUI::start_games.
+    fn start_games<R: Rng>(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
         i_initiated: bool,
-        game: &GameStart
+        game: &GameStart,
     ) -> Result<Vec<GameID>, Error> {
-        todo!();
+        let mut env = channel_handler_env(allocator, rng);
+        let mut penv: SynchronousGamePeerEnv<R> = SynchronousGamePeerEnv {
+            env: &mut env,
+            system_interface: &mut self.state,
+        };
+        self.peer.start_games(&mut penv, i_initiated, game)
     }
 
     /// Signal making a move.  Forwards to FromLocalUI::make_move.
-    fn make_move(
+    fn make_move<R: Rng>(
         &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
         id: &GameID,
-        readable: Vec<u8>
+        readable: Vec<u8>,
     ) -> Result<(), Error> {
-        todo!();
+        let mut env = channel_handler_env(allocator, rng);
+        let rehydrated_move = Program::from_bytes(&readable);
+        let readable = ReadableMove::from_nodeptr(rehydrated_move.to_nodeptr(env.allocator)?);
+        let mut penv: SynchronousGamePeerEnv<R> = SynchronousGamePeerEnv {
+            env: &mut env,
+            system_interface: &mut self.state,
+        };
+        self.peer.make_move(&mut penv, id, &readable)
     }
 
     /// Signal accepting a game outcome.  Forwards to FromLocalUI::accept.
     /// Perhaps we should consider reporting the rewards.
-    fn accept(&mut self, id: &GameID) -> Result<(), Error> {
-        todo!();
+    fn accept<R: Rng>(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        id: &GameID,
+    ) -> Result<(), Error> {
+        let mut env = channel_handler_env(allocator, rng);
+        let mut penv: SynchronousGamePeerEnv<R> = SynchronousGamePeerEnv {
+            env: &mut env,
+            system_interface: &mut self.state,
+        };
+        self.peer.accept(&mut penv, id)
     }
 
     /// Signal shutdown.  Forwards to FromLocalUI::shut_down.
@@ -228,34 +669,93 @@ impl GameCradle for SynchronousGameCradle {
         todo!();
     }
 
-    /// Whether changes were made to the registered coins.
-    fn registered_coins_changed(&self) -> bool {
-        todo!();
-    }
-
-    /// Tell us the coin list so we can register missing ones ourselves and pick out
-    /// the proper notifications to bubble up.
-    fn get_registered_coins(&self) -> RegisteredCoinsIterator<'_> {
-        todo!();
-    }
-
     /// Tell the game cradle that a new block arrived, giving a watch report.
-    fn new_block(&mut self, report: &WatchReport) -> Result<(), Error> {
-        todo!();
+    fn new_block<'a, R: Rng>(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        height: usize,
+        report: &WatchReport,
+    ) -> Result<(), Error> {
+        self.state.current_height = height as u64;
+        let mut env = channel_handler_env(allocator, rng);
+        let mut penv: SynchronousGamePeerEnv<R> = SynchronousGamePeerEnv {
+            env: &mut env,
+            system_interface: &mut self.state,
+        };
+        report_coin_changes_to_peer(&mut penv, &mut self.peer, report)?;
+        Ok(())
     }
 
     /// Deliver a message from the peer.
     fn deliver_message(&mut self, inbound_message: &[u8]) -> Result<(), Error> {
-        todo!();
+        self.state
+            .inbound_messages
+            .push_back(inbound_message.to_vec());
+        Ok(())
     }
 
     /// Allow the game to carry out tasks it needs to perform, yielding peer messages that
     /// should be forwarded.  Returns false when no more work is needed.
-    fn idle(
+    fn idle<'a, R: Rng>(
         &mut self,
-        outbound_messages: &mut VecDeque<Vec<u8>>,
-        local_ui: &mut dyn ToLocalUI
-    ) -> Result<bool, Error> {
-        todo!();
+        allocator: &mut AllocEncoder,
+        rng: &mut R,
+        local_ui: &mut dyn ToLocalUI,
+    ) -> Result<IdleResult, Error> {
+        let mut result = IdleResult::default();
+
+        swap(
+            &mut result.outbound_transactions,
+            &mut self.state.outbound_transactions,
+        );
+        self.state.outbound_transactions.clear();
+
+        swap(
+            &mut result.outbound_messages,
+            &mut self.state.outbound_messages,
+        );
+        self.state.outbound_messages.clear();
+
+        if let Some((id, msg)) = self.state.game_messages.pop_front() {
+            local_ui.game_message(&id, &msg)?;
+            return Ok(result);
+        }
+
+        if let Some((id, readable)) = self.state.opponent_moves.pop_front() {
+            local_ui.opponent_moved(&id, readable)?;
+            result.continue_on = true;
+            return Ok(result);
+        }
+
+        if let Some((id, amount)) = self.state.game_finished.pop_front() {
+            local_ui.game_finished(&id, amount.clone());
+            result.continue_on = true;
+            return Ok(result);
+        }
+
+        // If there's a message to deliver, deliver it and signal to continue.
+        if let Some(msg) = self.state.inbound_messages.pop_front() {
+            let mut env = channel_handler_env(allocator, rng);
+            let mut penv: SynchronousGamePeerEnv<R> = SynchronousGamePeerEnv {
+                env: &mut env,
+                system_interface: &mut self.state,
+            };
+            self.peer.received_message(&mut penv, msg)?;
+            result.continue_on = true;
+            return Ok(result);
+        }
+
+        if let Some(ph) = self.state.channel_puzzle_hash.clone() {
+            result.continue_on = self.create_partial_spend_for_channel_coin(allocator, rng, ph)?;
+            return Ok(result);
+        }
+
+        if let (false, Some(uo)) = (self.state.is_initiator, self.state.unfunded_offer.clone()) {
+            result.continue_on = self.respond_to_unfunded_offer(allocator, rng, uo)?;
+            return Ok(result);
+        }
+
+        Ok(result)
     }
 }

--- a/src/peer_container.rs
+++ b/src/peer_container.rs
@@ -6,6 +6,14 @@ use crate::channel_handler::types::ReadableMove;
 use crate::common::types::{CoinString, Error, GameID, PuzzleHash, Spend, SpendBundle, Timeout};
 use crate::outside::{GameStart, ToLocalUI};
 
+#[derive(Default)]
+pub struct MessagePipe {
+    pub my_id: usize,
+
+    // PacketSender
+    pub queue: VecDeque<Vec<u8>>,
+}
+
 pub trait MessagePeerQueue {
     fn message_pipe(&mut self) -> &mut MessagePipe;
     fn get_channel_puzzle_hash(&self) -> Option<PuzzleHash>;
@@ -23,14 +31,6 @@ pub struct WatchReport {
     pub created_watched: HashSet<CoinString>,
     pub deleted_watched: HashSet<CoinString>,
     pub timed_out: HashSet<CoinString>,
-}
-
-#[derive(Default)]
-pub struct MessagePipe {
-    pub my_id: usize,
-
-    // PacketSender
-    pub queue: VecDeque<Vec<u8>>,
 }
 
 pub enum WalletBootstrapState {

--- a/src/peer_container.rs
+++ b/src/peer_container.rs
@@ -43,6 +43,7 @@ pub enum WalletBootstrapState {
 /// watch report.
 #[derive(Default)]
 pub struct FullCoinSetAdapter {
+    current_height: u64,
     watching_coins: HashMap<CoinString, WatchEntry>,
     current_coins: HashSet<CoinString>
 }
@@ -50,12 +51,13 @@ pub struct FullCoinSetAdapter {
 impl FullCoinSetAdapter {
     pub fn make_report_from_coin_set_update(
         &mut self,
-        current_height: Timeout,
+        current_height: u64,
         current_coins: &[CoinString],
     ) -> Result<WatchReport, Error> {
         debug!(
             "update known coins {current_height:?}: current coins from blockchain {current_coins:?}"
         );
+        self.current_height = current_height;
         let mut current_coin_set: HashSet<CoinString> = current_coins.iter().cloned().collect();
         let created_coins: HashSet<CoinString> = current_coin_set
             .difference(&self.current_coins)

--- a/src/peer_container.rs
+++ b/src/peer_container.rs
@@ -22,7 +22,6 @@ pub trait MessagePeerQueue {
 }
 
 pub struct WatchEntry {
-    pub established_height: Timeout,
     pub timeout_height: Timeout,
 }
 

--- a/src/tests/peer/outside.rs
+++ b/src/tests/peer/outside.rs
@@ -128,7 +128,7 @@ impl ToLocalUI for Pipe {
         Ok(())
     }
     fn game_finished(&mut self, _id: &GameID, _my_share: Amount) -> Result<(), Error> {
-        todo!();
+        Ok(())
     }
     fn game_cancelled(&mut self, _id: &GameID) -> Result<(), Error> {
         todo!();
@@ -336,7 +336,8 @@ where
             };
 
             if let Some(ch) = penv.system_interface.get_channel_puzzle_hash() {
-                let parent = CoinString::from_parts(&CoinID::default(), &PuzzleHash::default(), &amount);
+                let parent =
+                    CoinString::from_parts(&CoinID::default(), &PuzzleHash::default(), &amount);
                 penv.test_handle_received_channel_puzzle_hash(&mut peers[who], &parent, &ch)?;
                 penv.system_interface.set_channel_puzzle_hash(None);
             }
@@ -344,8 +345,7 @@ where
             if let Some(ufo) = penv.system_interface.get_unfunded_offer() {
                 penv.test_handle_received_unfunded_offer(&mut peers[who], &ufo)?;
             }
-
-}
+        }
 
         if i >= 10 && i < 12 {
             let mut env = channel_handler_env(allocator, rng);

--- a/src/tests/peer/outside.rs
+++ b/src/tests/peer/outside.rs
@@ -255,10 +255,6 @@ where
 
     peer.received_message(&mut penv, msg)?;
 
-    if let Some(ufo) = penv.system_interface.get_unfunded_offer() {
-        penv.test_handle_received_unfunded_offer(peer, &ufo)?;
-    }
-
     Ok(true)
 }
 
@@ -344,7 +340,12 @@ where
                 penv.test_handle_received_channel_puzzle_hash(&mut peers[who], &parent, &ch)?;
                 penv.system_interface.set_channel_puzzle_hash(None);
             }
-        }
+
+            if let Some(ufo) = penv.system_interface.get_unfunded_offer() {
+                penv.test_handle_received_unfunded_offer(&mut peers[who], &ufo)?;
+            }
+
+}
 
         if i >= 10 && i < 12 {
             let mut env = channel_handler_env(allocator, rng);

--- a/src/tests/peer/outside.rs
+++ b/src/tests/peer/outside.rs
@@ -255,6 +255,16 @@ where
 
     peer.received_message(&mut penv, msg)?;
 
+    if let Some(ch) = penv.system_interface.get_channel_puzzle_hash() {
+        let parent = CoinString::from_parts(&CoinID::default(), &PuzzleHash::default(), &amount);
+        penv.test_handle_received_channel_puzzle_hash(peer, &parent, &ch)?;
+        penv.system_interface.set_channel_puzzle_hash(None);
+    }
+
+    if let Some(ufo) = penv.system_interface.get_unfunded_offer() {
+        penv.test_handle_received_unfunded_offer(peer, &ufo)?;
+    }
+
     Ok(true)
 }
 
@@ -327,24 +337,6 @@ where
         }
 
         i += 1;
-
-        {
-            let mut env = channel_handler_env(allocator, rng);
-            let mut penv: TestPeerEnv<P, R> = TestPeerEnv {
-                env: &mut env,
-                system_interface: &mut pipes[who],
-            };
-
-            if let Some(ch) = penv.system_interface.get_channel_puzzle_hash() {
-                let parent = CoinString::from_parts(&CoinID::default(), &PuzzleHash::default(), &amount);
-                penv.test_handle_received_channel_puzzle_hash(&mut peers[who], &parent, &ch)?;
-                penv.system_interface.set_channel_puzzle_hash(None);
-            }
-
-            if let Some(ufo) = penv.system_interface.get_unfunded_offer() {
-                penv.test_handle_received_unfunded_offer(&mut peers[who], &ufo)?;
-            }
-        }
 
         if i >= 10 && i < 12 {
             let mut env = channel_handler_env(allocator, rng);

--- a/src/tests/peer/outside.rs
+++ b/src/tests/peer/outside.rs
@@ -255,16 +255,6 @@ where
 
     peer.received_message(&mut penv, msg)?;
 
-    if let Some(ch) = penv.system_interface.get_channel_puzzle_hash() {
-        let parent = CoinString::from_parts(&CoinID::default(), &PuzzleHash::default(), &amount);
-        penv.test_handle_received_channel_puzzle_hash(peer, &parent, &ch)?;
-        penv.system_interface.set_channel_puzzle_hash(None);
-    }
-
-    if let Some(ufo) = penv.system_interface.get_unfunded_offer() {
-        penv.test_handle_received_unfunded_offer(peer, &ufo)?;
-    }
-
     Ok(true)
 }
 
@@ -337,6 +327,24 @@ where
         }
 
         i += 1;
+
+        {
+            let mut env = channel_handler_env(allocator, rng);
+            let mut penv: TestPeerEnv<P, R> = TestPeerEnv {
+                env: &mut env,
+                system_interface: &mut pipes[who],
+            };
+
+            if let Some(ch) = penv.system_interface.get_channel_puzzle_hash() {
+                let parent = CoinString::from_parts(&CoinID::default(), &PuzzleHash::default(), &amount);
+                penv.test_handle_received_channel_puzzle_hash(&mut peers[who], &parent, &ch)?;
+                penv.system_interface.set_channel_puzzle_hash(None);
+            }
+
+            if let Some(ufo) = penv.system_interface.get_unfunded_offer() {
+                penv.test_handle_received_unfunded_offer(&mut peers[who], &ufo)?;
+            }
+        }
 
         if i >= 10 && i < 12 {
             let mut env = channel_handler_env(allocator, rng);

--- a/src/tests/peer/outside.rs
+++ b/src/tests/peer/outside.rs
@@ -21,6 +21,7 @@ use crate::outside::{
     BootstrapTowardGame, BootstrapTowardWallet, FromLocalUI, GameStart, GameType, PacketSender,
     PeerEnv, PeerMessage, PotatoHandler, SpendWalletReceiver, ToLocalUI, WalletSpendInterface,
 };
+use crate::peer_container::{MessagePeerQueue, MessagePipe, WalletBootstrapState};
 
 use crate::common::constants::CREATE_COIN;
 use crate::common::standard_coin::standard_solution_partial;
@@ -28,30 +29,6 @@ use crate::common::types::{CoinSpend, Program};
 
 use crate::tests::calpoker::{load_calpoker, test_moves_1};
 use crate::tests::simenv::GameAction;
-
-#[allow(dead_code)]
-enum NotificationToLocalUI {
-    OpponentMoved(GameID, ReadableMove),
-    MessageFromOpponent(GameID, ReadableMove),
-    GameFinished(GameID, Amount),
-    GameCancelled(GameID),
-    ShutdownComplete(CoinString),
-    GoingOnChain,
-}
-
-#[allow(dead_code)]
-pub enum WalletBootstrapState {
-    PartlySigned(Spend),
-    FullySigned(Spend),
-}
-
-#[derive(Default)]
-pub struct MessagePipe {
-    pub my_id: usize,
-
-    // PacketSender
-    pub queue: VecDeque<Vec<u8>>,
-}
 
 #[derive(Default)]
 struct Pipe {
@@ -73,13 +50,6 @@ struct Pipe {
 
     #[allow(dead_code)]
     bootstrap_state: Option<WalletBootstrapState>,
-}
-
-pub trait MessagePeerQueue {
-    fn message_pipe(&mut self) -> &mut MessagePipe;
-    fn get_channel_puzzle_hash(&self) -> Option<PuzzleHash>;
-    fn set_channel_puzzle_hash(&mut self, ph: Option<PuzzleHash>);
-    fn get_unfunded_offer(&self) -> Option<SpendBundle>;
 }
 
 impl MessagePeerQueue for Pipe {

--- a/src/tests/peer/outside.rs
+++ b/src/tests/peer/outside.rs
@@ -255,12 +255,6 @@ where
 
     peer.received_message(&mut penv, msg)?;
 
-    if let Some(ch) = penv.system_interface.get_channel_puzzle_hash() {
-        let parent = CoinString::from_parts(&CoinID::default(), &PuzzleHash::default(), &amount);
-        penv.test_handle_received_channel_puzzle_hash(peer, &parent, &ch)?;
-        penv.system_interface.set_channel_puzzle_hash(None);
-    }
-
     if let Some(ufo) = penv.system_interface.get_unfunded_offer() {
         penv.test_handle_received_unfunded_offer(peer, &ufo)?;
     }
@@ -337,6 +331,20 @@ where
         }
 
         i += 1;
+
+        {
+            let mut env = channel_handler_env(allocator, rng);
+            let mut penv: TestPeerEnv<P, R> = TestPeerEnv {
+                env: &mut env,
+                system_interface: &mut pipes[who],
+            };
+
+            if let Some(ch) = penv.system_interface.get_channel_puzzle_hash() {
+                let parent = CoinString::from_parts(&CoinID::default(), &PuzzleHash::default(), &amount);
+                penv.test_handle_received_channel_puzzle_hash(&mut peers[who], &parent, &ch)?;
+                penv.system_interface.set_channel_puzzle_hash(None);
+            }
+        }
 
         if i >= 10 && i < 12 {
             let mut env = channel_handler_env(allocator, rng);

--- a/src/tests/peer/outsim.rs
+++ b/src/tests/peer/outsim.rs
@@ -22,10 +22,10 @@ use crate::outside::{
     BootstrapTowardGame, BootstrapTowardWallet, FromLocalUI, GameStart, GameType, PacketSender,
     PeerEnv, PeerMessage, PotatoHandler, SpendWalletReceiver, ToLocalUI, WalletSpendInterface,
 };
-use crate::peer_container::{FullCoinSetAdapter, WatchReport};
+use crate::peer_container::{FullCoinSetAdapter, MessagePeerQueue, MessagePipe, WatchReport};
 
 use crate::tests::calpoker::test_moves_1;
-use crate::tests::peer::outside::{quiesce, run_move, MessagePeerQueue, MessagePipe};
+use crate::tests::peer::outside::{quiesce, run_move};
 use crate::tests::simenv::GameAction;
 use crate::tests::simulator::Simulator;
 

--- a/src/tests/peer/outsim.rs
+++ b/src/tests/peer/outsim.rs
@@ -22,16 +22,12 @@ use crate::outside::{
     BootstrapTowardGame, BootstrapTowardWallet, FromLocalUI, GameStart, GameType, PacketSender,
     PeerEnv, PeerMessage, PotatoHandler, SpendWalletReceiver, ToLocalUI, WalletSpendInterface,
 };
-use crate::peer_container::{FullCoinSetAdapter, MessagePeerQueue, MessagePipe, WatchReport};
+use crate::peer_container::{FullCoinSetAdapter, MessagePeerQueue, MessagePipe, WatchEntry, WatchReport};
 
 use crate::tests::calpoker::test_moves_1;
 use crate::tests::peer::outside::{quiesce, run_move};
 use crate::tests::simenv::GameAction;
 use crate::tests::simulator::Simulator;
-
-struct WatchEntry {
-    timeout_height: Timeout,
-}
 
 // potato handler tests with simulator.
 #[derive(Default)]

--- a/src/tests/peer/outsim.rs
+++ b/src/tests/peer/outsim.rs
@@ -24,7 +24,7 @@ use crate::outside::{
 };
 use crate::peer_container::{
     report_coin_changes_to_peer, FullCoinSetAdapter, GameCradle, MessagePeerQueue, MessagePipe,
-    SynchronousGameCradle, WatchEntry, WatchReport,
+    SynchronousGameCradle, SynchronousGameCradleConfig, WatchEntry, WatchReport,
 };
 
 use crate::tests::calpoker::test_moves_1;
@@ -828,23 +828,27 @@ fn run_calpoker_container_with_action_list(allocator: &mut AllocEncoder, moves: 
 
     let cradle1 = SynchronousGameCradle::new(
         &mut rng,
-        game_type_map.clone(),
-        true,
-        &identities[0],
-        Amount::new(100),
-        Amount::new(100),
-        Timeout::new(100),
-        id1.puzzle_hash.clone(),
+        SynchronousGameCradleConfig {
+            game_types: game_type_map.clone(),
+            have_potato: true,
+            identity: &identities[0],
+            my_contribution: Amount::new(100),
+            their_contribution: Amount::new(100),
+            channel_timeout: Timeout::new(100),
+            reward_puzzle_hash: id1.puzzle_hash.clone(),
+        },
     );
     let cradle2 = SynchronousGameCradle::new(
         &mut rng,
-        game_type_map.clone(),
-        false,
-        &identities[1],
-        Amount::new(100),
-        Amount::new(100),
-        Timeout::new(100),
-        id2.puzzle_hash.clone(),
+        SynchronousGameCradleConfig {
+            game_types: game_type_map.clone(),
+            have_potato: false,
+            identity: &identities[1],
+            my_contribution: Amount::new(100),
+            their_contribution: Amount::new(100),
+            channel_timeout: Timeout::new(100),
+            reward_puzzle_hash: id2.puzzle_hash.clone(),
+        },
     );
     let mut cradles = [cradle1, cradle2];
     let mut game_ids = Vec::default();

--- a/src/tests/peer/outsim.rs
+++ b/src/tests/peer/outsim.rs
@@ -492,11 +492,19 @@ pub fn handshake<'a, R: Rng + 'a>(
             )?;
         }
 
-        if let Some(u) = pipes[who].unfunded_offer.as_ref() {
+        if let Some(u) = pipes[who].unfunded_offer.clone() {
             debug!(
                 "unfunded offer received by {:?}",
                 identities[who].synthetic_private_key
             );
+
+            {
+                let mut env = channel_handler_env(allocator, rng);
+                let mut penv =
+                    SimulatedPeerSystem::new(&mut env, &identities[who], &mut pipes[who], simulator);
+                peers[who].channel_transaction_completion(&mut penv, &u)?;
+            }
+
             let mut env = channel_handler_env(allocator, rng);
             let mut spends = u.clone();
             // Create no coins.  The target is already created in the partially funded


### PR DESCRIPTION
Introduces a container which handles most state keeping for one side of a peer conversation.
Receives normal blockchain style updates with added and removed coins.
Relays local ui notifications, which in practice are the only relevant ones the outside user needs.