### PR TITLE
wasm: expose SpendBundle.name in JsSpendBundle binding

### DIFF
--- a/wasm/src/mod.rs
+++ b/wasm/src/mod.rs
@@ -77,6 +77,7 @@ mod gaming_wasm {
     };
 
     export type SpendBundle = {
+        "name"?: string,
         "spends": Array<CoinSpend>
     };
 
@@ -1053,6 +1054,8 @@ mod gaming_wasm {
 
     #[derive(Serialize)]
     struct JsSpendBundle {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
         spends: Vec<JsCoinSpend>,
     }
 
@@ -1104,6 +1107,7 @@ mod gaming_wasm {
 
     fn spend_bundle_to_js(spend_bundle: &SpendBundle) -> JsSpendBundle {
         JsSpendBundle {
+            name: spend_bundle.name.clone(),
             spends: spend_bundle.spends.iter().map(coin_spend_to_js).collect(),
         }
     }


### PR DESCRIPTION
The Rust `SpendBundle` has a `name: Option<String>` field that the framework populates with labels like "create channel", "on chain move", "create unroll (timeout)", "preempt unroll", etc. The wasm-bindgen binding was dropping it when serializing to JS, so consumers had to infer the bundle's purpose from external channel state.

This exposes `name` through `JsSpendBundle` with `#[serde(skip_serializing_if = "Option::is_none")]` so absent names don't clutter the payload, and marks the field optional in the TS type hint. Fully additive — existing consumers that don't read `name` keep working unchanged.