### PR TITLE
handshake: fix asymmetric channel funding (use my_contribution, not total/2)

### DIFF
--- a/src/potato_handler/handshake_initiator.rs
+++ b/src/potato_handler/handshake_initiator.rs
@@ -337,7 +337,7 @@ impl HandshakeInitiatorHandler {
             &channel_puzzle_hash,
             &total_amount,
         )?;
-        let per_player = Amount::new(total_amount.to_u64() / 2);
+        let per_player = self.my_contribution.clone();
 
         let launcher_ph_bytes = crate::common::constants::SINGLETON_LAUNCHER_HASH.to_vec();
         let zero_bytes = Self::encode_u64_as_clvm_int(0);

--- a/src/potato_handler/handshake_receiver.rs
+++ b/src/potato_handler/handshake_receiver.rs
@@ -238,7 +238,7 @@ impl HandshakeReceiverHandler {
             &channel_puzzle_hash,
             &total_amount,
         )?;
-        let per_player = Amount::new(total_amount.to_u64() / 2);
+        let per_player = self.my_contribution.clone();
         let conditions = vec![RawCoinCondition {
             opcode: crate::common::constants::ASSERT_COIN_ANNOUNCEMENT,
             args: vec![ann_hash.bytes().to_vec()],


### PR DESCRIPTION
Both `HandshakeInitiator::build_alice_coin_spend_request` and `HandshakeReceiver::build_bob_coin_spend_request` compute the per-player coin spend amount as `total_amount / 2`. When players fund the channel with different amounts, this produces a `NeedCoinSpend.amount` that doesn't match the real funding coin and the bundle gets rejected on-chain.

With symmetric funding the division happens to equal each contribution, so the existing tests don't catch it.

Fix replaces the division with `self.my_contribution.clone()` in both handlers — two lines. Channel puzzle hash and announcement hash still use `total_amount`, which is correct.