### PR TITLE
Update Rust lint/test jobs to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,7 +46,7 @@ jobs:
         toolchain: stable
 
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: cargo fmt
     steps:
       - uses: actions/checkout@v3
@@ -62,7 +62,7 @@ jobs:
         run: cargo fmt -- --files-with-diff --check
 
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -80,7 +80,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   unit_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Unit tests
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Update motivated by GitHub's deprecation of the 20.04 image. Notice text here:

```
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

March 4 14:00 UTC – 22:00 UTC
March 11 13:00 UTC – 21:00 UTC
March 18 13:00 UTC – 21:00 UTC
March 25 13:00 UTC – 21:00 UTC
```