### PR TITLE
Add a script to toggle chialisp dev

### DIFF
--- a/chialisp-dev/build.rs
+++ b/chialisp-dev/build.rs
@@ -1,0 +1,80 @@
+use std::collections::HashMap;
+use std::fs;
+
+use clvmr::Allocator;
+use toml::{Table, Value};
+
+use clvm_tools_rs::classic::clvm_tools::clvmc::CompileError;
+use clvm_tools_rs::classic::clvm_tools::comp_input::RunAndCompileInputData;
+use clvm_tools_rs::classic::platform::argparse::ArgumentValue;
+use clvm_tools_rs::compiler::comptypes::CompileErr;
+use clvm_tools_rs::compiler::srcloc::Srcloc;
+
+fn do_compile(title: &str, filename: &str) -> Result<(), CompileError> {
+    let mut allocator = Allocator::new();
+    let mut arguments: HashMap<String, ArgumentValue> = HashMap::new();
+    arguments.insert(
+        "include".to_string(),
+        ArgumentValue::ArgArray(vec![
+            ArgumentValue::ArgString(None, "clsp".to_string()),
+            ArgumentValue::ArgString(None, ".".to_string()),
+        ]),
+    );
+
+    let file_content = fs::read_to_string(filename).map_err(|e| {
+        CompileErr(
+            Srcloc::start(filename),
+            format!("failed to read {filename}: {e:?}"),
+        )
+    })?;
+
+    arguments.insert(
+        "path_or_code".to_string(),
+        ArgumentValue::ArgString(Some(filename.to_string()), file_content),
+    );
+
+    let parsed = RunAndCompileInputData::new(&mut allocator, &arguments).map_err(|e| {
+        CompileError::Modern(
+            Srcloc::start("*error*"),
+            format!("error building chialisp {title}: {e}"),
+        )
+    })?;
+    let mut symbol_table = HashMap::new();
+
+    parsed.compile_modern(&mut allocator, &mut symbol_table)?;
+
+    Ok(())
+}
+
+fn compile_chialisp() -> Result<(), CompileError> {
+    let srcloc = Srcloc::start("chialisp.toml");
+    let chialisp_toml_text = fs::read_to_string("chialisp.toml").map_err(|e| {
+        CompileError::Modern(
+            srcloc.clone(),
+            format!("Error reading chialisp.toml: {e:?}"),
+        )
+    })?;
+
+    let chialisp_toml = chialisp_toml_text
+        .parse::<Table>()
+        .map_err(|e| CompileError::Modern(srcloc, format!("Error parsing chialisp.toml: {e:?}")))?;
+
+    if let Some(Value::Table(t)) = chialisp_toml.get("compile") {
+        for (k, v) in t.iter() {
+            if let Value::String(s) = v {
+                do_compile(k, s)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// Compile chialisp programs in this tree.
+fn main() {
+    if std::env::var("CHIALISP_NOCOMPILE").is_err() {
+        if let Err(e) = compile_chialisp() {
+            panic!("error compiling chialisp: {e:?}");
+        }
+    }
+}

--- a/chialisp-dev/dev.toml
+++ b/chialisp-dev/dev.toml
@@ -1,0 +1,5 @@
+[dev]
+clvm_tools_rs = { git = "https://github.com/Chia-Network/clvm_tools_rs.git", rev = "ec75759377791c9b785123d2d3e2457d08ac6621" }
+
+[nodev]
+clvm_tools_rs = "0.1.45"

--- a/toggle_chialisp_dev.py
+++ b/toggle_chialisp_dev.py
@@ -1,0 +1,67 @@
+import os
+import shutil
+import json
+import tomllib
+
+def edit_line(k, v, line):
+    if line.strip().startswith(k):
+        return f'{k} = {json.dumps(v)}\n'
+    else:
+        return line
+
+def replace_line(file, k, v):
+    res = []
+    edit = False
+
+    for line in file:
+        l = line.strip()
+        if l.startswith('[build-dependencies]'):
+            edit = True
+        elif l.startswith('['):
+            edit = False
+
+        if edit:
+            res.append(edit_line(k, v, line))
+        else:
+            res.append(line)
+
+    return res
+
+def edit_cargo_toml(key):
+    dev_toml = tomllib.load(open('chialisp-dev/dev.toml', 'rb'))
+
+    lines = []
+    with open('Cargo.toml','r') as cargo:
+        lines = cargo.readlines()
+
+    for k,v in dev_toml[key].items():
+        lines = replace_line(lines, k, v)
+
+    with open('Cargo.toml','w') as cargo:
+        for l in lines:
+            cargo.write(l)
+
+def disable_chialisp_dev():
+    os.unlink('build.rs')
+
+    edit_cargo_toml('nodev')
+
+def enable_chialisp_dev():
+    shutil.copy('chialisp-dev/build.rs','build.rs')
+    edit_cargo_toml('dev')
+
+def toggle_chialisp_dev():
+    build_rs_exists = False
+    try:
+        os.stat('build.rs')
+        build_rs_exists = True
+    except:
+        build_rs_exists = False
+
+    if build_rs_exists:
+        disable_chialisp_dev()
+    else:
+        enable_chialisp_dev()
+
+if __name__ == '__main__':
+    toggle_chialisp_dev()


### PR DESCRIPTION
running toggle_chialisp_dev.py toggles whether chialisp will be compiled in the tree, but also introduces an unreleased chialisp compiler dependency (for now)