### PR TITLE
use getNextAddress with new_address=true instead of getCurrentAddress

### DIFF
--- a/front-end/src/hooks/JsonRpcContext.tsx
+++ b/front-end/src/hooks/JsonRpcContext.tsx
@@ -4,9 +4,9 @@ import {
   CreateOfferForIdsResponse,
 } from '../types/rpc/CreateOfferForIds';
 import {
-  GetCurrentAddressRequest,
-  GetCurrentAddressResponse,
-} from '../types/rpc/GetCurrentAddress';
+  GetNextAddressRequest,
+  GetNextAddressResponse,
+} from '../types/rpc/GetNextAddress';
 import {
   GetWalletBalanceRequest,
   GetWalletBalanceResponse,
@@ -189,10 +189,10 @@ async function getWalletBalance(data: GetWalletBalanceRequest) {
   );
 }
 
-async function getCurrentAddress(data: GetCurrentAddressRequest) {
-  const resp = await request<Record<string, unknown>>(
+async function getNextAddress(data: GetNextAddressRequest) {
+  return await request<GetNextAddressResponse>(
     ChiaMethod.GetNextAddress,
-    { ...data, newAddress: false },
+    data,
   );
   return (resp as any).address as GetCurrentAddressResponse;
 }
@@ -247,7 +247,7 @@ async function getPuzzleAndSolution(data: GetPuzzleAndSolutionRequest) {
 export const rpc = {
   getWallets,
   getWalletBalance,
-  getCurrentAddress,
+  getNextAddress,
   selectCoins,
   getHeightInfo,
   createOfferForIds,

--- a/front-end/src/hooks/JsonRpcContext.tsx
+++ b/front-end/src/hooks/JsonRpcContext.tsx
@@ -194,7 +194,6 @@ async function getNextAddress(data: GetNextAddressRequest) {
     ChiaMethod.GetNextAddress,
     data,
   );
-  return (resp as any).address as GetCurrentAddressResponse;
 }
 
 async function selectCoins(data: SelectCoinsRequest) {

--- a/front-end/src/hooks/RealBlockchainInterface.ts
+++ b/front-end/src/hooks/RealBlockchainInterface.ts
@@ -80,7 +80,9 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
   }
 
   async startMonitoring() {
-    const addr = await rpc.getCurrentAddress({ walletId: 1 });
+  
+    const resp = await rpc.getNextAddress({ walletId: 1, newAddress: true });
+    const addr = resp.address;
     const puzzleHash = decodeBech32mPuzzleHash(addr);
     if (!puzzleHash) {
       throw new Error(`failed to decode change address: ${addr}`);

--- a/front-end/src/types/rpc/GetCurrentAddress.ts
+++ b/front-end/src/types/rpc/GetCurrentAddress.ts
@@ -1,5 +1,0 @@
-export interface GetCurrentAddressRequest {
-  walletId?: number;
-}
-
-export type GetCurrentAddressResponse = string;

--- a/front-end/src/types/rpc/GetNextAddress.ts
+++ b/front-end/src/types/rpc/GetNextAddress.ts
@@ -1,0 +1,9 @@
+export interface GetNextAddressRequest {
+  walletId: number;
+  newAddress: boolean;
+}
+
+export interface GetNextAddressResponse {
+  address: string;
+  walletId: number;
+}


### PR DESCRIPTION
This fixes the bug where two users connected to the same wallet may have duplicate payout addresses.