### PR TITLE
Ensure that idle is called after every successfully processed message…

### DIFF
--- a/resources/gaming-fe/src/hooks/WasmBlobWrapper.ts
+++ b/resources/gaming-fe/src/hooks/WasmBlobWrapper.ts
@@ -121,17 +121,15 @@ export class WasmBlobWrapper {
   };
 
   internalKickIdle(): any {
-    this.kickMessageHandling().then((res: any) => {
-      let idle_info;
-      do {
-        idle_info = this.idle();
-        if (!idle_info) {
-          return res;
-        }
-        this.rxjsEmitter?.next(idle_info);
-      } while (!idle_info.stop);
-      return res;
-    });
+    let idle_info;
+    do {
+      idle_info = this.idle();
+      if (!idle_info) {
+        return idle_info;
+      }
+      this.rxjsEmitter?.next(idle_info);
+    } while (!idle_info.stop);
+    return idle_info;
   }
 
   pushEvent(msg: any): any {


### PR DESCRIPTION
….  Previously, we'd trigger it only in pushEvent after pushing a message, but if that message followed another that was still in process, the idle wouldn't apply to it.  We'd wait until another message followed to do idle.