### PR TITLE
Improve local restore and tracker reconnect handling

### DIFF
--- a/front-end/src/components/GameSession.tsx
+++ b/front-end/src/components/GameSession.tsx
@@ -7,6 +7,7 @@ import { formatMojos, formatAmount } from '../util';
 import { getPlayerId } from '../hooks/save';
 import { CalpokerOutcome, SessionPhase } from '../types/ChiaGaming';
 import { WasmBlobWrapper, RestoreStatus } from '../hooks/WasmBlobWrapper';
+import type { BlockchainPoller } from '../hooks/BlockchainPoller';
 import Calpoker from '../features/calPoker';
 import {
   CalpokerDisplaySnapshotView,
@@ -662,12 +663,13 @@ export interface GameSessionProps {
   onProtocolStateProviderChange?: (getter: (() => string | null) | null) => void;
   onCoinsProviderChange?: (getter: (() => import('../types/ChiaGaming').CoinOfInterestEntry[]) | null) => void;
   suppressPhaseReporting?: boolean;
+  blockchain: BlockchainPoller | null;
 }
 
-const GameSession: React.FC<GameSessionProps> = ({ params, peerConn, registerMessageHandler, appendGameLog, sessionSave, onGameActivity, onSessionPhaseChange, onRestoreStatusChange, onSessionModelChange, onProtocolStateProviderChange, onCoinsProviderChange, suppressPhaseReporting }) => {
+const GameSession: React.FC<GameSessionProps> = ({ params, peerConn, registerMessageHandler, appendGameLog, sessionSave, onGameActivity, onSessionPhaseChange, onRestoreStatusChange, onSessionModelChange, onProtocolStateProviderChange, onCoinsProviderChange, suppressPhaseReporting, blockchain }) => {
   const uniqueId = getPlayerId();
 
-  const session = useGameSession(params, uniqueId, peerConn, registerMessageHandler, appendGameLog, sessionSave);
+  const session = useGameSession(params, uniqueId, peerConn, registerMessageHandler, appendGameLog, sessionSave, blockchain);
 
   useEffect(() => {
     onRestoreStatusChange?.(session.restoreStatus, session.restoreError);

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -51,7 +51,7 @@ import {
 } from '../hooks/BlockchainPoller';
 import { RestoreStatus } from '../hooks/WasmBlobWrapper';
 import { useThemeSyncToIframe } from '../hooks/useThemeSyncToIframe';
-import { isRestoreBlocked, shouldAdvertiseAvailable, shouldMountGameSession } from '../lib/restoreLifecycle';
+import { isRestoreBlocked, shouldAdvertiseAvailable, shouldMountGameSession, shouldSwitchToTrackerOnResolved } from '../lib/restoreLifecycle';
 import {
   selectGameDashboardView,
   selectStatusBarBalances,
@@ -1254,7 +1254,7 @@ const Shell = () => {
     trackerConnRef.current?.setBusy(false);
     sessionSaveRef.current = null;
     activePairingTokenRef.current = null;
-    if (previousPhase !== 'on-chain' && !hasError) {
+    if (shouldSwitchToTrackerOnResolved(previousPhase, !!hasError)) {
       setActiveTab('tracker');
     }
   }, [setActiveTab]);

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -47,10 +47,11 @@ import { activate, deactivate, getActiveBlockchain } from '../hooks/activeBlockc
 import {
   BALANCE_POLL_INTERVAL_MS,
   CHAIN_POLL_INTERVAL_MS,
+  type BlockchainPoller,
 } from '../hooks/BlockchainPoller';
 import { RestoreStatus } from '../hooks/WasmBlobWrapper';
 import { useThemeSyncToIframe } from '../hooks/useThemeSyncToIframe';
-import { isRestoreBlocked, shouldAdvertiseAvailable } from '../lib/restoreLifecycle';
+import { isRestoreBlocked, shouldAdvertiseAvailable, shouldMountGameSession } from '../lib/restoreLifecycle';
 import {
   selectGameDashboardView,
   selectStatusBarBalances,
@@ -521,7 +522,9 @@ const Shell = () => {
       if (blockchainTypeRef.current !== 'walletconnect') {
         activeBlockchainRef.current?.disconnect().catch(() => {});
       }
+      deactivate();
       activeBlockchainRef.current = null;
+      setActiveBlockchainPoller(null);
       setBootState(prev => {
         if (prev.kind !== 'ready') return prev;
         return { kind: 'tabConflict', save: peekSession(), midSession: true };
@@ -573,6 +576,7 @@ const Shell = () => {
   const [blockchainType, setBlockchainType] = useState<'simulator' | 'walletconnect' | undefined>(() => getBlockchainType());
   const blockchainTypeRef = useRef<'simulator' | 'walletconnect' | undefined>(blockchainType);
   const activeBlockchainRef = useRef<InternalBlockchainInterface | null>(null);
+  const [activeBlockchainPoller, setActiveBlockchainPoller] = useState<BlockchainPoller | null>(null);
 
   useEffect(() => {
     blockchainTypeRef.current = blockchainType;
@@ -807,11 +811,18 @@ const Shell = () => {
       if (connected) {
         setWalletAlert(false);
         setWalletConnected(true);
+        const poller = activeBlockchainPoller;
+        if (poller && blobSingleton) {
+          blobSingleton.attachBlockchain(poller);
+        }
+        if (blockchainTypeRef.current) {
+          startBalancePolling(blockchainTypeRef.current);
+        }
       } else {
         setWalletConnected(false);
       }
     });
-  }, [blockchainType]);
+  }, [activeBlockchainPoller, blockchainType, startBalancePolling]);
 
   const [trackerOrigin, setTrackerOrigin] = useState<string | null>(null);
 
@@ -1105,9 +1116,10 @@ const Shell = () => {
   ) => {
     console.log('[Shell] completeConnection: bcType=%s', bcType);
     deactivate();
-    activate(iface, pollMs);
+    const poller = activate(iface, pollMs);
     saveSession({ blockchainType: bcType });
     activeBlockchainRef.current = iface;
+    setActiveBlockchainPoller(poller);
     setBlockchainType(bcType);
     setWalletConnected(true);
     setConnecting(false);
@@ -1162,7 +1174,7 @@ const Shell = () => {
       }
       if (silent) {
         // beginConnect may have failed before completeConnection ran.
-        if (!activeBlockchainRef.current && bcType !== 'walletconnect') {
+        if (bcType !== 'walletconnect') {
           completeConnection(iface, bcType, pollMs);
         }
       } else {
@@ -1202,6 +1214,7 @@ const Shell = () => {
     }
     deactivate();
     activeBlockchainRef.current = null;
+    setActiveBlockchainPoller(null);
     setConnectionSetup(null);
     setBlockchainType(undefined);
     clearSession();
@@ -1282,7 +1295,7 @@ const Shell = () => {
 
   // Hydrate local UI state from a SessionState and kick off a backend connect.
   // Called only after the user has consented (Resume button) and the lease is ours.
-  const performResume = useCallback(async (save: SessionState) => {
+  const performResume = useCallback((save: SessionState) => {
     const bcType = save.blockchainType ?? 'simulator';
     console.log('[Shell] performResume: bcType=%s token=%s', bcType, save.pairingToken ?? 'none');
     setActiveTab('game');
@@ -1316,34 +1329,37 @@ const Shell = () => {
     setBlockchainType(bcType);
 
     const { iface, pollMs } = getInterface(bcType);
+    activeBlockchainRef.current = iface;
+    setWalletConnected(iface.isConnected());
+    setResuming(false);
 
     // For WalletConnect restores, finalize performs the first wallet RPC
-    // (address lookup).  Keep it ahead of completeConnection so requestBalance
-    // and the poller do not occupy the serialized WalletConnect queue first.
-    try {
-      const setup = await iface.beginConnect(uniqueId);
-      const needsWalletPairing = bcType === 'walletconnect' && !setup.skipQr && !setup.fields;
-      if (needsWalletPairing) {
-        setConnectionSetup(setup);
-        setWalletConnected(false);
-        setConnecting(false);
-        setWalletAlert(true);
-        setResuming(false);
-        return;
-      }
-      if (setup.skipQr || setup.fields) {
-        await setup.finalize();
-      }
-      completeConnection(iface, bcType, pollMs);
-    } catch (err) {
-      console.warn('[Shell] performResume connect failed, falling back', err);
-      // beginConnect may have failed before completeConnection ran.
-      if (!activeBlockchainRef.current && bcType !== 'walletconnect') {
+    // (address lookup). Keep it in the background so local restore can render
+    // while the simulator/wallet is unavailable.
+    void (async () => {
+      try {
+        const setup = await iface.beginConnect(uniqueId);
+        const needsWalletPairing = bcType === 'walletconnect' && !setup.skipQr && !setup.fields;
+        if (needsWalletPairing) {
+          setConnectionSetup(setup);
+          setWalletConnected(false);
+          setConnecting(false);
+          setWalletAlert(true);
+          return;
+        }
+        if (setup.skipQr || setup.fields) {
+          await setup.finalize();
+        }
         completeConnection(iface, bcType, pollMs);
+      } catch (err) {
+        console.warn('[Shell] performResume connect failed, falling back', err);
+        // beginConnect may have failed before completeConnection ran.
+        if (!activeBlockchainRef.current && bcType !== 'walletconnect') {
+          completeConnection(iface, bcType, pollMs);
+        }
       }
-    }
-    console.log('[Shell] performResume: done');
-    setResuming(false);
+      console.log('[Shell] performResume: blockchain connect task done');
+    })();
   }, [uniqueId, completeConnection, stablePeerConn, setActiveTab]);
 
   // User clicked "Resume Session" in the resumeDialog.
@@ -1398,6 +1414,8 @@ const Shell = () => {
     trackerConnRef.current = null;
     activeBlockchainRef.current?.disconnect().catch(() => {});
     activeBlockchainRef.current = null;
+    setActiveBlockchainPoller(null);
+    deactivate();
     setBootState({ kind: 'tabDead' });
   }, [stopBalancePolling]);
 
@@ -1418,6 +1436,7 @@ const Shell = () => {
     }
     deactivate();
     activeBlockchainRef.current = null;
+    setActiveBlockchainPoller(null);
     setWalletConnected(false);
     setBlockchainType(undefined);
     setBalance(undefined);
@@ -1679,19 +1698,20 @@ const Shell = () => {
   }
 
   const sessionCanMount = gameParams !== null && peerConn !== null;
-  const hasActiveBlockchain = activeBlockchainRef.current !== null;
-  const sessionReadyToStart =
-    sessionCanMount &&
-    hasActiveBlockchain &&
-    (walletConnected || !!gameParams?.restoring);
+  const { startSession: sessionReadyToStart, keepSession } = shouldMountGameSession(
+    sessionCanMount,
+    walletConnected,
+    !!gameParams?.restoring,
+    sessionStartedRef.current,
+  );
   if (sessionReadyToStart) sessionStartedRef.current = true;
-  const keepSession = sessionCanMount && hasActiveBlockchain && sessionStartedRef.current;
-  console.log('[Shell] render: gameParams=%s peerConn=%s activeBlockchain=%s walletConnected=%s restoring=%s → keepSession=%s',
-    !!gameParams, !!peerConn, hasActiveBlockchain, walletConnected, !!gameParams?.restoring, keepSession);
+  console.log('[Shell] render: gameParams=%s peerConn=%s poller=%s walletConnected=%s restoring=%s → keepSession=%s',
+    !!gameParams, !!peerConn, !!activeBlockchainPoller, walletConnected, !!gameParams?.restoring, keepSession);
 
   const dashboardView: GameDashboardViewModel = selectGameDashboardView(dashboardSessionModel, {
     hasSession: dashboardSessionModel !== null,
     cleanShutdownGraceActive,
+    chainAvailable: walletConnected,
   });
   const statusBarBalances = selectStatusBarBalances(dashboardSessionModel);
 
@@ -2056,12 +2076,13 @@ const Shell = () => {
             ) : keepSession ? (
               <GameSessionErrorBoundary>
                 <GameSession
-                  key={gameParams.pairingToken}
-                  params={gameParams}
-                  peerConn={peerConn}
+                  key={gameParams!.pairingToken}
+                  params={gameParams!}
+                  peerConn={peerConn!}
                   registerMessageHandler={registerMessageHandler}
                   appendGameLog={appendHistory}
                   sessionSave={sessionSaveForReactProps(sessionSaveRef.current)}
+                  blockchain={activeBlockchainPoller}
                   onGameActivity={onGameActivity}
                   onSessionPhaseChange={handleSessionPhaseChange}
                   onRestoreStatusChange={handleRestoreStatusChange}

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -416,6 +416,8 @@ const Shell = () => {
     saveActiveTab(tab);
   }, []);
   const [gameParams, setGameParams] = useState<GameSessionParams | null>(null);
+  const gameParamsRef = useRef<GameSessionParams | null>(null);
+  gameParamsRef.current = gameParams;
   const [peerConn, setPeerConn] = useState<PeerConnectionResult | null>(null);
   const [dashboardSessionModel, setDashboardSessionModel] = useState<SessionModel | null>(null);
   const [cleanShutdownGraceActive, setCleanShutdownGraceActive] = useState(false);
@@ -859,7 +861,8 @@ const Shell = () => {
       sessionFinishedCleanupRef.current = false;
       sessionPhaseRef.current = 'none';
       activePairingTokenRef.current = token;
-      conn.setBusy(save ? sessionSaveStartsBusy(save) : true);
+      const resolvedMyAlias = myAlias ?? save?.myAlias ?? save?.alias;
+      conn.setBusy(save ? sessionSaveStartsBusy(save) : true, resolvedMyAlias);
       peerConnTargetRef.current = conn.getPeerConnection();
       if (!save) {
         setRestoreStatus('idle');
@@ -873,7 +876,6 @@ const Shell = () => {
       const alreadyHydrated = !!sessionSaveRef.current;
       if (!alreadyHydrated) {
         sessionSaveRef.current = save;
-        const resolvedMyAlias = myAlias ?? save?.myAlias;
         const resolvedOpponentAlias = opponentAlias ?? save?.opponentAlias;
         setGameParams({
           iStarted,
@@ -1030,6 +1032,7 @@ const Shell = () => {
           trackerWsUpRef.current = true;
           lastTrackerActivityRef.current = Date.now();
           setTrackerLiveness('connected');
+          conn.refreshPresence(gameParamsRef.current?.myAlias ?? sessionSaveRef.current?.myAlias ?? sessionSaveRef.current?.alias);
         },
         onTrackerActivity: () => {
           lastTrackerActivityRef.current = Date.now();
@@ -1049,7 +1052,10 @@ const Shell = () => {
             setTrackerAlert(true);
           }
         },
-      }, { initialBusy: sessionSaveStartsBusy(initialSave) });
+      }, {
+        initialBusy: sessionSaveStartsBusy(initialSave),
+        initialAlias: initialSave?.myAlias ?? initialSave?.alias,
+      });
     } catch (err) {
       console.error('[Shell] TrackerConnection failed for origin=%s', origin, err);
       saveTrackerUrl(undefined);
@@ -1251,7 +1257,7 @@ const Shell = () => {
 
     console.log('[Shell] session resolved; marking not busy');
     sessionFinishedCleanupRef.current = true;
-    trackerConnRef.current?.setBusy(false);
+    trackerConnRef.current?.setBusy(false, gameParamsRef.current?.myAlias ?? sessionSaveRef.current?.myAlias ?? sessionSaveRef.current?.alias);
     sessionSaveRef.current = null;
     activePairingTokenRef.current = null;
     if (shouldSwitchToTrackerOnResolved(previousPhase, !!hasError)) {
@@ -1278,8 +1284,11 @@ const Shell = () => {
   const restoreBlocked = isRestoreBlocked(!!gameParams?.restoring, restoreStatus, restoreTrackerReconciled);
 
   useEffect(() => {
-    trackerConnRef.current?.setBusy(!shouldAdvertiseAvailable(sessionPhase, restoreBlocked));
-  }, [sessionPhase, restoreBlocked]);
+    trackerConnRef.current?.setBusy(
+      !shouldAdvertiseAvailable(sessionPhase, restoreBlocked),
+      gameParams?.myAlias ?? sessionSaveRef.current?.myAlias ?? sessionSaveRef.current?.alias,
+    );
+  }, [sessionPhase, restoreBlocked, gameParams?.myAlias]);
 
   const handleTabChange = useCallback((tabId: TabId) => {
     setActiveTab(tabId);
@@ -1501,6 +1510,7 @@ const Shell = () => {
   }, []);
 
   const cancelDashboardSession = useCallback(() => {
+    const alias = gameParamsRef.current?.myAlias ?? sessionSaveRef.current?.myAlias ?? sessionSaveRef.current?.alias;
     trackerConnRef.current?.close();
     markPeerInactive();
     destroyBlobSingleton();
@@ -1521,7 +1531,7 @@ const Shell = () => {
     setHistory([]);
     setChatMessages([]);
     setActiveTab('tracker');
-    trackerConnRef.current?.setBusy(false);
+    trackerConnRef.current?.setBusy(false, alias);
   }, [markPeerInactive, setActiveTab]);
 
   const requestDashboardCleanShutdown = useCallback(() => {

--- a/front-end/src/hooks/BlockchainPoller.ts
+++ b/front-end/src/hooks/BlockchainPoller.ts
@@ -286,6 +286,7 @@ export class BlockchainPoller {
       }
       this.consecutiveFailures = 0;
     } catch (e) {
+      if (!this.running) return;
       this.consecutiveFailures++;
       diagStack('blockchain-poller height failed', e);
       log(`[blockchain-poller] height failed: ${String(e)}`);
@@ -316,6 +317,7 @@ export class BlockchainPoller {
       }
       this.consecutiveFailures = 0;
     } catch (e) {
+      if (!this.running) return;
       this.consecutiveFailures++;
       diagStack('blockchain-poller coin poll failed', e);
       log(`[blockchain-poller] coin poll failed: ${String(e)}`);

--- a/front-end/src/hooks/FakeBlockchainInterface.ts
+++ b/front-end/src/hooks/FakeBlockchainInterface.ts
@@ -314,9 +314,6 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
     }
     this.setupComplete = false;
     this.fireConnectionChange(false);
-    if (this.pending.size > 0) {
-      diagNote(`FakeBlockchain close(): rejecting ${this.pending.size} pending request(s) with "closed" (ids=${[...this.pending.keys()].join(',')})`);
-    }
     for (const [, p] of this.pending) {
       p.reject(new Error('closed'));
     }

--- a/front-end/src/hooks/FakeBlockchainInterface.ts
+++ b/front-end/src/hooks/FakeBlockchainInterface.ts
@@ -54,6 +54,7 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
   private reconnectAttempt = 0;
   private connectLoopPromise: Promise<void> | null = null;
   private blockWaiters = new Set<() => void>();
+  private setupComplete = false;
 
   constructor(wsUrl: string) {
     this.wsUrl = wsUrl;
@@ -84,7 +85,6 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
         clearTimeout(connectTimeout);
         log(`[sim-blockchain] connect: connected (${Math.round(performance.now() - t0)}ms)`);
         this.ws = ws;
-        this.fireConnectionChange(true);
         resolve();
       };
       ws.onerror = () => {
@@ -98,6 +98,7 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
       ws.onclose = () => {
         if (this.ws !== ws) return;
         this.ws = null;
+        this.setupComplete = false;
         this.fireConnectionChange(false);
         if (this.pending.size > 0) {
           diagNote(`FakeBlockchain onclose: rejecting ${this.pending.size} pending request(s) with "WebSocket closed" (ids=${[...this.pending.keys()].join(',')})`);
@@ -158,6 +159,8 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
           this.token = token;
           this.blockchainAddressData = { puzzleHash: token };
           await this.sendRequest('get_peak');
+          this.setupComplete = true;
+          this.fireConnectionChange(true);
           this.reconnectAttempt = 0;
           log('[sim-blockchain] connected and setup complete');
           return;
@@ -167,6 +170,7 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
             try { this.ws.close(); } catch { /* ignore */ }
             this.ws = null;
           }
+          this.setupComplete = false;
           this.fireConnectionChange(false);
           const base = FakeBlockchainInterface.RECONNECT_DELAYS[
             Math.min(this.reconnectAttempt, FakeBlockchainInterface.RECONNECT_DELAYS.length - 1)
@@ -308,6 +312,7 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
       try { this.ws.close(); } catch { /* ignore */ }
       this.ws = null;
     }
+    this.setupComplete = false;
     this.fireConnectionChange(false);
     if (this.pending.size > 0) {
       diagNote(`FakeBlockchain close(): rejecting ${this.pending.size} pending request(s) with "closed" (ids=${[...this.pending.keys()].join(',')})`);
@@ -351,7 +356,7 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
   }
 
   isConnected(): boolean {
-    return this.ws !== null && this.ws.readyState === 1;
+    return this.ws !== null && this.ws.readyState === 1 && this.setupComplete;
   }
 
   onConnectionChange(cb: (connected: boolean) => void): () => void {

--- a/front-end/src/hooks/RealBlockchainInterface.ts
+++ b/front-end/src/hooks/RealBlockchainInterface.ts
@@ -153,6 +153,9 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
   private lastConnectedState = false;
   private wcSubscription: { unsubscribe: () => void } | null = null;
   private pendingLocalRemovalsForNextPush: CoinsetCoin[] = [];
+  private monitoringReady = false;
+  private monitoringPromise: Promise<void> | null = null;
+  private monitoringEpoch = 0;
 
   constructor() {
     this.blockchainAddressData = { puzzleHash: '' };
@@ -163,6 +166,17 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
   }
 
   async startMonitoring() {
+    if (this.monitoringPromise) {
+      return this.monitoringPromise;
+    }
+    const epoch = this.monitoringEpoch;
+    this.monitoringPromise = this.doStartMonitoring(epoch).finally(() => {
+      this.monitoringPromise = null;
+    });
+    return this.monitoringPromise;
+  }
+
+  private async doStartMonitoring(epoch: number) {
     try {
       const addr = await rpc.getNextAddress({ walletId: 1n, newAddress: true });
       const puzzleHash = decodeBech32mPuzzleHash(addr);
@@ -173,11 +187,25 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
       log(`[wc-blockchain] address resolved: ${addr} → ${puzzleHash}`);
       this.ensureRemoteWallet();
       await this.waitForRemoteWallet();
+      if (epoch !== this.monitoringEpoch || !walletConnectState.getSession()) {
+        return;
+      }
+      this.monitoringReady = true;
+      this.fireConnectionChange(true);
     } catch (err) {
       const e = err as any;
       console.error('[wc-blockchain] startMonitoring failed:', err);
       throw err;
     }
+  }
+
+  private markDisconnected() {
+    this.monitoringEpoch++;
+    this.monitoringReady = false;
+    this.monitoringPromise = null;
+    this.remoteWalletId = undefined;
+    this.remoteWalletPending = false;
+    this.fireConnectionChange(false);
   }
 
   private spendSeq = 0;
@@ -555,7 +583,15 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
     if (this.wcSubscription) return;
     this.wcSubscription = walletConnectState.getObservable().subscribe({
       next: (evt) => {
-        this.fireConnectionChange(evt.stateName === 'connected');
+        if (evt.stateName === 'connected') {
+          void this.startMonitoring().catch((err) => {
+            console.warn('[wc-blockchain] monitoring setup after WalletConnect event failed', err);
+            log(`[wc-blockchain] monitoring setup after WalletConnect event failed: ${String(err)}`);
+            this.markDisconnected();
+          });
+        } else if (evt.connected === false || (evt.stateName === 'initialized' && evt.sessions === 0)) {
+          this.markDisconnected();
+        }
       },
     });
   }
@@ -570,7 +606,6 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
         skipQr: true,
         finalize: async () => {
           await this.startMonitoring();
-          this.fireConnectionChange(true);
         },
       };
     }
@@ -581,7 +616,6 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
       finalize: async () => {
         await walletConnectState.connect(approval);
         await this.startMonitoring();
-        this.fireConnectionChange(true);
       },
     };
   }
@@ -592,7 +626,7 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
       this.wcSubscription = null;
     }
     await walletConnectState.disconnect();
-    this.fireConnectionChange(false);
+    this.markDisconnected();
   }
 
   isConnected(): boolean {

--- a/front-end/src/hooks/WasmBlobWrapper.ts
+++ b/front-end/src/hooks/WasmBlobWrapper.ts
@@ -100,7 +100,8 @@ export class WasmBlobWrapper implements PollingCradle {
   onChain: boolean;
   reloading: boolean;
   qualifyingEvents: number;
-  blockchain: BlockchainPoller;
+  blockchain: BlockchainPoller | null;
+  private blockchainAttached = false;
   rxjsMessageSingleton: Subject<WasmEvent>;
   rxjsEmitter: NextObserver<WasmEvent> | undefined;
   private eventQueue: CradleEvent[] = [];
@@ -148,7 +149,7 @@ export class WasmBlobWrapper implements PollingCradle {
   }
 
   constructor(
-    blockchain: BlockchainPoller,
+    blockchain: BlockchainPoller | null,
     uniqueId: string,
     amount: bigint,
     peer_conn: PeerConnectionResult,
@@ -197,6 +198,31 @@ export class WasmBlobWrapper implements PollingCradle {
 
   setReloading() { this.reloading = true; }
 
+  attachBlockchain(blockchain: BlockchainPoller) {
+    if (this.blockchain && this.blockchain !== blockchain) {
+      this.blockchain.detachCradle(this);
+      this.blockchainAttached = false;
+    }
+    const alreadyAttached = this.blockchain === blockchain && this.blockchainAttached;
+    this.blockchain = blockchain;
+    if (alreadyAttached) {
+      blockchain.snapshotCradleCoinInterest(this);
+    } else {
+      blockchain.attachCradle(this);
+      this.blockchainAttached = true;
+    }
+    this.flushPendingCoinStates();
+    this.cradle?.resubmit_submitted();
+    this.drainAndSubmitTransactions();
+  }
+
+  detachBlockchain(blockchain: BlockchainPoller) {
+    if (this.blockchain !== blockchain) return;
+    blockchain.detachCradle(this);
+    this.blockchainAttached = false;
+    this.blockchain = null;
+  }
+
   setPeerKeepalive(sendKeepalive: () => void) {
     this.peerSendKeepalive = sendKeepalive;
     this.startKeepaliveTimer();
@@ -206,6 +232,9 @@ export class WasmBlobWrapper implements PollingCradle {
     this.cleanShutdownCalled = true;
     this.storedMessages = [];
     this.rxjsMessageSingleton.complete();
+    this.blockchain?.detachCradle(this);
+    this.blockchainAttached = false;
+    this.blockchain = null;
     if (this.saveTimer) {
       clearTimeout(this.saveTimer);
       this.saveTimer = null;
@@ -318,17 +347,12 @@ export class WasmBlobWrapper implements PollingCradle {
     if (this.restoredSession) {
       this.restoredSession = false;
       this.resendUnacked();
-      // A transaction drained to the host before the reload may not have
-      // reached the network.  Re-queue the manager's retained submission set,
-      // then drain and submit so any in-flight transaction is resent.
-      this.cradle?.resubmit_submitted();
-      this.drainAndSubmitTransactions();
     }
   }
 
   setGameCradle(cradle: ChiaGame) {
     this.cradle = cradle;
-    this.blockchain.snapshotCradleCoinInterest(this);
+    this.blockchain?.snapshotCradleCoinInterest(this);
     this.flushPendingCoinStates();
     this.spillStoredMessages();
   }
@@ -355,10 +379,15 @@ export class WasmBlobWrapper implements PollingCradle {
 
   private async handleNeedLauncherCoin() {
     if (this.launcherProvided) return;
+    const blockchain = this.blockchain;
+    if (!blockchain) {
+      this.rxjsEmitter?.next({ type: 'error', error: 'Blockchain is not connected' });
+      return;
+    }
     this.launcherProvided = true;
 
     try {
-      const coin = await this.blockchain.rpc.selectCoins(this.uniqueId, this.amount);
+      const coin = await blockchain.rpc.selectCoins(this.uniqueId, this.amount);
       if (!coin) {
         throw new Error('ASSERT_FAIL: selectCoins returned null for launcher parent coin');
       }
@@ -378,6 +407,11 @@ export class WasmBlobWrapper implements PollingCradle {
   }
 
   private async handleNeedCoinSpend(request: any) {
+    const blockchain = this.blockchain;
+    if (!blockchain) {
+      this.rxjsEmitter?.next({ type: 'error', error: 'Blockchain is not connected' });
+      return;
+    }
     try {
       const offerAmount = -BigInt(request.amount);
       const extraConditions = (request.conditions || []).map((c: any) => ({
@@ -387,7 +421,7 @@ export class WasmBlobWrapper implements PollingCradle {
       const coinIds = request.coin_id ? [request.coin_id] : undefined;
       const maxHeight = request.max_height != null ? BigInt(request.max_height) : undefined;
 
-      const bundle = await this.blockchain.rpc.createOfferForIds(
+      const bundle = await blockchain.rpc.createOfferForIds(
         this.uniqueId,
         { '1': offerAmount },
         extraConditions,
@@ -403,10 +437,10 @@ export class WasmBlobWrapper implements PollingCradle {
       if (typeof bundle === 'string' && bundle.startsWith('offer')) {
         console.warn('[wasm] createOfferForIds returned offer string; decoding via bech32 WASM path');
         const localSpendBundle = this.wc?.convert_offer_to_coinset_org(bundle);
-        await this.blockchain.rpc.rememberLocalRemovals?.(localSpendBundle);
+        await blockchain.rpc.rememberLocalRemovals?.(localSpendBundle);
         result = this.cradle?.provide_offer_bech32(bundle);
       } else {
-        await this.blockchain.rpc.rememberLocalRemovals?.(bundle);
+        await blockchain.rpc.rememberLocalRemovals?.(bundle);
         const bundleJson = typeof bundle === 'string' ? bundle : jsonStringify(bundle);
         result = this.cradle?.provide_coin_spend_bundle(bundleJson);
       }
@@ -442,6 +476,8 @@ export class WasmBlobWrapper implements PollingCradle {
   }
 
   private async submitTransactionNow(tx: SpendBundle) {
+    const blockchain = this.blockchain;
+    if (!blockchain) return;
     try {
       // The blob/conversion/fee work used to run before the try, so a throw
       // here (e.g. from the wasm connection) rejected the submit queue
@@ -450,7 +486,7 @@ export class WasmBlobWrapper implements PollingCradle {
       const spendBundle = this.wc?.convert_spend_to_coinset_org(blob);
       const fee = this.getFee();
       log(`[wasm] submitTransaction blobLen=${blob.length}`);
-      await this.blockchain.rpc.spend(blob, spendBundle, 'submitTransaction', fee || undefined);
+      await blockchain.rpc.spend(blob, spendBundle, 'submitTransaction', fee || undefined);
     } catch (e) {
       const message = extractErrorMessage(e);
       if (isBenignTransactionSubmitError(message)) {
@@ -479,7 +515,7 @@ export class WasmBlobWrapper implements PollingCradle {
    * action that drains the cradle.
    */
   private drainAndSubmitTransactions() {
-    if (!this.cradle) return;
+    if (!this.cradle || !this.blockchain) return;
     let bundles: SpendBundle[];
     try {
       bundles = this.cradle.drain_submissions();
@@ -496,8 +532,9 @@ export class WasmBlobWrapper implements PollingCradle {
   processResult(result: WasmResult | undefined): void {
     if (!result) return;
 
+    const blockchain = this.blockchain;
     for (const coin of result.watchCoins || []) {
-      this.blockchain.watchCoin(this, coin);
+      blockchain?.watchCoin(this, coin);
     }
     for (const event of result.events || []) {
       this.eventQueue.push(event);
@@ -622,8 +659,13 @@ export class WasmBlobWrapper implements PollingCradle {
   }
 
   private async fulfillPuzzleSolutionRequest(coinHex: string) {
+    const blockchain = this.blockchain;
+    if (!blockchain) {
+      this.rxjsEmitter?.next({ type: 'error', error: 'Blockchain is not connected' });
+      return;
+    }
     try {
-      const ps = await this.blockchain.rpc.getPuzzleAndSolution(coinHex);
+      const ps = await blockchain.rpc.getPuzzleAndSolution(coinHex);
       if (this.cradle) {
         const result = ps
           ? this.cradle.report_puzzle_and_solution(coinHex, ps[0], ps[1])

--- a/front-end/src/hooks/WasmBlobWrapper.ts
+++ b/front-end/src/hooks/WasmBlobWrapper.ts
@@ -328,6 +328,7 @@ export class WasmBlobWrapper implements PollingCradle {
 
   setGameCradle(cradle: ChiaGame) {
     this.cradle = cradle;
+    this.blockchain.snapshotCradleCoinInterest(this);
     this.flushPendingCoinStates();
     this.spillStoredMessages();
   }

--- a/front-end/src/hooks/blobSingleton.ts
+++ b/front-end/src/hooks/blobSingleton.ts
@@ -119,7 +119,7 @@ export async function restoreSession(
 }
 
 export function getBlobSingleton(
-  blockchain: BlockchainPoller,
+  blockchain: BlockchainPoller | null,
   peerConn: PeerConnectionResult,
   registerMessageHandler: (handler: (msgno: number, msg: Uint8Array) => void, ackHandler: (ack: number) => void, keepaliveHandler: () => void) => void,
   uniqueId: string,
@@ -187,6 +187,9 @@ export function getBlobSingleton(
   } else {
     const newSession = async () => {
       try {
+        if (!blockchain) {
+          throw new Error('Cannot start a new session without a blockchain connection');
+        }
         startNewSession();
         const gameHexes = await loadGameHexes(fetchHex);
         await configGameObject(

--- a/front-end/src/hooks/useGameSession.ts
+++ b/front-end/src/hooks/useGameSession.ts
@@ -14,13 +14,13 @@ import {
   GameStatusState,
   SessionPhase,
 } from '../types/ChiaGaming';
-import { getActiveBlockchain } from './activeBlockchain';
 import {
   getBlobSingleton,
   initStarted,
   setInitStarted,
 } from './blobSingleton';
 import { WasmBlobWrapper, RestoreStatus } from './WasmBlobWrapper';
+import type { BlockchainPoller } from './BlockchainPoller';
 import { SessionState, saveSession, getDefaultFee, getBlockchainType, uint8ToBase64 } from './save';
 import { coinIdFromBytes, coerceToBytes } from '../util';
 import { log } from '../services/log';
@@ -582,11 +582,10 @@ export function useGameSession(
   registerMessageHandler: (handler: (msgno: number, msg: Uint8Array) => void, ackHandler: (ack: number) => void, keepaliveHandler: () => void) => void,
   appendGameLog: (line: string) => void,
   sessionSave?: SessionState,
+  blockchain: BlockchainPoller | null = null,
 ): UseGameSessionResult {
   const { iStarted, amount, perGameAmount } = params;
   const playerNumber = iStarted ? 1 : 2;
-
-  const blockchain = getActiveBlockchain();
 
   const { gameObject } = getBlobSingleton(
     blockchain,
@@ -1377,10 +1376,10 @@ export function useGameSession(
   // Drive the cradle's coin polling: the poller asks the cradle which coins to
   // watch and feeds raw chain state back via report_coin_states.
   useEffect(() => {
-    if (!gameObject) return;
-    blockchain.attachCradle(gameObject);
+    if (!gameObject || !blockchain) return;
+    gameObject.attachBlockchain(blockchain);
     return () => {
-      blockchain.detachCradle(gameObject);
+      gameObject.detachBlockchain(blockchain);
     };
   }, [gameObject, blockchain]);
 

--- a/front-end/src/lib/restoreLifecycle.ts
+++ b/front-end/src/lib/restoreLifecycle.ts
@@ -42,3 +42,10 @@ export function shouldMountGameSession(
     keepSession: sessionCanMount && (sessionStarted || startSession),
   };
 }
+
+export function shouldSwitchToTrackerOnResolved(
+  previousPhase: SessionPhase,
+  hasError: boolean,
+): boolean {
+  return previousPhase !== 'none' && previousPhase !== 'on-chain' && !hasError;
+}

--- a/front-end/src/lib/restoreLifecycle.ts
+++ b/front-end/src/lib/restoreLifecycle.ts
@@ -29,3 +29,16 @@ export function shouldAdvertiseAvailable(
     },
   }), sessionPhase);
 }
+
+export function shouldMountGameSession(
+  sessionCanMount: boolean,
+  walletConnected: boolean,
+  restoring: boolean,
+  sessionStarted: boolean,
+): { startSession: boolean; keepSession: boolean } {
+  const startSession = sessionCanMount && (walletConnected || restoring);
+  return {
+    startSession,
+    keepSession: sessionCanMount && (sessionStarted || startSession),
+  };
+}

--- a/front-end/src/lib/session/model.ts
+++ b/front-end/src/lib/session/model.ts
@@ -507,6 +507,7 @@ export function selectShellView(model: SessionModel, phase: SessionPhase): Shell
 export interface GameDashboardSelectorOptions {
   hasSession?: boolean;
   cleanShutdownGraceActive?: boolean;
+  chainAvailable?: boolean;
 }
 
 function channelStatusDetail(model: SessionModel): string | null {
@@ -621,13 +622,19 @@ export function selectGameDashboardView(
 
   const channel = model.channel.status;
   const action = dashboardActionFor(model, options.cleanShutdownGraceActive ?? false);
+  const chainActionOffline =
+    options.chainAvailable === false &&
+    (action.actionKind === 'clean-shutdown' || action.actionKind === 'go-on-chain');
+  const channelDetail = channelStatusDetail(model);
 
   return {
     channelStatusLabel: CHANNEL_STATE_LABELS[channel.state],
-    channelDetail: channelStatusDetail(model),
+    channelDetail: chainActionOffline
+      ? [channelDetail, 'Reconnect wallet to submit chain transactions.'].filter(Boolean).join(' ')
+      : channelDetail,
     handStatusLabel: collapsedHandStatusLabel(model),
     handDetail: collapsedHandDetail(model),
-    ...action,
+    ...(chainActionOffline ? { ...action, actionEnabled: false, actionKind: 'none' as const } : action),
   };
 }
 

--- a/front-end/src/lib/tests/message_protocol.test.ts
+++ b/front-end/src/lib/tests/message_protocol.test.ts
@@ -374,7 +374,7 @@ describe('restore ordering', () => {
     expect(cradle.deliver_message).not.toHaveBeenCalled();
     expect(sentAcks).toEqual([1]);
     expect(sentMessages).toEqual([{ msgno: 4, msg: enc('outbound') }]);
-    expect(cradle.resubmit_submitted).toHaveBeenCalledTimes(1);
+    expect(cradle.resubmit_submitted).not.toHaveBeenCalled();
     expect(blob.messageNumber).toBe(5n);
     expect(blob.remoteNumber).toBe(1n);
     expect(statuses).toEqual(['idle', 'restoring', 'restored']);
@@ -489,7 +489,7 @@ describe('transaction submission', () => {
 
     blob.loadWasm(mockWasmConnection);
     blob.setGameCradle(cradle);
-    blockchain.attachCradle(blob);
+    blob.attachBlockchain(blockchain);
     (cradle.snapshot_watched_coins as jest.Mock).mockClear();
 
     blob.processResult({
@@ -500,10 +500,10 @@ describe('transaction submission', () => {
 
     expect(cradle.snapshot_watched_coins).not.toHaveBeenCalled();
     expect(queriedNames).toEqual([['aa']]);
-    blockchain.detachCradle(blob);
+    blob.detachBlockchain(blockchain);
   });
 
-  it('refreshes watched coins when a restored cradle is installed after poller attach', async () => {
+  it('refreshes watched coins when a hydrated cradle receives a later blockchain attach', async () => {
     const queriedNames: string[][] = [];
     const blockchain = new BlockchainPoller(new Proxy(
       {
@@ -522,7 +522,7 @@ describe('transaction submission', () => {
     ), 60000);
     const sentMessages: Array<{ msgno: number; msg: Uint8Array }> = [];
     const sentAcks: number[] = [];
-    const blob = new WasmBlobWrapper(blockchain, 'test', 100n, makePeerConn(sentMessages, sentAcks));
+    const blob = new WasmBlobWrapper(null, 'test', 100n, makePeerConn(sentMessages, sentAcks));
     activeBlob = blob;
     const cradle = {
       ...makeMockCradle(),
@@ -530,12 +530,53 @@ describe('transaction submission', () => {
     } as unknown as ChiaGame;
 
     blob.loadWasm(mockWasmConnection);
-    blockchain.attachCradle(blob);
     blob.setGameCradle(cradle);
+    expect(queriedNames).toEqual([]);
+
+    blob.attachBlockchain(blockchain);
     await (blockchain as unknown as { pollOnce: () => Promise<void> }).pollOnce();
 
+    expect(cradle.snapshot_watched_coins).toHaveBeenCalledTimes(1);
     expect(queriedNames).toEqual([['bb']]);
-    blockchain.detachCradle(blob);
+
+    blob.attachBlockchain(blockchain);
+    expect(cradle.snapshot_watched_coins).toHaveBeenCalledTimes(2);
+    blob.detachBlockchain(blockchain);
+  });
+
+  it('hydrates without blockchain and replays retained submissions on later attach', async () => {
+    const spend = jest.fn().mockResolvedValue('');
+    const blockchain = new BlockchainPoller({
+      ...mockRpc,
+      spend,
+      getHeightInfo: () => Promise.resolve(1n),
+      registerCoins: () => Promise.resolve(),
+      getCoinRecordsByNames: () => Promise.resolve([]),
+    } as InternalBlockchainInterface, 60000);
+    const sentMessages: Array<{ msgno: number; msg: Uint8Array }> = [];
+    const sentAcks: number[] = [];
+    const blob = new WasmBlobWrapper(null, 'test', 100n, makePeerConn(sentMessages, sentAcks));
+    activeBlob = blob;
+    const cradle = {
+      ...makeMockCradle(),
+      snapshot_watched_coins: jest.fn(() => [{ coin_name: 'cc', coin_string: 'coin-c' }]),
+      drain_submissions: jest.fn(() => [testSpendBundle('05')]),
+    } as unknown as ChiaGame;
+
+    blob.loadWasm(mockWasmConnection);
+    blob.setGameCradle(cradle);
+    blob.processResult({ events: [] });
+
+    expect(cradle.drain_submissions).not.toHaveBeenCalled();
+    expect(spend).not.toHaveBeenCalled();
+
+    blob.attachBlockchain(blockchain);
+    await transactionSubmitQueue(blob);
+
+    expect(cradle.resubmit_submitted).toHaveBeenCalledTimes(1);
+    expect(cradle.drain_submissions).toHaveBeenCalledTimes(1);
+    expect(spend).toHaveBeenCalledTimes(1);
+    blob.detachBlockchain(blockchain);
   });
 
   it('submits drained transactions sequentially', async () => {

--- a/front-end/src/lib/tests/message_protocol.test.ts
+++ b/front-end/src/lib/tests/message_protocol.test.ts
@@ -503,6 +503,41 @@ describe('transaction submission', () => {
     blockchain.detachCradle(blob);
   });
 
+  it('refreshes watched coins when a restored cradle is installed after poller attach', async () => {
+    const queriedNames: string[][] = [];
+    const blockchain = new BlockchainPoller(new Proxy(
+      {
+        getHeightInfo: () => Promise.resolve(1n),
+        registerCoins: () => Promise.resolve(),
+        getCoinRecordsByNames: (names: string[]) => {
+          queriedNames.push(names);
+          return Promise.resolve([]);
+        },
+      } as unknown as InternalBlockchainInterface,
+      {
+        get: (target, prop) =>
+          (target as Record<string, unknown>)[prop as string] ??
+          (() => Promise.resolve(undefined)),
+      },
+    ), 60000);
+    const sentMessages: Array<{ msgno: number; msg: Uint8Array }> = [];
+    const sentAcks: number[] = [];
+    const blob = new WasmBlobWrapper(blockchain, 'test', 100n, makePeerConn(sentMessages, sentAcks));
+    activeBlob = blob;
+    const cradle = {
+      ...makeMockCradle(),
+      snapshot_watched_coins: jest.fn(() => [{ coin_name: 'bb', coin_string: 'coin-b' }]),
+    } as unknown as ChiaGame;
+
+    blob.loadWasm(mockWasmConnection);
+    blockchain.attachCradle(blob);
+    blob.setGameCradle(cradle);
+    await (blockchain as unknown as { pollOnce: () => Promise<void> }).pollOnce();
+
+    expect(queriedNames).toEqual([['bb']]);
+    blockchain.detachCradle(blob);
+  });
+
   it('submits drained transactions sequentially', async () => {
     let resolveFirst: (() => void) | null = null;
     const spend = jest.fn()

--- a/front-end/src/lib/tests/real_blockchain_interface.test.ts
+++ b/front-end/src/lib/tests/real_blockchain_interface.test.ts
@@ -1,20 +1,52 @@
 jest.mock('../../hooks/WalletConnectRpc', () => ({
   rpc: {
     createOfferForIds: jest.fn(),
+    createNewRemoteWallet: jest.fn(),
+    getNextAddress: jest.fn(),
     getCoinRecordsByNames: jest.fn(),
+    getWallets: jest.fn(),
     pushTransactions: jest.fn(),
+    registerRemoteCoins: jest.fn(),
     selectCoins: jest.fn(),
   },
+}));
+
+const mockWalletListeners = new Set<(evt: any) => void>();
+let mockWalletSession: unknown;
+const mockWalletConnectState = {
+  getObservable: () => ({
+    subscribe: ({ next }: { next: (evt: any) => void }) => {
+      mockWalletListeners.add(next);
+      return { unsubscribe: () => { mockWalletListeners.delete(next); } };
+    },
+  }),
+  init: jest.fn(async () => {}),
+  getSession: jest.fn(() => mockWalletSession),
+  disconnect: jest.fn(async () => {
+    mockWalletSession = undefined;
+    for (const next of mockWalletListeners) {
+      next({ stateName: 'initialized', connected: false, sessions: 0 });
+    }
+  }),
+};
+
+jest.mock('../../hooks/useWalletConnect', () => ({
+  walletConnectState: mockWalletConnectState,
 }));
 
 import { rpc } from '../../hooks/WalletConnectRpc';
 import { RealBlockchainInterface } from '../../hooks/RealBlockchainInterface';
 import { CoinRecord } from '../../types/rpc/CoinRecord';
 import { coinIdFromBytes, toUint8 } from '../../util';
+import { encodePuzzleHashToBech32m } from '../../util/bech32m';
 
 const mockCreateOfferForIds = rpc.createOfferForIds as jest.Mock;
+const mockCreateNewRemoteWallet = rpc.createNewRemoteWallet as jest.Mock;
+const mockGetNextAddress = rpc.getNextAddress as jest.Mock;
 const mockGetCoinRecordsByNames = rpc.getCoinRecordsByNames as jest.Mock;
+const mockGetWallets = rpc.getWallets as jest.Mock;
 const mockPushTransactions = rpc.pushTransactions as jest.Mock;
+const mockRegisterRemoteCoins = rpc.registerRemoteCoins as jest.Mock;
 const mockSelectCoins = rpc.selectCoins as jest.Mock;
 
 function encodedWalletConnectError(payload: unknown): string {
@@ -25,9 +57,62 @@ function encodedWalletConnectError(payload: unknown): string {
 describe('RealBlockchainInterface', () => {
   beforeEach(() => {
     mockCreateOfferForIds.mockReset();
+    mockCreateNewRemoteWallet.mockReset();
+    mockGetNextAddress.mockReset();
     mockGetCoinRecordsByNames.mockReset();
+    mockGetWallets.mockReset();
     mockPushTransactions.mockReset();
+    mockRegisterRemoteCoins.mockReset();
     mockSelectCoins.mockReset();
+    mockWalletListeners.clear();
+    mockWalletSession = undefined;
+    mockWalletConnectState.init.mockClear();
+    mockWalletConnectState.getSession.mockClear();
+    mockWalletConnectState.disconnect.mockClear();
+  });
+
+  it('notifies blockchain readiness after WalletConnect reconnect events', async () => {
+    jest.useFakeTimers();
+    try {
+      const address = encodePuzzleHashToBech32m('11'.repeat(32));
+      mockGetNextAddress.mockResolvedValue(address);
+      mockGetWallets.mockResolvedValue([{ type: 205, id: 7n }]);
+      const blockchain = new RealBlockchainInterface();
+      const events: boolean[] = [];
+      blockchain.onConnectionChange((connected) => events.push(connected));
+
+      mockWalletSession = { topic: 'wallet-1' };
+      for (const next of mockWalletListeners) {
+        next({ stateName: 'connected', connected: true, sessions: 1 });
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+      jest.advanceTimersByTime(500);
+      await Promise.resolve();
+
+      expect(events).toEqual([true]);
+      expect(mockGetNextAddress).toHaveBeenCalledTimes(1);
+
+      mockWalletSession = undefined;
+      for (const next of mockWalletListeners) {
+        next({ stateName: 'initialized', connected: false, sessions: 0 });
+      }
+      expect(events).toEqual([true, false]);
+
+      mockWalletSession = { topic: 'wallet-2' };
+      for (const next of mockWalletListeners) {
+        next({ stateName: 'connected', connected: true, sessions: 1 });
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+      jest.advanceTimersByTime(500);
+      await Promise.resolve();
+
+      expect(events).toEqual([true, false, true]);
+      expect(mockGetNextAddress).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('treats encoded WalletConnect coin record misses as absent coins', async () => {

--- a/front-end/src/lib/tests/restore_lifecycle.test.ts
+++ b/front-end/src/lib/tests/restore_lifecycle.test.ts
@@ -1,6 +1,7 @@
 import {
   isRestoreBlocked,
   shouldAdvertiseAvailable,
+  shouldMountGameSession,
 } from '../restoreLifecycle';
 
 describe('restore lifecycle gates', () => {
@@ -19,5 +20,20 @@ describe('restore lifecycle gates', () => {
     expect(shouldAdvertiseAvailable('none', false)).toBe(true);
     expect(shouldAdvertiseAvailable('resolved', false)).toBe(true);
     expect(shouldAdvertiseAvailable('off-chain', false)).toBe(false);
+  });
+
+  it('mounts a saved session without requiring a live blockchain connection', () => {
+    expect(shouldMountGameSession(true, false, true, false)).toEqual({
+      startSession: true,
+      keepSession: true,
+    });
+    expect(shouldMountGameSession(true, false, false, false)).toEqual({
+      startSession: false,
+      keepSession: false,
+    });
+    expect(shouldMountGameSession(true, false, false, true)).toEqual({
+      startSession: false,
+      keepSession: true,
+    });
   });
 });

--- a/front-end/src/lib/tests/restore_lifecycle.test.ts
+++ b/front-end/src/lib/tests/restore_lifecycle.test.ts
@@ -2,6 +2,7 @@ import {
   isRestoreBlocked,
   shouldAdvertiseAvailable,
   shouldMountGameSession,
+  shouldSwitchToTrackerOnResolved,
 } from '../restoreLifecycle';
 
 describe('restore lifecycle gates', () => {
@@ -35,5 +36,12 @@ describe('restore lifecycle gates', () => {
       startSession: false,
       keepSession: true,
     });
+  });
+
+  it('only switches to tracker for a live clean-resolution transition', () => {
+    expect(shouldSwitchToTrackerOnResolved('none', false)).toBe(false);
+    expect(shouldSwitchToTrackerOnResolved('on-chain', false)).toBe(false);
+    expect(shouldSwitchToTrackerOnResolved('off-chain', true)).toBe(false);
+    expect(shouldSwitchToTrackerOnResolved('off-chain', false)).toBe(true);
   });
 });

--- a/front-end/src/lib/tests/session_model.test.ts
+++ b/front-end/src/lib/tests/session_model.test.ts
@@ -115,6 +115,29 @@ describe('session model selectors', () => {
     });
   });
 
+  it('disables chain-submitting dashboard actions while the blockchain is offline', () => {
+    const cleanShutdown = selectGameDashboardView(createSessionModel({
+      channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'Active' } },
+      game: { activeIds: [] },
+    }), { chainAvailable: false });
+    expect(cleanShutdown).toMatchObject({
+      actionLabel: 'Clean Shutdown',
+      actionEnabled: false,
+      actionKind: 'none',
+      channelDetail: 'Reconnect wallet to submit chain transactions.',
+    });
+
+    const goOnChain = selectGameDashboardView(createSessionModel({
+      channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'Active' } },
+      game: { activeIds: ['7'] },
+    }), { chainAvailable: false });
+    expect(goOnChain).toMatchObject({
+      actionLabel: 'Go On-Chain',
+      actionEnabled: false,
+      actionKind: 'none',
+    });
+  });
+
   it('separates channel advisories from hand terminal details', () => {
     const terminal = createSessionModel({
       channel: {

--- a/front-end/src/lib/tests/tracker_connection.test.ts
+++ b/front-end/src/lib/tests/tracker_connection.test.ts
@@ -186,6 +186,15 @@ describe('connection setup', () => {
     const ws = MockWebSocket.instance!;
     expect(ws.sentJson).toEqual([{ type: 'identify', session_id: 's1', busy: true }]);
   });
+
+  it('sends identify with initial alias over ws on open', async () => {
+    const cb = makeCallbacks();
+    makeConnection('http://t', 's1', cb, { initialBusy: true, initialAlias: 'Alice' });
+    await Promise.resolve(); // flush microtasks
+
+    const ws = MockWebSocket.instance!;
+    expect(ws.sentJson).toEqual([{ type: 'identify', session_id: 's1', busy: true, alias: 'Alice' }]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -461,6 +470,22 @@ describe('setBusy', () => {
     expect(ws.sentJson).toEqual([{ type: 'set_busy', session_id: 's1', busy: true }]);
   });
 
+  it('sends set_busy with alias and keeps it for later refreshes', async () => {
+    const cb = makeCallbacks();
+    const conn = makeConnection('http://t', 's1', cb);
+    await Promise.resolve();
+    const ws = MockWebSocket.instance!;
+    ws.sentJson = [];
+
+    conn.setBusy(true, 'Alice');
+    conn.refreshPresence();
+
+    expect(ws.sentJson).toEqual([
+      { type: 'set_busy', session_id: 's1', busy: true, alias: 'Alice' },
+      { type: 'set_busy', session_id: 's1', busy: true, alias: 'Alice' },
+    ]);
+  });
+
   it('includes busy=true in identify on reconnect', async () => {
     jest.useFakeTimers();
     const cb = makeCallbacks();
@@ -479,6 +504,25 @@ describe('setBusy', () => {
     const identifyMsg = ws2.sentJson.find((m: any) => m.type === 'identify') as any;
     expect(identifyMsg).toBeDefined();
     expect(identifyMsg.busy).toBe(true);
+    jest.useRealTimers();
+  });
+
+  it('includes alias in identify on reconnect', async () => {
+    jest.useFakeTimers();
+    const cb = makeCallbacks();
+    const conn = makeConnection('http://t', 's1', cb);
+    await Promise.resolve();
+    expectedTrackerDisconnects = 1;
+    conn.setBusy(true, 'Alice');
+
+    const ws1 = MockWebSocket.instance!;
+    ws1._fireClose();
+    jest.advanceTimersByTime(1000);
+
+    const ws2 = MockWebSocket.instance!;
+    expect(ws2).not.toBe(ws1);
+    const identifyMsg = ws2.sentJson.find((m: any) => m.type === 'identify') as any;
+    expect(identifyMsg).toMatchObject({ type: 'identify', session_id: 's1', busy: true, alias: 'Alice' });
     jest.useRealTimers();
   });
 });

--- a/front-end/src/lib/tests/tracker_connection.test.ts
+++ b/front-end/src/lib/tests/tracker_connection.test.ts
@@ -486,7 +486,7 @@ describe('setBusy', () => {
     ]);
   });
 
-  it('includes busy=true in identify on reconnect', async () => {
+  it('preserves busy presence in identify on reconnect', async () => {
     jest.useFakeTimers();
     const cb = makeCallbacks();
     const conn = makeConnection('http://t', 's1', cb);
@@ -517,7 +517,8 @@ describe('setBusy', () => {
 
     const ws1 = MockWebSocket.instance!;
     ws1._fireClose();
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(5000);
+    await Promise.resolve();
 
     const ws2 = MockWebSocket.instance!;
     expect(ws2).not.toBe(ws1);

--- a/front-end/src/services/TrackerConnection.ts
+++ b/front-end/src/services/TrackerConnection.ts
@@ -40,6 +40,7 @@ export interface TrackerConnectionCallbacks {
 
 export interface TrackerConnectionOptions {
   initialBusy?: boolean;
+  initialAlias?: string | null;
 }
 
 // Binary frame type tags for peer-to-peer relay (opaque to the tracker).
@@ -73,12 +74,14 @@ export class TrackerConnection {
   static readonly MAX_RECONNECT_ATTEMPTS = 18;
   private reconnectAttempt = 0;
   private busy = false;
+  private alias: string | undefined;
 
   constructor(trackerUrl: string, sessionId: string, callbacks: TrackerConnectionCallbacks, options: TrackerConnectionOptions = {}) {
     this.trackerUrl = trackerUrl;
     this.sessionId = sessionId;
     this.callbacks = callbacks;
     this.busy = options.initialBusy ?? false;
+    this.alias = options.initialAlias ?? undefined;
     this.connectWs();
   }
 
@@ -95,6 +98,15 @@ export class TrackerConnection {
     const ws = this.ws;
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
     ws.send(JSON.stringify(payload));
+  }
+
+  private presencePayload(type: 'identify' | 'set_busy'): Record<string, unknown> {
+    return {
+      type,
+      session_id: this.sessionId,
+      busy: this.busy,
+      ...(this.alias ? { alias: this.alias } : {}),
+    };
   }
 
   private connectWs(): void {
@@ -121,7 +133,7 @@ export class TrackerConnection {
       globalThis.clearTimeout(connectTimeout);
       this.ws = ws;
       this.reconnectAttempt = 0;
-      this.sendWs({ type: 'identify', session_id: this.sessionId, busy: this.busy });
+      this.sendWs(this.presencePayload('identify'));
       if (this.closePending) {
         this.sendCloseRequest();
       }
@@ -389,9 +401,19 @@ export class TrackerConnection {
     }
   }
 
-  setBusy(busy: boolean) {
+  setBusy(busy: boolean, alias?: string | null) {
     this.busy = busy;
-    this.sendWs({ type: 'set_busy', session_id: this.sessionId, busy });
+    if (alias !== undefined) {
+      this.alias = alias || undefined;
+    }
+    this.sendWs(this.presencePayload('set_busy'));
+  }
+
+  refreshPresence(alias?: string | null) {
+    if (alias !== undefined) {
+      this.alias = alias || undefined;
+    }
+    this.sendWs(this.presencePayload('set_busy'));
   }
 
   disconnect() {

--- a/lobby/lobby-service/src/index.ts
+++ b/lobby/lobby-service/src/index.ts
@@ -37,10 +37,10 @@ type LobbyInboundMessage =
   | { type: 'keepalive' };
 
 type GameInboundMessage =
-  | { type: 'identify'; session_id: string; busy?: boolean }
+  | { type: 'identify'; session_id: string; busy?: boolean; alias?: string }
   | { type: 'chat'; session_id: string; text: string }
   | { type: 'close'; session_id: string }
-  | { type: 'set_busy'; session_id: string; busy: boolean }
+  | { type: 'set_busy'; session_id: string; busy: boolean; alias?: string }
   | { type: 'keepalive' };
 
 interface LobbyConnMeta {
@@ -166,7 +166,19 @@ function sendLobbyEvent(playerId: string, type: string, payload: unknown): void 
 }
 
 function aliasForPlayer(playerId: string): string {
-  return lobby.players[playerId]?.alias ?? playerId;
+  const liveAlias = lobby.players[playerId]?.alias;
+  if (liveAlias) return liveAlias;
+  const sessionId = playerToSession.get(playerId);
+  return sessionId ? knownAliases.get(sessionId) ?? playerId : playerId;
+}
+
+function rememberGameAlias(sessionId: string, playerId: string, alias: string | undefined): void {
+  if (!alias) return;
+  knownAliases.set(sessionId, alias);
+  const player = lobby.players[playerId];
+  if (player) {
+    player.alias = alias;
+  }
 }
 
 function replayPendingChallengesToPlayer(playerId: string): void {
@@ -603,6 +615,7 @@ function onIdentify(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'ide
     logTracker('game_connection_replaced', { ws_id: wsId(previousGameConn), session_id: msg.session_id });
     try { previousGameConn.close(4001, 'replaced_by_new_connection'); } catch {}
   }
+  rememberGameAlias(msg.session_id, playerId, msg.alias);
   wsGameMeta.set(ws, { sessionId: msg.session_id, playerId, busy: msg.busy });
   gameConnections.set(msg.session_id, ws);
   logTracker('identify_complete_registration', { ws_id: wsId(ws), session_id: msg.session_id, player_id: playerId });
@@ -658,6 +671,7 @@ function onSetBusy(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'set_
     return;
   }
   const playerId = meta.playerId;
+  rememberGameAlias(meta.sessionId, playerId, msg.alias);
   meta.busy = msg.busy;
   logTracker('set_busy', { player_id: playerId, busy: msg.busy });
   applyPlayerBusy(playerId, msg.busy);

--- a/lobby/lobby-service/src/tracker.behavior.test.mjs
+++ b/lobby/lobby-service/src/tracker.behavior.test.mjs
@@ -211,3 +211,48 @@ test('challenge authority and availability come from bound sessions', async () =
     await tracker.stop();
   }
 });
+
+test('playing status uses cached opponent alias after lobby disconnect', async () => {
+  const tracker = await startTracker();
+  try {
+    const aliceSession = 'secret-alice-alias-cache';
+    const bobSession = 'secret-bob-alias-cache';
+    const alice = await joinLobby(tracker.origin, aliceSession, 'Alice');
+    const bob = await joinLobby(tracker.origin, bobSession, 'Bob');
+    const aliceGame = await identifyGame(tracker.origin, aliceSession);
+    const bobGame = await identifyGame(tracker.origin, bobSession);
+
+    sendJson(alice.lobby, { type: 'challenge', target_id: bob.id, amount: '100' });
+    const challenge = await nextJson(bob.lobby, (msg) => msg.type === 'challenge_received');
+    const aliceMatched = nextJson(aliceGame, (msg) => msg.type === 'matched');
+    const bobMatched = nextJson(bobGame, (msg) => msg.type === 'matched');
+    sendJson(bob.lobby, { type: 'challenge_accept', challenge_id: challenge.challenge_id });
+    await Promise.all([aliceMatched, bobMatched]);
+
+    sendJson(alice.lobby, { type: 'leave' });
+    await nextJson(bob.lobby, (msg) =>
+      msg.type === 'lobby_update' && !msg.players.some((player) => player.id === alice.id),
+    );
+
+    sendJson(bobGame, { type: 'set_busy', session_id: bobSession, busy: false, alias: 'Bob' });
+    await nextJson(bob.lobby, (msg) =>
+      msg.type === 'lobby_update' &&
+      msg.players.some((player) => player.id === bob.id && player.status === 'waiting'),
+    );
+
+    sendJson(bobGame, { type: 'set_busy', session_id: bobSession, busy: true, alias: 'Bob' });
+    const update = await nextJson(bob.lobby, (msg) =>
+      msg.type === 'lobby_update' &&
+      msg.players.some((player) => player.id === bob.id && player.status === 'playing'),
+    );
+    const bobPlayer = update.players.find((player) => player.id === bob.id);
+    assert.equal(bobPlayer.opponent_alias, 'Alice');
+
+    await closeWs(alice.lobby);
+    await closeWs(bob.lobby);
+    await closeWs(aliceGame);
+    await closeWs(bobGame);
+  } finally {
+    await tracker.stop();
+  }
+});

--- a/src/tests/calpoker_handlers.rs
+++ b/src/tests/calpoker_handlers.rs
@@ -933,6 +933,7 @@ fn calpoker_parser_succeeds(allocator: &mut AllocEncoder, wire_data: NodePtr) ->
     .is_ok()
 }
 
+#[test]
 fn test_calpoker_proposal_rejects_zero_stake() {
     let mut allocator = AllocEncoder::new();
 
@@ -949,6 +950,7 @@ fn test_calpoker_proposal_rejects_zero_stake() {
     );
 }
 
+#[test]
 fn test_calpoker_parser_rejects_zero_stake_peer_wire_data() {
     let mut allocator = AllocEncoder::new();
 
@@ -971,6 +973,7 @@ fn test_calpoker_parser_rejects_zero_stake_peer_wire_data() {
     );
 }
 
+#[test]
 fn test_calpoker_handlers_happy_path() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -978,6 +981,7 @@ fn test_calpoker_handlers_happy_path() {
     run_handler_game(&mut allocator, &setup, &moves);
 }
 
+#[test]
 fn test_calpoker_handlers_evil_path() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -985,6 +989,7 @@ fn test_calpoker_handlers_evil_path() {
     run_handler_game(&mut allocator, &setup, &moves);
 }
 
+#[test]
 fn test_calpoker_terminal_nil_evidence_precheck_slashes_short_final_move() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);

--- a/src/tests/calpoker_validation.rs
+++ b/src/tests/calpoker_validation.rs
@@ -618,6 +618,7 @@ fn e_move(td: &TestData) -> Vec<u8> {
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
+#[test]
 fn test_calpoker_validator_hashes() {
     let mut allocator = AllocEncoder::new();
     let lib = load_validators(&mut allocator);
@@ -628,6 +629,7 @@ fn test_calpoker_validator_hashes() {
     }
 }
 
+#[test]
 fn test_calpoker_a_slash_too_short() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -641,6 +643,7 @@ fn test_calpoker_a_slash_too_short() {
     );
 }
 
+#[test]
 fn test_calpoker_a_slash_too_long() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -656,6 +659,7 @@ fn test_calpoker_a_slash_too_long() {
     );
 }
 
+#[test]
 fn test_calpoker_b_slash_too_short() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -683,6 +687,7 @@ fn test_calpoker_b_slash_too_short() {
     );
 }
 
+#[test]
 fn test_calpoker_b_slash_too_long() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -712,6 +717,7 @@ fn test_calpoker_b_slash_too_long() {
     );
 }
 
+#[test]
 fn test_calpoker_c_slash_too_short() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -735,6 +741,7 @@ fn test_calpoker_c_slash_too_short() {
     );
 }
 
+#[test]
 fn test_calpoker_c_slash_too_long() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -760,6 +767,7 @@ fn test_calpoker_c_slash_too_long() {
     );
 }
 
+#[test]
 fn test_calpoker_c_slash_bad_alice_reveal() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -787,6 +795,7 @@ fn test_calpoker_c_slash_bad_alice_reveal() {
     );
 }
 
+#[test]
 fn test_calpoker_d_slash_too_short() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -811,6 +820,7 @@ fn test_calpoker_d_slash_too_short() {
     );
 }
 
+#[test]
 fn test_calpoker_d_slash_too_long() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -835,6 +845,7 @@ fn test_calpoker_d_slash_too_long() {
     );
 }
 
+#[test]
 fn test_calpoker_d_slash_too_few_bits() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -859,6 +870,7 @@ fn test_calpoker_d_slash_too_few_bits() {
     );
 }
 
+#[test]
 fn test_calpoker_d_slash_too_many_bits() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -883,6 +895,7 @@ fn test_calpoker_d_slash_too_many_bits() {
     );
 }
 
+#[test]
 fn test_calpoker_e_slash_too_short() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -905,6 +918,7 @@ fn test_calpoker_e_slash_too_short() {
     );
 }
 
+#[test]
 fn test_calpoker_e_slash_too_long() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -928,6 +942,7 @@ fn test_calpoker_e_slash_too_long() {
     );
 }
 
+#[test]
 fn test_calpoker_e_slash_bad_reveal() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -952,6 +967,7 @@ fn test_calpoker_e_slash_bad_reveal() {
     );
 }
 
+#[test]
 fn test_calpoker_e_slash_too_few_discards() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -976,6 +992,7 @@ fn test_calpoker_e_slash_too_few_discards() {
     );
 }
 
+#[test]
 fn test_calpoker_e_slash_too_many_discards() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1000,6 +1017,7 @@ fn test_calpoker_e_slash_too_many_discards() {
     );
 }
 
+#[test]
 fn test_calpoker_e_slash_too_few_selections() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1024,6 +1042,7 @@ fn test_calpoker_e_slash_too_few_selections() {
     );
 }
 
+#[test]
 fn test_calpoker_e_slash_too_many_selections() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1048,6 +1067,7 @@ fn test_calpoker_e_slash_too_many_selections() {
     );
 }
 
+#[test]
 fn test_calpoker_happy_path() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1068,6 +1088,7 @@ fn test_calpoker_happy_path() {
     );
 }
 
+#[test]
 fn test_calpoker_e_mover_share_zero_slash() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1089,6 +1110,7 @@ fn test_calpoker_e_mover_share_zero_slash() {
     );
 }
 
+#[test]
 fn test_calpoker_e_alice_loss_slash() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1113,6 +1135,7 @@ fn test_calpoker_e_alice_loss_slash() {
     );
 }
 
+#[test]
 fn test_calpoker_e_alice_loss_mover_share_100_slash() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1137,6 +1160,7 @@ fn test_calpoker_e_alice_loss_mover_share_100_slash() {
     );
 }
 
+#[test]
 fn test_calpoker_e_bob_loss_make_move() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1158,6 +1182,7 @@ fn test_calpoker_e_bob_loss_make_move() {
     );
 }
 
+#[test]
 fn test_calpoker_e_bob_loss_zero_make_move() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1179,6 +1204,7 @@ fn test_calpoker_e_bob_loss_zero_make_move() {
     );
 }
 
+#[test]
 fn test_calpoker_e_nil_evidence_exception() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1194,6 +1220,7 @@ fn test_calpoker_e_nil_evidence_exception() {
     );
 }
 
+#[test]
 fn test_calpoker_e_bad_evidence_exception() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1230,6 +1257,7 @@ fn expected_infohash_b_for_valid_a_move(
     sha256_concat(&[&b_hash, &move_state_hash])
 }
 
+#[test]
 fn test_slash_succeeds_on_explicit_validator_slash() {
     let mut allocator = AllocEncoder::new();
     let invalid_move = vec![0xAA; 31];
@@ -1240,6 +1268,7 @@ fn test_slash_succeeds_on_explicit_validator_slash() {
     );
 }
 
+#[test]
 fn test_slash_succeeds_on_infohash_misalignment() {
     let mut allocator = AllocEncoder::new();
     let valid_move = vec![0xAB; 32];
@@ -1250,6 +1279,7 @@ fn test_slash_succeeds_on_infohash_misalignment() {
     );
 }
 
+#[test]
 fn test_slash_succeeds_on_max_move_size_misalignment() {
     let mut allocator = AllocEncoder::new();
     let valid_move = vec![0xAC; 32];
@@ -1261,6 +1291,7 @@ fn test_slash_succeeds_on_max_move_size_misalignment() {
     );
 }
 
+#[test]
 fn test_slash_fails_on_aligned_valid_move() {
     let mut allocator = AllocEncoder::new();
     let valid_move = vec![0xAD; 32];
@@ -1272,6 +1303,7 @@ fn test_slash_fails_on_aligned_valid_move() {
     );
 }
 
+#[test]
 fn test_move_rejects_when_new_move_exceeds_max_move_size() {
     let mut allocator = AllocEncoder::new();
     let too_large_move = vec![0xEF; 9];
@@ -1424,6 +1456,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
 /// coin has INFOHASH_B = nil. Slashing this coin should fail because the game
 /// is over and the move was valid. This test confirms whether the referee
 /// puzzle correctly rejects slash on a terminal coin.
+#[test]
 fn test_terminal_coin_nil_infohash_b_slash() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -1535,6 +1568,7 @@ fn test_terminal_coin_nil_infohash_b_slash() {
 /// Same setup as the valid-move terminal test, but the mover cheated by
 /// claiming mover_share = 0 when they should get more. The validator returns
 /// nil (invalid move), so slash must succeed even on a terminal coin.
+#[test]
 fn test_terminal_coin_nil_infohash_b_slash_invalid_move() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);

--- a/src/tests/chialisp.rs
+++ b/src/tests/chialisp.rs
@@ -6,6 +6,7 @@ use clvmr::{run_program, ChiaDialect};
 
 use crate::utils::first;
 
+#[test]
 fn test_make_cards() {
     let mut allocator = AllocEncoder::new();
     let program =
@@ -36,6 +37,7 @@ fn test_make_cards() {
     );
 }
 
+#[test]
 fn test_mergein() {
     let mut allocator = AllocEncoder::new();
     let tests = [
@@ -61,6 +63,7 @@ fn test_mergein() {
     }
 }
 
+#[test]
 fn test_handcalc() {
     let mut allocator = AllocEncoder::new();
     // Add additional case tests for normal range, not a straight.

--- a/src/tests/referee_conditions.rs
+++ b/src/tests/referee_conditions.rs
@@ -136,6 +136,7 @@ fn run_referee_slash_with_mock(
 }
 
 /// Validator returns nil → unconditional slash, output = payout_conditions only
+#[test]
 fn test_slash_succeeds_nil() {
     let mut allocator = AllocEncoder::new();
     let result = run_referee_slash_with_mock(&mut allocator, NodePtr::NIL, &[0x00; 32], 5);
@@ -145,6 +146,7 @@ fn test_slash_succeeds_nil() {
 }
 
 /// Validator returns (wrong_vh state mms) — values misaligned → unconditional slash
+#[test]
 fn test_slash_succeeds_misaligned_no_conditions() {
     let mut allocator = AllocEncoder::new();
 
@@ -164,6 +166,7 @@ fn test_slash_succeeds_misaligned_no_conditions() {
 }
 
 /// Validator returns (correct_vh state mms (AGG_SIG_UNSAFE key msg)) — aligned with conditions → conditional slash
+#[test]
 fn test_slash_succeeds_aligned_with_conditions() {
     let mut allocator = AllocEncoder::new();
 
@@ -214,6 +217,7 @@ fn test_slash_succeeds_aligned_with_conditions() {
 }
 
 /// Validator returns (correct_vh state mms) — aligned, no conditions → move valid, slash fails
+#[test]
 fn test_slash_fails_aligned_no_conditions() {
     let mut allocator = AllocEncoder::new();
 

--- a/src/tests/spacepoker_handlers.rs
+++ b/src/tests/spacepoker_handlers.rs
@@ -680,6 +680,7 @@ fn find_bob_seed_for_outcome(
     panic!("could not find seeds for coin toss outcome");
 }
 
+#[test]
 fn test_spacepoker_setup_game() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -723,6 +724,7 @@ fn parser_succeeds(allocator: &mut AllocEncoder, wire_data: NodePtr) -> bool {
     .is_ok()
 }
 
+#[test]
 fn test_spacepoker_make_proposal_requires_explicit_valid_bet_unit() {
     let mut allocator = AllocEncoder::new();
 
@@ -751,6 +753,7 @@ fn test_spacepoker_make_proposal_requires_explicit_valid_bet_unit() {
     );
 }
 
+#[test]
 fn test_spacepoker_parser_rejects_invalid_peer_bet_unit() {
     let mut allocator = AllocEncoder::new();
 
@@ -777,6 +780,7 @@ fn test_spacepoker_parser_rejects_invalid_peer_bet_unit() {
     );
 }
 
+#[test]
 fn test_spacepoker_happy_path_all_calls() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -835,6 +839,7 @@ fn test_spacepoker_happy_path_all_calls() {
 // Coin toss says Alice opens: 2 nil moves (commitA, commitB), then Alice
 // opens directly. Standard alternation, Alice ends. Uses seeds picked so
 // that mover_opens is true for Alice.
+#[test]
 fn test_spacepoker_happy_path_alice_opens() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -886,6 +891,7 @@ fn test_spacepoker_happy_path_alice_opens() {
 // Coin toss says Alice must pong: 3 nil-style moves (commitA, commitB,
 // Alice pong), then Bob opens. Bob and Alice's roles in the betting
 // alternation are swapped from the alice-opens case, and Bob ends.
+#[test]
 fn test_spacepoker_happy_path_alice_pongs() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -945,6 +951,7 @@ fn test_spacepoker_happy_path_alice_pongs() {
     run_handler_game(&mut allocator, &setup, &moves);
 }
 
+#[test]
 fn test_spacepoker_bob_terminal_nil_evidence_precheck_slashes_short_final_move() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -996,6 +1003,7 @@ fn test_spacepoker_bob_terminal_nil_evidence_precheck_slashes_short_final_move()
     run_handler_game(&mut allocator, &setup, &moves);
 }
 
+#[test]
 fn test_spacepoker_alice_terminal_nil_evidence_precheck_slashes_short_final_move() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -1069,6 +1077,7 @@ fn run_hand_eval(allocator: &mut AllocEncoder, cards: &[i64], boost: i64) -> Vec
     items.iter().map(|n| int_from_node(allocator, *n)).collect()
 }
 
+#[test]
 fn test_hand_eval_high_card() {
     let mut a = AllocEncoder::new();
     let result = run_hand_eval(&mut a, &[14, 10, 7, 5, 3], 0);
@@ -1079,12 +1088,14 @@ fn test_hand_eval_high_card() {
     );
 }
 
+#[test]
 fn test_hand_eval_pair() {
     let mut a = AllocEncoder::new();
     let result = run_hand_eval(&mut a, &[10, 10, 7, 5, 3], 0);
     assert_eq!(result[0], 2, "pair should have leading count 2");
 }
 
+#[test]
 fn test_hand_eval_two_pair() {
     let mut a = AllocEncoder::new();
     let result = run_hand_eval(&mut a, &[10, 10, 7, 7, 3], 0);
@@ -1092,6 +1103,7 @@ fn test_hand_eval_two_pair() {
     assert_eq!(result[1], 2, "two pair second count = 2");
 }
 
+#[test]
 fn test_hand_eval_set() {
     let mut a = AllocEncoder::new();
     let result = run_hand_eval(&mut a, &[10, 10, 10, 7, 3], 0);
@@ -1100,6 +1112,7 @@ fn test_hand_eval_set() {
     assert_eq!(result[2], 1, "set third count = 1");
 }
 
+#[test]
 fn test_hand_eval_straight() {
     let mut a = AllocEncoder::new();
     let result = run_hand_eval(&mut a, &[10, 9, 8, 7, 6], 0);
@@ -1107,6 +1120,7 @@ fn test_hand_eval_straight() {
     assert_eq!(result[1], 3, "straight second = 3");
 }
 
+#[test]
 fn test_hand_eval_full_house() {
     let mut a = AllocEncoder::new();
     let result = run_hand_eval(&mut a, &[10, 10, 10, 7, 7], 0);
@@ -1114,18 +1128,21 @@ fn test_hand_eval_full_house() {
     assert_eq!(result[1], 2, "full house second count = 2");
 }
 
+#[test]
 fn test_hand_eval_four_of_a_kind() {
     let mut a = AllocEncoder::new();
     let result = run_hand_eval(&mut a, &[10, 10, 10, 10, 7], 0);
     assert_eq!(result[0], 4, "four of a kind first count = 4");
 }
 
+#[test]
 fn test_hand_eval_five_of_a_kind() {
     let mut a = AllocEncoder::new();
     let result = run_hand_eval(&mut a, &[10, 10, 10, 10, 10], 0);
     assert_eq!(result[0], 5, "five of a kind first count = 5");
 }
 
+#[test]
 fn test_straight_beats_full_house() {
     let mut a = AllocEncoder::new();
     let straight = run_hand_eval(&mut a, &[10, 9, 8, 7, 6], 0);
@@ -1141,6 +1158,7 @@ fn test_straight_beats_full_house() {
     );
 }
 
+#[test]
 fn test_boosted_set_does_not_beat_unboosted_full_house() {
     let mut a = AllocEncoder::new();
     let boosted_set = run_hand_eval(&mut a, &[10, 10, 10, 7, 3], 1);
@@ -1153,6 +1171,7 @@ fn test_boosted_set_does_not_beat_unboosted_full_house() {
     );
 }
 
+#[test]
 fn test_boost_wins_within_same_hand_type() {
     let mut a = AllocEncoder::new();
     let boosted_pair = run_hand_eval(&mut a, &[10, 10, 7, 5, 3], 1);
@@ -1165,6 +1184,7 @@ fn test_boost_wins_within_same_hand_type() {
     );
 }
 
+#[test]
 fn test_evil_path_wrong_mover_share() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -1257,6 +1277,7 @@ fn run_end_validator_with_evidence(
     code
 }
 
+#[test]
 fn test_generous_mover_share_allowed() {
     let mut allocator = AllocEncoder::new();
 
@@ -1290,6 +1311,7 @@ fn test_generous_mover_share_allowed() {
     );
 }
 
+#[test]
 fn test_greedy_mover_share_slashed() {
     let mut allocator = AllocEncoder::new();
 
@@ -1367,6 +1389,7 @@ fn readable_tag(allocator: &mut AllocEncoder, readable: NodePtr) -> String {
 //
 // Uses run_handler_game for the setup phase, then manually inspects the
 // key steps.
+#[test]
 fn test_spacepoker_open_readable_has_cards_and_message_parser() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -1709,6 +1732,7 @@ fn test_spacepoker_open_readable_has_cards_and_message_parser() {
 // Alice opens with a raise, Bob calls. Exercises the raise path which
 // requires mover_share to remain unchanged on the initial open (the bet
 // only commits once the opponent responds).
+#[test]
 fn test_spacepoker_raise_and_call() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -1779,6 +1803,7 @@ fn test_spacepoker_raise_and_call() {
 // Alice raises, Bob re-raises, Alice calls. Exercises the mid_round
 // re-raise path and subsequent call. On re-raise the prior raise commits
 // to the pot for both players (half_pot += last_raise).
+#[test]
 fn test_spacepoker_reraise_and_call() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);
@@ -1862,6 +1887,7 @@ fn test_spacepoker_reraise_and_call() {
 
 // Alice raises, Bob calls on street 1. Then Alice raises again on street 2,
 // Bob calls again. Exercises repeated raise+call across multiple streets.
+#[test]
 fn test_spacepoker_raise_call_multiple_streets() {
     let mut allocator = AllocEncoder::new();
     let setup = setup_game(&mut allocator);

--- a/src/tests/spacepoker_validation.rs
+++ b/src/tests/spacepoker_validation.rs
@@ -396,6 +396,7 @@ fn make_end_state(
 
 // ─── Tests ───────────────────────────────────────────────────────────────
 
+#[test]
 fn test_spacepoker_validator_hashes() {
     let mut allocator = AllocEncoder::new();
     let lib = load_validators(&mut allocator);
@@ -406,6 +407,7 @@ fn test_spacepoker_validator_hashes() {
     }
 }
 
+#[test]
 fn test_spacepoker_commit_a_happy() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -427,6 +429,7 @@ fn test_spacepoker_commit_a_happy() {
     assert!(result.is_some(), "commitA happy path should succeed");
 }
 
+#[test]
 fn test_spacepoker_commit_a_slash_too_short() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -446,6 +449,7 @@ fn test_spacepoker_commit_a_slash_too_short() {
     );
 }
 
+#[test]
 fn test_spacepoker_commit_a_slash_too_long() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -465,6 +469,7 @@ fn test_spacepoker_commit_a_slash_too_long() {
     );
 }
 
+#[test]
 fn test_spacepoker_commit_a_slash_wrong_mover_share() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -477,6 +482,7 @@ fn test_spacepoker_commit_a_slash_wrong_mover_share() {
     );
 }
 
+#[test]
 fn test_spacepoker_commit_b_happy() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -511,6 +517,7 @@ fn test_spacepoker_commit_b_happy() {
     assert!(result.is_some(), "commitB happy path should succeed");
 }
 
+#[test]
 fn test_spacepoker_commit_b_slash_too_short() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -544,6 +551,7 @@ fn test_spacepoker_commit_b_slash_too_short() {
     );
 }
 
+#[test]
 fn test_spacepoker_commit_b_slash_wrong_mover_share() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -619,6 +627,7 @@ fn drive_to_begin_round(
     .unwrap()
 }
 
+#[test]
 fn test_spacepoker_begin_round_happy() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -646,6 +655,7 @@ fn test_spacepoker_begin_round_happy() {
     assert!(result.is_some(), "begin_round happy path should succeed");
 }
 
+#[test]
 fn test_spacepoker_begin_round_slash_bad_image() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -700,6 +710,7 @@ fn test_spacepoker_begin_round_slash_bad_image() {
 }
 
 // Coin toss says mover opens: open path with bare 32-byte move (check).
+#[test]
 fn test_spacepoker_begin_round_coin_toss_mover_opens_check() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -729,6 +740,7 @@ fn test_spacepoker_begin_round_coin_toss_mover_opens_check() {
 
 // Coin toss says mover must pong: bare 32-byte move is accepted as pong,
 // transitions back to begin_round with images swapped.
+#[test]
 fn test_spacepoker_begin_round_coin_toss_pong() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -758,6 +770,7 @@ fn test_spacepoker_begin_round_coin_toss_pong() {
 
 // Coin toss says mover must pong, but mover tries to open by appending a
 // raise amount. Must slash.
+#[test]
 fn test_spacepoker_begin_round_coin_toss_slash_open_when_should_pong() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -786,6 +799,7 @@ fn test_spacepoker_begin_round_coin_toss_slash_open_when_should_pong() {
 // After a pong, the next begin_round has swapped images. The new mover
 // must always open (the coin toss flips on swap). Verify the full
 // pong-then-open sequence.
+#[test]
 fn test_spacepoker_begin_round_pong_then_open() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -842,6 +856,7 @@ fn test_spacepoker_begin_round_pong_then_open() {
 // is a check (raise=0), which is a valid open. So this test verifies that
 // a bare 32-byte move after a pong is correctly interpreted as a check
 // (not as another pong).
+#[test]
 fn test_spacepoker_begin_round_pong_then_check_is_open() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -890,6 +905,7 @@ fn test_spacepoker_begin_round_pong_then_check_is_open() {
     );
 }
 
+#[test]
 fn test_spacepoker_end_slash_too_short() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -912,6 +928,7 @@ fn test_spacepoker_end_slash_too_short() {
     );
 }
 
+#[test]
 fn test_spacepoker_end_slash_bad_preimage() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -930,6 +947,7 @@ fn test_spacepoker_end_slash_bad_preimage() {
     );
 }
 
+#[test]
 fn test_spacepoker_end_slash_bad_selection_popcount() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -948,6 +966,7 @@ fn test_spacepoker_end_slash_bad_selection_popcount() {
     );
 }
 
+#[test]
 fn test_spacepoker_end_valid_move_nil_evidence_exception() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);
@@ -973,6 +992,7 @@ fn test_spacepoker_end_valid_move_nil_evidence_exception() {
     );
 }
 
+#[test]
 fn test_spacepoker_end_valid_move_bad_evidence_exception() {
     let mut a = AllocEncoder::new();
     let lib = load_validators(&mut a);

--- a/src/tests/standard_coin.rs
+++ b/src/tests/standard_coin.rs
@@ -23,6 +23,7 @@ use crate::tests::constants::{
 };
 use crate::utils::number_from_u8;
 
+#[test]
 fn test_puzzle_for_pk() {
     let mut allocator = AllocEncoder::new();
 
@@ -47,6 +48,7 @@ fn test_puzzle_for_pk() {
     assert_eq!(got_puzzle_hash, predicted_puzzle_hash);
 }
 
+#[test]
 fn test_calculate_synthetic_offset() {
     let pk_bytes: [u8; 48] = [
         0xa3, 0xbb, 0xce, 0xd3, 0x3d, 0x27, 0x32, 0x9d, 0xa1, 0xe3, 0x60, 0xff, 0x4b, 0x0f, 0x00,
@@ -66,6 +68,7 @@ fn test_calculate_synthetic_offset() {
     assert_eq!(offset, want_offset);
 }
 
+#[test]
 fn test_calculate_synthetic_public_key() {
     let pk_bytes: [u8; 48] = [
         0xa3, 0xbb, 0xce, 0xd3, 0x3d, 0x27, 0x32, 0x9d, 0xa1, 0xe3, 0x60, 0xff, 0x4b, 0x0f, 0x00,
@@ -87,6 +90,7 @@ fn test_calculate_synthetic_public_key() {
     assert_eq!(spk, want_spk);
 }
 
+#[test]
 fn test_puzzle_for_synthetic_public_key() {
     let mut allocator = AllocEncoder::new();
     let expect_hex = "ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a3bbced33d27329da1e360ff4b0f00db1747eee8e66c0c0ae450f90b760f42972216c2ff027636aeeb5268bc2be2cedbff018080";
@@ -115,6 +119,7 @@ fn test_puzzle_for_synthetic_public_key() {
     );
 }
 
+#[test]
 fn test_standard_puzzle() {
     let mut allocator = AllocEncoder::new();
     let test_key = PublicKey::from_bytes(*TEST_PUBLIC_KEY_BYTES).expect("should be a public key");
@@ -126,6 +131,7 @@ fn test_standard_puzzle() {
     assert_eq!(expected_hash, puzzle_hash);
 }
 
+#[test]
 fn test_public_key_add() {
     let mut rng = ChaCha8Rng::from_seed([0; 32]);
     let private_key_1: PrivateKey = rng.random();
@@ -138,6 +144,7 @@ fn test_public_key_add() {
     assert_ne!(pk3, pk2);
 }
 
+#[test]
 fn test_bram_2_of_2_signature() {
     let mut rng = ChaCha8Rng::from_seed([0; 32]);
     let private_key_1: PrivateKey = rng.random();
@@ -154,6 +161,7 @@ fn test_bram_2_of_2_signature() {
     assert_eq!(signature_combined, total_sign_from_parts);
 }
 
+#[test]
 fn test_partial_signer() {
     let private_key = PrivateKey::from_bytes(&KEY_PAIR_PRIVATE.clone()).expect("should work");
     let public_key = PublicKey::from_bytes(*KEY_PAIR_PUBLIC).expect("should work");
@@ -165,6 +173,7 @@ fn test_partial_signer() {
     assert_eq!(want_signature, result_sig);
 }
 
+#[test]
 fn test_standard_puzzle_form() {
     let mut allocator = AllocEncoder::new();
     let std_puzzle = get_standard_coin_puzzle(&mut allocator).expect("should work");
@@ -174,6 +183,7 @@ fn test_standard_puzzle_form() {
     );
 }
 
+#[test]
 fn test_calculate_synthetic_public_key_interface() {
     let public_key = PublicKey::from_bytes(*KEY_PAIR_PUBLIC).expect("should work");
     let synthetic_public_key =
@@ -185,6 +195,7 @@ fn test_calculate_synthetic_public_key_interface() {
     );
 }
 
+#[test]
 fn test_curry_and_treehash() {
     let mut allocator = AllocEncoder::new();
 
@@ -236,6 +247,7 @@ fn test_curry_and_treehash() {
 
 // From: https://github.com/richardkiss/chialisp_stdlib/blob/bram-api/tests/test_signing.py
 // Thanks for giving this concise explanation.
+#[test]
 fn test_standard_puzzle_solution_maker() {
     // (defun standard_puzzle_solution_maker (conditions private_key)
     // make a standard puzzle (which we've already tested)

--- a/tools/local-wasm-tests.sh
+++ b/tools/local-wasm-tests.sh
@@ -82,6 +82,9 @@ if [ "$SKIP_BUILD" -eq 0 ]; then
     fi
 fi
 
+echo "=== Running lobby-service tests ==="
+(cd "$REPO_ROOT/lobby/lobby-service" && pnpm run test)
+
 # Kill any stale simulator on our port before starting a fresh one
 lsof -ti:5800 -sTCP:LISTEN | xargs kill 2>/dev/null || true
 lsof -ti:5801 -sTCP:LISTEN | xargs kill 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Make wallet and blockchain polling more robust across reloads, reconnects, and retained transaction replay.
- Allow saved game sessions to restore before wallet/simulator reconnection, then refresh coin watches and submissions when chain access is ready.
- Refresh tracker presence with aliases on restore/reconnect and use cached aliases when lobby peers temporarily disconnect.
- Include lobby-service behavior tests in the normal `./ct.sh` path.

## Test plan
- `./ct.sh`
- `pnpm run test` in `lobby/lobby-service`
- Focused frontend Jest coverage for tracker reconnect, restore lifecycle, message protocol, session model, blockchain poller, and WalletConnect RPC behavior


Made with [Cursor](https://cursor.com)