### PR TITLE
Next step 5. capture unroll coin state number at the appropriate time rather than hackily subtracting 1

### DIFF
--- a/src/channel_handler/mod.rs
+++ b/src/channel_handler/mod.rs
@@ -217,6 +217,7 @@ impl ChannelHandler {
             my_balance,
             their_balance,
             puzzle_hashes_and_amounts: puzzle_hashes_and_amounts.to_vec(),
+            rem_condition_state: self.current_state_number,
         }
     }
 
@@ -328,7 +329,7 @@ impl ChannelHandler {
 
             cached_last_action: None,
 
-            current_state_number: 1,
+            current_state_number: 0,
             next_nonce_number: 0,
 
             state_channel: ChannelCoinInfo {
@@ -381,6 +382,7 @@ impl ChannelHandler {
             // XXX might need to mutate slightly.
             &inputs,
         )?;
+        myself.current_state_number += 1;
 
         let channel_coin_spend =
             myself.create_conditions_and_signature_of_channel_coin(env, &myself.unroll.coin)?;
@@ -494,9 +496,6 @@ impl ChannelHandler {
         &mut self,
         env: &mut ChannelHandlerEnv<R>,
     ) -> Result<PotatoSignatures, Error> {
-        self.current_state_number += 1;
-        self.unroll.coin.state_number = self.current_state_number;
-
         let new_game_coins_on_chain: Vec<(PuzzleHash, Amount)> =
             self.compute_unroll_data_for_games(&[], None, &self.live_games)?;
 
@@ -505,6 +504,9 @@ impl ChannelHandler {
             self.their_out_of_game_balance.clone() - self.their_allocated_balance.clone(),
             &new_game_coins_on_chain,
         );
+
+        self.current_state_number += 1;
+        self.unroll.coin.state_number = self.current_state_number;
 
         // Now update our unroll state.
         self.unroll.coin.update(

--- a/src/channel_handler/types/unroll_coin.rs
+++ b/src/channel_handler/types/unroll_coin.rs
@@ -84,7 +84,11 @@ impl UnrollCoin {
 
     fn get_old_state_number(&self) -> Result<usize, Error> {
         if let Some(r) = self.outcome.as_ref() {
-            Ok(r.state_number)
+            if r.state_number > 0 {
+                Ok(r.state_number - 1)
+            } else {
+                Err(Error::StrErr("unroll impossible for first state".to_string()))
+            }
         } else {
             Err(Error::StrErr("no default setup".to_string()))
         }
@@ -136,7 +140,7 @@ impl UnrollCoin {
             program: env.unroll_puzzle.clone(),
             args: clvm_curried_args!(
                 shared_puzzle_hash,
-                self.get_old_state_number()? - 1,
+                self.get_old_state_number()?,
                 conditions_hash
             ),
         }

--- a/src/channel_handler/types/unroll_coin.rs
+++ b/src/channel_handler/types/unroll_coin.rs
@@ -84,11 +84,7 @@ impl UnrollCoin {
 
     fn get_old_state_number(&self) -> Result<usize, Error> {
         if let Some(r) = self.outcome.as_ref() {
-            if r.state_number > 0 {
-                Ok(r.state_number - 1)
-            } else {
-                Err(Error::StrErr("unroll impossible for first state".to_string()))
-            }
+            Ok(r.state_number)
         } else {
             Err(Error::StrErr("no default setup".to_string()))
         }
@@ -242,7 +238,7 @@ impl UnrollCoin {
         self.outcome = Some(UnrollCoinOutcome {
             conditions: unroll_conditions,
             conditions_without_hash: unroll_conditions,
-            state_number: self.state_number,
+            state_number: inputs.rem_condition_state,
             hash: conditions_hash,
             signature: unroll_signature.clone(),
         });
@@ -282,6 +278,7 @@ pub struct UnrollCoinConditionInputs {
     pub my_balance: Amount,
     pub their_balance: Amount,
     pub puzzle_hashes_and_amounts: Vec<(PuzzleHash, Amount)>,
+    pub rem_condition_state: usize,
 }
 
 #[derive(Clone, Debug)]

--- a/src/tests/channel_handler.rs
+++ b/src/tests/channel_handler.rs
@@ -200,6 +200,7 @@ fn test_unroll_can_verify_own_signature() {
         my_balance: Amount::new(0),
         their_balance: Amount::new(100),
         puzzle_hashes_and_amounts: vec![],
+        rem_condition_state: 0,
     };
 
     let _sig1 = unroll_coin_1


### PR DESCRIPTION
There was a potentially unsafe subtraction that also was doing something sneaky.  It was emulating the state number of channel handler before a mutating += 1 everywhere unroll coin's update was called.  This captures it at the right time in each case so it doesn't need to subtract 1 when generating the curried unroll coin arguments and should be more durable.  Ultimately it'd be nice to remove mutability from channel_handler, but I'm just getting a hold of that in referee, so it'll likely be much later.