### PR TITLE
Tracker protocol rework

### DIFF
--- a/CONNECTIVITY.md
+++ b/CONNECTIVITY.md
@@ -354,8 +354,9 @@ The tracker does not create a session. It can only advise and relay:
 - **Peer relay**: Addressed message relay through tracker WebSocket pipe with
   numbered ack protocol, reorder queue, and keepalive
   (`front-end/src/hooks/WasmBlobWrapper.ts`).
-- **Peer liveness**: 60-second activity timeout with 5-second polling
-  interval in `Shell.tsx`. Tracker liveness with 45-second timeout.
+- **Peer liveness**: 30-second degradation threshold (no dead-from-timeout)
+  with 5-second polling interval in `Shell.tsx`. Dead state only from explicit
+  go-on-chain or FOAD signals. Tracker liveness with 45-second timeout.
 - **Advisory matchmaking**: Challenge acceptance sends `advisory_start` to the
   challenge accepter; peers exchange consent messages before starting WASM.
 - **Session persistence**: `SessionState` in localStorage with serialized
@@ -454,7 +455,7 @@ and serve a different purpose.
 |-----|-------|--------|-----|------|
 | Wallet | Connected | — | Disconnected | — |
 | Tracker | Connected | Reconnecting | Inactive (no heartbeat) | Not connected (null / disconnected) |
-| Game | Off-chain, peer up | On-chain (resolving) | Error state or peer lost while off-chain | No session |
+| Game | Peer connected | On-chain or peer degraded | Error, or peer dead | No session / resolved |
 | Chat | Peer connected | — | — | No peer |
 | History | — | — | — | Always gray |
 | Log | — | — | — | Always gray |
@@ -463,16 +464,17 @@ and serve a different purpose.
 
 The Game tab dot checks conditions in this order:
 
-1. `sessionPhase === 'none'` → **gray** (no session)
+1. `sessionPhase === 'none' || 'resolved'` → **gray** (no active session)
 2. `sessionError` → **red** (genuine error — always wins)
-3. `sessionPhase === 'on-chain'` → **yellow** (actively resolving — overrides peer-lost red because peer loss auto-transitions to on-chain)
-4. `sessionPhase === 'off-chain'` and `!peerConnected` → **red** (peer lost while off-chain, briefly visible before auto-transition)
-5. `sessionPhase === 'off-chain'` and `peerConnected` → **green** (playing normally)
+3. `peerLiveness === 'dead'` → **red** (terminal — go-on-chain or FOAD)
+4. `sessionPhase === 'on-chain'` or `peerLiveness === 'degraded'` → **yellow** (resolving or stale peer)
+5. `peerLiveness === 'connected'` → **green** (playing normally)
+6. Otherwise → **gray**
 
 ### Game tab error conditions (red dot)
 
-The Game tab shows a red dot when `sessionError` is true or when the peer
-is lost while the session is off-chain. `sessionError` is derived from:
+The Game tab shows a red dot when `sessionError` is true or when
+`peerLiveness === 'dead'` (go-on-chain or FOAD received). `sessionError` is derived from:
 
 - `Failed` channel state — the channel encountered an unrecoverable error
 - `ResolvedStale` channel state — the channel resolved but the outcome is

--- a/CONNECTIVITY.md
+++ b/CONNECTIVITY.md
@@ -147,15 +147,20 @@ blockchain operations stall but the logical state is unchanged.
 Forced cascades flow downward through the dependency chain:
 
 ```
-tracker dies  →  peer dies  →  off-chain session goes on-chain
+tracker dies  →  peer degraded  →  user decides whether to go on-chain
 ```
 
 Specific rules:
 
+- **Tracker goes down temporarily** → peer relay interrupted → liveness
+  degrades to yellow. Tracker auto-reconnects; peer messages resume when
+  the pipe is back.
 - **Tracker goes down permanently** → peer is gone (rides the same socket) →
-  if session is off-chain, auto-transition to on-chain.
-- **Peer lost** (hard disconnect, liveness timeout, or tracker death) → if
-  session is off-chain, auto-transition to on-chain.
+  liveness degrades to yellow. User must manually go on-chain to resolve.
+- **Peer silent 30+ seconds or delivery failure** → liveness degrades to
+  yellow. No automatic escalation — silence alone is not terminal.
+- **Explicit terminal signal** (local go-on-chain or received FOAD) → peer
+  marked dead (red). This is the only path to the dead state.
 - **Session transitions off-chain → on-chain** — one-way. No going back.
 - **Wallet loss** — no cascade. Session is logically unchanged; blockchain
   operations just can't make progress until a wallet is reconnected.
@@ -422,13 +427,15 @@ The tracker does not create a session. It can only advise and relay:
   warning if peer/session would be affected.
 
 - **User-initiated peer disconnect**: Ending a peer session means marking
-  oneself as available again (`setBusy(false)`). If the session is off-chain,
-  losing the peer automatically cascades to on-chain.
+  oneself as available again (`setBusy(false)`). The session remains
+  off-chain until the user explicitly goes on-chain.
 
-- **Automatic peer-loss cascade**: When the peer is lost (delivery failures,
-  liveness timeout, or tracker disconnect) while the session is off-chain,
-  Shell automatically calls `goOnChain()` on the WASM cradle. No user
-  prompt — this is the cascade rule: off-chain + no peer = on-chain.
+- **Peer degradation (no auto-cascade)**: When the peer becomes unreachable
+  (delivery failures, 30-second silence, or tracker disconnect) while the
+  session is off-chain, `peerLiveness` moves to `'degraded'` (yellow dot).
+  There is no automatic go-on-chain — the user must decide to escalate.
+  Only explicit terminal signals (user clicks "Go On-Chain" or receives a
+  FOAD) mark the peer as dead.
 
 - **Cascade warning dialogs**: Confirmation dialogs currently warn before
   disconnecting or switching trackers when a peer/session would be affected.

--- a/CONNECTIVITY.md
+++ b/CONNECTIVITY.md
@@ -46,8 +46,8 @@ make progress.
 WalletConnect is an external protocol. The player app can adapt around its
 quirks at the edges (for example BigInt serialization handling), but it does
 not control WalletConnect's wire format. This is different from the peer/tracker
-protocol, which is project-owned and can move further toward binary framing over
-time.
+protocol, which is project-owned: the game WebSocket control envelopes and
+peer app messages use bencodex, while the lobby iframe WebSocket remains JSON.
 
 ### Tracker
 
@@ -67,17 +67,15 @@ transport (WebRTC is a future option). The peer relay rides on the tracker's
 WebSocket — structurally, **peer requires tracker**. If the tracker is down,
 the peer is down by definition.
 
-There are two ways to end a peer connection:
+Peer sessions are established through addressed messaging: after the tracker
+sends an `advisory_start` to the challenge accepter, the peers exchange consent
+messages (`session_proposal` / `session_reject`) as bencodex peer app
+dictionaries and then binary handshake frames through the tracker's relay pipe.
+The tracker acts as a dumb pipe — it delivers messages to the target peer if
+connected and reports `delivery_failure` if not.
 
-1. **Hard disconnect** — `close()` via the tracker. The tracker notifies the
-   peer (`closed` event), removes the pairing, and sets both players to
-   `'waiting'`. The relay is gone, including chat.
-2. **Soft disconnect** — going on-chain while the tracker/peer relay is still
-   alive. Game messages stop flowing, but chat continues over the same relay.
-   The pairing still exists on the tracker.
-
-Once the peer connection is considered lost (either via hard disconnect, or
-liveness timeout without reconnect), it is gone. There is no "reconnect to
+Once the peer connection is considered lost (delivery failures without
+reconnect within the liveness window), it is gone. There is no "reconnect to
 the same peer" — both sides would have to re-match on a tracker.
 
 ### Session
@@ -178,15 +176,15 @@ Specific rules:
 | Action | Allowed? | Warning | Consequence |
 |--------|----------|---------|-------------|
 | Disconnect | Always | If peer up: "This will end your peer connection." If session off-chain: "This will force your game on-chain." | Peer dies (cascade). |
-| Reconnect (same tracker) | Always | None | Tracker re-identifies. If pairing still exists on server, peer may reconnect. |
+| Reconnect (same tracker) | Always | None | Tracker re-identifies. Resends un-acked messages if session active. |
 | Connect to new tracker | Always | None | New lobby. If session is active, join as unavailable. |
 
 ### Peer
 
 | Action | Allowed? | Warning | Consequence |
 |--------|----------|---------|-------------|
-| Hard disconnect (`close()`) | Always | None currently. | Pairing removed. Peer notified. Both go to `'waiting'`. Off-chain session transitions to on-chain via the peer-loss cascade. |
-| Reconnect | Not a user action | — | Handled by tracker auto-reconnect and `peer_reconnected` events. |
+| End session | Always | None currently. | Player marks available (`setBusy(false)`). Off-chain session transitions to on-chain via the peer-loss cascade. |
+| Reconnect | Not a user action | — | Handled by tracker auto-reconnect; player resends un-acked messages on `registered`. |
 
 ### Session
 
@@ -206,6 +204,7 @@ Specific rules:
 | `none` | `gameParams === null` | No session. Not busy and available for matchmaking. |
 | `off-chain` | Session exists, not yet resolving on-chain | Playing through the peer relay. `cleanShutdown()` stays off-chain until the shutdown transaction is formed. |
 | `on-chain` | `goOnChain()` initiated, clean shutdown transaction submitted, or channel resolved while game outcomes are still pending | Resolving on the blockchain or waiting for remaining hand outcomes. May or may not have peer. |
+| `resolved` | Terminal channel state and no pending hand obligations | No live protocol obligation. Not busy and available for matchmaking, while the finished session may remain visible as display state. |
 
 The on-chain state persists until the broader session phase is terminal. A raw
 channel status of `ResolvedClean`, `ResolvedUnrolled`, `ResolvedStale`, or
@@ -239,8 +238,9 @@ any pending hand obligations have finished:
 1. The session is done.
 2. Shell is notified (via callback from `useGameSession`).
 3. Live protocol interaction stops: the WASM cradle is no longer used for new
-   game actions, `sessionStartedRef` and `activePairingTokenRef` are reset, and
-   the finished session is treated as a read-only display.
+   game actions, peer relay refs and message handlers are cleared, keepalives
+   stop, `sessionStartedRef` and `activePairingTokenRef` are reset, and the
+   finished session is treated as a read-only display.
 4. The resolved display is intentionally preserved so the user can see what just
    happened. A reload may restore this finished view, but it should not resume
    live protocol behavior.
@@ -250,10 +250,11 @@ any pending hand obligations have finished:
    play instead of making the user manually clear the finished game.
 7. A new match replaces the old resolved display. There is no manual "Close
    Session" button.
-8. The peer connection is not forcibly closed — chat can continue until a
-   new match replaces the pairing or either side disconnects.
-9. Chat messages persist across session boundaries and are only cleared
-   when a new pairing starts (new match).
+8. The old peer connection is no longer a live session route. The app may still
+   show the finished session and prior chat/history, but new peer messages must
+   come from a newly accepted session.
+9. Chat messages persist across session boundaries and are only cleared when a
+   new pairing starts.
 
 ---
 
@@ -278,31 +279,33 @@ and a much harder surface to guard against. Busy signaling goes over
 the WebSocket because it's the more defensible transport, not because the
 tracker is trusted.
 
-Busy is session-obligation state, not just pairing state. A player can be busy
-because an old session is still unresolved even if the tracker no longer has a
-pairing for that player (for example, after disconnecting from the tracker while
-resolving on-chain). Conversely, after a session finishes, the player can become
-not busy and available for new matches while a previous pairing/chat is still
-visible until a new session replaces it.
+Busy is client-authoritative session-obligation state, not just tracker pairing
+state. A player can be busy because an old session is still unresolved even if
+the tracker no longer has a pairing for that player (for example, after
+disconnecting from the tracker while resolving on-chain). Conversely, after a
+session finishes, the player can become not busy and available for new matches
+while a previous result remains visible until a new session replaces it.
 
-The app is not busy if and only if the broader session phase is `none` or
-`resolved`. Raw `ChannelState` is more detailed than this (`Handshaking`,
-funding/offer states, `Active`, shutdown states, on-chain transition states,
-resolved channel states, `Failed`, etc.) and must not be treated as the lobby
-availability state directly. The broader session phase folds in pending hand
-state: a raw channel status can be resolved while the session remains `on-chain`
-because a hand is still being settled.
+The app is available for a new session when the broader session phase is `none`
+or `resolved` and there is no consent prompt, reserved peer id, buffered
+handshake, or live message handler. A consent prompt is a temporary unavailable
+state: while it is open, the app sends `set_busy: true` and declines any other
+incoming advisory/proposal. Raw `ChannelState` is more detailed than this
+(`Handshaking`, funding/offer states, `Active`, shutdown states, on-chain
+transition states, resolved channel states, `Failed`, etc.) and must not be
+treated as the lobby availability state directly. The broader session phase
+folds in pending hand state: a raw channel status can be resolved while the
+session remains `on-chain` because a hand is still being settled.
 
 **Player app → Tracker (game channel):**
 
-```json
-{ "type": "set_busy", "session_id": "...", "busy": true }
-```
+Logical bencodex dictionary: `{ type: "set_busy", session_id: "...", busy: true }`.
 
-Sent whenever the broader session phase changes. The same `busy` bit is also
-included in the initial `identify` message so the tracker has correct status
-immediately after a game channel opens, reconnects, or restores. This avoids a
-brief `waiting` flicker for unresolved restored sessions.
+Sent whenever the broader session phase or consent-prompt availability changes.
+The same `busy` bit is also included in the initial `identify` message so the
+tracker has correct status immediately after a game channel opens, reconnects,
+or restores. This avoids a brief `waiting` flicker for unresolved restored
+sessions.
 
 The tracker updates the player's lobby status to `'busy'` or `'playing'` while
 busy, or `'waiting'` when not busy, and broadcasts a lobby update. When a player
@@ -318,6 +321,28 @@ The lobby iframe receives the updated `Player.status` via the normal
 `lobby_update` broadcast and renders busy players as unavailable. No
 iframe-side protocol changes are needed — it is read-only for this signal.
 
+### Proposal Handoff
+
+The tracker does not create a session. It can only advise and relay:
+
+1. A lobby user creates a challenge. The tracker stores that pending challenge
+   and sends `challenge_received` to the target lobby iframe.
+2. If the target accepts in the lobby, the tracker removes that challenge,
+   cancels stale challenge records involving either player, and sends
+   `advisory_start` to the target player's game channel. The target is now the
+   proposed channel initiator.
+3. The target player's app checks local availability. If it is in a live
+   session, on-chain resolution, restore/handshake, or another consent prompt,
+   it declines by sending `session_reject` to the peer through the relay.
+4. If the target consents, it marks itself busy, sends a bencodex
+   `session_proposal` app message to the challenger through the addressed relay,
+   starts WASM as initiator, and sends binary handshake frames.
+5. The challenger app checks local availability before showing the proposal
+   prompt. While the prompt is open it reserves that peer id so early
+   `HandshakeA` bytes can buffer, and it marks itself busy. If unavailable or
+   declined, it sends `session_reject` and discards buffered handshake bytes. If
+   accepted, it starts WASM as receiver and drains the buffer.
+
 ---
 
 ## Implementation Status
@@ -326,13 +351,13 @@ iframe-side protocol changes are needed — it is read-only for this signal.
 
 - **Tracker connection**: `TrackerConnection` class with auto-reconnect,
   backoff, and keepalive (`front-end/src/services/TrackerConnection.ts`).
-- **Peer relay**: Message relay through tracker WebSocket with numbered
-  ack protocol, reorder queue, and keepalive
+- **Peer relay**: Addressed message relay through tracker WebSocket pipe with
+  numbered ack protocol, reorder queue, and keepalive
   (`front-end/src/hooks/WasmBlobWrapper.ts`).
 - **Peer liveness**: 60-second activity timeout with 5-second polling
   interval in `Shell.tsx`. Tracker liveness with 45-second timeout.
-- **Tracker `close()`**: Protocol-level session end that notifies peer and
-  removes pairing (`TrackerConnection.close()`).
+- **Advisory matchmaking**: Challenge acceptance sends `advisory_start` to the
+  challenge accepter; peers exchange consent messages before starting WASM.
 - **Session persistence**: `SessionState` in localStorage with serialized
   WASM cradle, message numbers, unacked messages, etc.
   (`front-end/src/hooks/save.ts`).
@@ -362,7 +387,7 @@ iframe-side protocol changes are needed — it is read-only for this signal.
   internal refs (`sessionStartedRef`, `activePairingTokenRef`), and marks the
   player as not busy. The game UI stays visible as a read-only resolved display
   until a new match replaces it, and a reload may restore that finished view.
-  Chat persists across session boundaries and is only cleared when a new pairing
+  Chat persists across session boundaries and is only cleared when a new session
   starts. Terminal error or suspect outcomes are carried separately via
   `sessionError`.
 
@@ -372,7 +397,8 @@ iframe-side protocol changes are needed — it is read-only for this signal.
   `OutboundMessage` events.
 
 - **Tracker busy signaling**: `TrackerConnection.setBusy()`
-  sends `{ type: "set_busy", busy }` over the game WebSocket.
+  sends a bencodex `{ type: "set_busy", busy }` dictionary over the game
+  WebSocket.
   The `identify` message includes the current busy bit. Shell calls
   `setBusy(!(sessionPhase === 'none' || sessionPhase === 'resolved'))` whenever
   the broader session phase changes, while restore blocking keeps unresolved
@@ -380,7 +406,7 @@ iframe-side protocol changes are needed — it is read-only for this signal.
   an active game obligation, so the player can be available for a new match even
   if the existing relay/chat is still visible.
 
-- **Tracker-side `set_busy` handler**: The tracker server accepts
+- **Tracker-side `set_busy` handler**: The tracker server accepts bencodex
   `set_busy` messages on the game channel. It updates the player's lobby
   status to `'playing'`, `'busy'`, or `'waiting'` and broadcasts a lobby update.
   When busy becomes true, pending challenges involving that player are cancelled;
@@ -388,18 +414,18 @@ iframe-side protocol changes are needed — it is read-only for this signal.
 
 - **Tracker retry budget**: `TrackerConnection` now has a
   `MAX_RECONNECT_ATTEMPTS` budget. After the budget is exhausted, the
-  tracker is declared permanently dead and `onClosed` fires.
+  tracker is declared permanently dead.
 
 - **User-initiated tracker disconnect**: A "Disconnect" button in the
   tracker tab header allows explicit tracker disconnect. Gated by a cascade
   warning if peer/session would be affected.
 
-- **User-initiated peer disconnect**: A "Disconnect" button in the Chat tab
-  sends `close()` via the tracker, ending the pairing. If the session is
-  off-chain, losing the peer automatically cascades to on-chain.
+- **User-initiated peer disconnect**: Ending a peer session means marking
+  oneself as available again (`setBusy(false)`). If the session is off-chain,
+  losing the peer automatically cascades to on-chain.
 
-- **Automatic peer-loss cascade**: When the peer is lost (via `close()`,
-  liveness timeout, or tracker notification) while the session is off-chain,
+- **Automatic peer-loss cascade**: When the peer is lost (delivery failures,
+  liveness timeout, or tracker disconnect) while the session is off-chain,
   Shell automatically calls `goOnChain()` on the WASM cradle. No user
   prompt — this is the cascade rule: off-chain + no peer = on-chain.
 

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -638,10 +638,16 @@ keepalive freshness into four states:
 Transitions: `onTrackerDisconnected` → Reconnecting, `onTrackerReconnected` →
 Connected, keepalive timeout while WS is up → Inactive.
 
-**Peer indicator** is a boolean: any peer activity (data, ack, or keepalive)
-within the last 60 seconds (`PEER_LIVENESS_MS`) means Active, otherwise
-Inactive. The activity ref is updated by the `onPeerMessage` callback in
-`TrackerConnection`, ensuring it stays current across reconnects.
+**Peer indicator** (`PeerLiveness`) has four states:
+
+| State | Meaning | Dot color |
+|-------|---------|-----------|
+| `connected` | Peer traffic received within the last 30 seconds | Green |
+| `degraded` | Delivery failure reported by tracker, or no peer traffic for 30+ seconds | Yellow |
+| `dead` | Local go-on-chain or session rejection (FOAD) — terminal for this peer relationship | Red |
+| `null` | No active peer session | Grey |
+
+`dead` is sticky: incoming messages from that peer are ignored. Only a new session start resets to `null`.
 
 **Action buttons**: Controls live with the state axis they affect. The tracker
 disconnect button lives in the Tracker tab header strip (right-aligned next to

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -70,10 +70,11 @@ configuration.
 The tracker has two communication channels per player:
 
 1. **Lobby/control channel** — a bespoke tracker protocol used by the lobby
-   iframe for alias, presence, challenge, and matchmaking messages.
+   iframe for alias, presence, challenge, and matchmaking messages. This
+   channel remains JSON over `/ws/lobby`.
 2. **Game relay channel** — the player app's `TrackerConnection` WebSocket. Its
-   JSON control frames establish/monitor the tracker session and its binary
-   frames carry game-specific peer messages unchanged.
+   tracker-control envelopes are bencodex binary dictionaries over `/ws/game`;
+   addressed binary frames carry peer payloads through the tracker relay.
 
 Each channel uses a dedicated WebSocket endpoint: the lobby channel connects to
 `/ws/lobby` and the game channel connects to `/ws/game`. The player app provides
@@ -108,38 +109,42 @@ updates never include the secret nonce.
 | `challenge_received` | `{ challenge_id, from_id, from_alias, amount }` | Someone challenged you |
 | `challenge_resolved` | `{ challenge_id, accepted }` | Your outgoing challenge was accepted or declined |
 
-When a challenge is accepted, the tracker creates a **pairing** (two player IDs
-linked by a random token) and emits `matched` to both players' game channels.
-Both players' status is set to `'playing'` with the opponent's alias, and any
-pending challenges involving either player are cancelled. Separately, the player
-app self-declares whether it is `busy`. Busy means the app has an unresolved
-session obligation and should not receive challenges. When the app later reports
-that it is not busy, the tracker sets the player back to `'waiting'`; an old
-pairing/chat may still exist until a new session replaces it.
+When a challenge is accepted, the tracker removes that challenge, cancels stale
+pending challenges involving either player, and sends an **advisory_start**
+message to the accepter's game channel only. That advisory is not authority to
+start a session by itself; it asks the accepter's player app whether to initiate.
+The player app self-declares whether it is `busy` over the game channel. Busy
+means the app has an unresolved session obligation or is already showing a
+session-consent prompt and should not receive challenges. When the app later
+reports that it is not busy, the tracker sets the player back to `'waiting'`.
 
 #### Game channel events
+
+The tables below describe logical dictionary fields. On `/ws/game`, tracker
+control envelopes (`identify`, `set_busy`, `registered`, `advisory_start`,
+`delivery_failure`, `lobby_attention`, `keepalive`, and `error`) are bencodex
+binary dictionary frames. The addressed peer-relay envelope is still a
+length-prefixed binary frame; peer app messages inside that envelope
+(`session_proposal`, `session_reject`, and `chat`) are bencodex dictionaries,
+while WASM protocol frames remain raw bytes with the existing reliability tags.
 
 **Player App → Tracker:**
 
 | Event | Payload | Purpose |
 |-------|---------|---------|
-| `identify` | `{ session_id, busy }` | Sent immediately after the game channel opens. Links this channel to the player's lobby session and reports whether the player app currently has an unresolved session obligation. |
-| binary frame | `uint32be msgno || bytes` | Send an authoritative game-protocol byte blob to the paired peer. The tracker relays the binary frame verbatim. |
-| `message` | `{ session_id, data }` | Send JSON relay-control payloads such as `{ ack }` and `{ keepalive: true }` to the paired peer. |
-| `chat` | `{ session_id, text }` | Send chat text to the paired peer. |
-| `close` | `{ session_id }` | Request to end the relay session. |
-| `set_busy` | `{ session_id, busy }` | Update lobby availability as the local broader session phase changes. `busy: true` maps to lobby `busy` or `playing` and cancels pending challenges involving the player; `busy: false` maps to `waiting`. |
+| `identify` | `{ session_id, busy }` | Sent immediately after the game channel opens. Links this channel to the player's lobby session and reports whether the player app currently considers itself unavailable. |
+| binary frame | `[4-byte target_id_len BE][target_id UTF-8][payload]` | Send a peer payload addressed to a specific peer through the tracker relay pipe. |
+| `set_busy` | `{ session_id, busy }` | Update lobby availability from the client-authoritative state. `busy: true` maps to lobby `busy` or `playing` and cancels pending challenges involving the player; `busy: false` maps to `waiting`. |
 
 **Tracker → Player App:**
 
 | Event | Payload | Purpose |
 |-------|---------|---------|
-| `matched` | `{ token, amount, i_am_initiator, my_alias?, peer_alias? }` | A fresh match has been made (challenge accepted for the first time). `amount` is the channel buy-in. |
-| `connection_status` | `{ has_pairing, token?, amount?, i_am_initiator?, peer_connected?, my_alias?, peer_alias? }` | Definitive status report sent on `identify`. The player app uses this to reconcile tracker state against its local save (see [Reconnect Reconciliation](#reconnect-reconciliation)). |
-| `peer_reconnected` | `{}` | The other player's game channel just re-registered. Tells this side to re-send un-acked messages. |
-| binary frame | `uint32be msgno || bytes` | An authoritative game-protocol byte blob from the paired peer, relayed verbatim. |
-| `message` | `{ data }` | A JSON relay-control payload from the paired peer, currently ack or keepalive data (see [Peer Message Reliability](#peer-message-reliability)). |
-| `closed` | `{}` | The relay session is over. Sent to the peer when the other side sends `close`, AND echoed back to the sender of `close` as confirmation. |
+| `registered` | `{ player_id }` | Confirmation of identity. Sent in response to `identify`. |
+| `advisory_start` | `{ peer_id, peer_alias, amount, channel_timeout?, unroll_timeout? }` | The tracker suggests starting a session with this peer (triggered by challenge acceptance in the lobby). One-sided: only sent to the challenge accepter, who may become the channel initiator after local consent. |
+| binary frame | `[4-byte from_id_len BE][from_id UTF-8][4-byte alias_len BE][alias UTF-8][payload]` | A peer payload from another peer, relayed through the tracker pipe with the sender's public id and alias. |
+| `delivery_failure` | `{ to }` | The target peer is not connected; the message could not be delivered. |
+| `lobby_attention` | `{}` | Signals that something happened in the lobby that the user should look at. |
 
 **Connection lifecycle:**
 
@@ -149,26 +154,31 @@ pairing/chat may still exist until a new session replaces it.
 3. The tracker associates this game channel with the lobby session. If a
    previous game channel exists for this player, the tracker closes it and
    replaces it.
-4. The tracker always responds with `connection_status`, reporting whether a
-   pairing exists, its channel buy-in amount, and whether the peer is currently
-   connected.
-5. If a pairing exists and the peer is connected, the tracker also sends
-   `peer_reconnected` to the peer's game channel.
-6. When a challenge is accepted in the lobby, the tracker sends `matched` to
-   both players' game channels. The player app starts the WASM cradle and game
-   session.
-7. Both players exchange binary game frames and JSON relay-control messages
-   through the tracker relay.
-8. Either player can send `close` to end the session. The tracker sends `closed`
-   to the other player **and** echoes `closed` back to the sender as
-   confirmation. The client sets a `closePending` flag and ignores incoming
-   `message` events until the `closed` echo arrives.
+4. The tracker responds with `registered`, confirming the player's public ID.
+5. When a challenge is accepted in the lobby, the tracker sends `advisory_start`
+   to the accepter's game channel only. The app first checks its local
+   availability. If it is already in a session, restoring, handshaking, or
+   showing another consent prompt, it declines by sending `session_reject` to
+   the peer through the pipe.
+6. If the accepter consents, that app becomes the channel initiator. It marks
+   itself busy, sends a bencodex `session_proposal` app message to the peer,
+   starts the WASM session as initiator, and then sends the binary handshake
+   frames through the same addressed pipe.
+7. The peer receives the `session_proposal`, reserves that peer id so early
+   handshake bytes can buffer, marks itself busy while the prompt is open, and
+   shows its own consent prompt. If unavailable or declined, it sends
+   `session_reject` and discards any buffered handshake bytes. If accepted, it
+   starts the WASM session as receiver and drains the buffered handshake bytes.
+8. Both players exchange binary game frames through the addressed tracker pipe.
+   The reliability layer (msgno/ack/keepalive) is encoded inside the binary
+   payload, peer-to-peer — the tracker never interprets it.
 
-**What the tracker holds per paired session:** Just the two channels and the
-pairing metadata (player IDs, token, aliases, and channel buy-in amount). No
-message log, no delivery receipts, no game state. When a channel drops, messages
-to that peer are silently discarded. When a new game channel claims the slot
-(step 3), the tracker resumes routing. Lobby channel disconnects do NOT
+**What the tracker holds per game channel:** just the mapping from session ID to
+player ID and the WebSocket reference. The tracker has no authoritative session
+pairing, message log, delivery receipts, or game state. Message routing is
+purely addressed. When a channel drops, messages to that peer are silently
+discarded. When a new game channel claims the slot (step 3), the tracker resumes
+routing. Lobby channel disconnects do NOT
 immediately remove the player from the lobby — the tracker service applies a
 short TTL sweep to clean up truly departed players. The lobby iframe re-`join`s
 on reconnect, refreshing `lastActive`.
@@ -179,26 +189,29 @@ TCP closes are not always reliable (half-open connections, NAT timeouts, proxy
 buffering). The tracker and clients maintain bidirectional application-level
 keepalives at two separate layers:
 
-1. **Tracker-level keepalives** — `{ type: 'keepalive' }` envelope frames sent
-   directly between the tracker server and each client, every 15 seconds in both
-   directions. These prove the WebSocket connection itself is alive.
-2. **Peer-level keepalives** — `{ keepalive: true }` relay payloads sent inside
-   `message` events, relayed through the tracker to the paired peer. These prove
+1. **Tracker-level keepalives** — `{ type: 'keepalive' }` logical envelope
+   frames sent directly between the tracker server and each client, every 15
+   seconds in both directions. `/ws/lobby` serializes these as JSON; `/ws/game`
+   serializes them as bencodex dictionaries. These prove the WebSocket
+   connection itself is alive.
+2. **Peer-level keepalives** — relay payloads with the peer reliability
+   keepalive tag, relayed through the tracker to the paired peer. These prove
    the peer is alive end-to-end (see [Peer Liveness](#peer-liveness)).
 
 **Server side (`index.ts`):**
 
 - Maintains WebSocket clients for lobby and game channels.
-- Starts a 15-second keepalive interval per connection (`{ type: 'keepalive' }`).
-  The interval is cleared on `ws.close`.
-- Handles inbound `{ type: 'keepalive' }` as a no-op (the frame arriving is
+- Starts a 15-second keepalive interval per connection. Lobby keepalives are
+  JSON; game keepalives are bencodex. The interval is cleared on `ws.close`.
+- Handles inbound keepalive envelopes as no-ops (the frame arriving is
   sufficient proof of life).
 
 **Game channel client (`TrackerConnection`):**
 
 - Uses a WebSocket connection to `/ws/game` and re-sends `identify` on reconnect.
 - Starts a 15-second keepalive interval on `ws.onopen` that sends
-  `{ type: 'keepalive' }` to the tracker. Cleared on close/error/disconnect.
+  a bencodex `{ type: 'keepalive' }` dictionary to the tracker. Cleared on
+  close/error/disconnect.
 - Fires `onTrackerActivity()` on every incoming `ws.onmessage` (any message
   type proves the tracker is alive).
 
@@ -555,22 +568,19 @@ acks.
 
 #### Wire format
 
-Authoritative game messages are binary WebSocket frames, not JSON. The frame is:
+Authoritative WASM game messages remain raw bytes inside addressed peer-relay
+payloads, not JSON and not bencodex. The player app wraps them in a tiny
+peer-to-peer reliability tag before handing the payload to `TrackerConnection`:
 
-- **Data frame:** 4-byte big-endian `msgno`, followed by the opaque WASM peer
-  message bytes.
+- **Data payload:** tag `0x01`, 4-byte big-endian `msgno`, followed by the
+  opaque WASM peer message bytes.
+- **Ack payload:** tag `0x02`, 4-byte big-endian `msgno`.
+- **Keepalive payload:** tag `0x03`.
 
-Relay-control messages remain JSON today:
-
-- **Ack message:** `{ "type": "message", "session_id": "...", "data": { "ack": <number> } }`
-- **Keepalive message:** `{ "type": "message", "session_id": "...", "data": { "keepalive": true } }`
-
-This split keeps the authoritative game protocol in an efficient byte-oriented
-format. JSON is natively Unicode and is a poor fit for packing opaque protocol
-blobs without extra encoding. The current JSON control-plane pieces are a
-description of today's implementation, not a promise that future tracker formats
-will stay JSON; formats controlled by this project can move further toward
-binary over time.
+Peer app messages that are not WASM protocol bytes (`session_proposal`,
+`session_reject`, and `chat`) are bencodex dictionaries inside the same
+addressed peer-relay envelope. The tracker does not interpret either form; it
+only forwards the addressed payload.
 
 #### Outbound
 
@@ -630,64 +640,29 @@ Connected, keepalive timeout while WS is up → Inactive.
 
 **Peer indicator** is a boolean: any peer activity (data, ack, or keepalive)
 within the last 60 seconds (`PEER_LIVENESS_MS`) means Active, otherwise
-Inactive. The activity ref is updated by wrapped handlers in
-`registerMessageHandler`, ensuring it stays current even after
-`TrackerConnection.registerMessageHandler` replaces the initial callbacks.
+Inactive. The activity ref is updated by the `onPeerMessage` callback in
+`TrackerConnection`, ensuring it stays current across reconnects.
 
 **Action buttons**: Controls live with the state axis they affect. The tracker
 disconnect button lives in the Tracker tab header strip (right-aligned next to
-"Connected to {origin}"). The peer/pairing disconnect button lives in the Chat
-tab header. Go On-Chain lives in the Game tab session header. Disruptive
-tracker actions are gated by cascade confirmation dialogs; peer disconnect and
-explicit Go On-Chain currently do not prompt. See `CONNECTIVITY.md` for the full
-connectivity model.
+"Connected to {origin}"). Go On-Chain lives in the Game tab session header.
+Disruptive tracker actions are gated by cascade confirmation dialogs. See
+`CONNECTIVITY.md` for the full connectivity model.
 
 #### Reconnect
 
-When a player reconnects (`connection_status` received), and the peer is
-connected, the tracker sends `peer_reconnected` to the peer. Both sides call
-`resendUnacked()` to replay their un-acked messages. The ordering and
-deduplication logic on the receiving side handles any duplicates caused by the
-replay.
+When a player reconnects (receives `registered` from the tracker), and has an
+active session peer, it calls `resendUnacked()` to replay un-acked messages.
+The ordering and deduplication logic on the receiving side handles any
+duplicates caused by the replay.
 
 ### Reconnect Reconciliation
 
-The `onConnectionStatus` handler fires on every `identify` response from the
+The `onRegistered` handler fires on every `identify` response from the
 tracker — both on initial page load and on mid-session game channel reconnects.
-`Shell.tsx` uses an `activePairingTokenRef` to distinguish the two cases.
-
-#### Initial page load (`activePairingTokenRef` is null)
-
-On page reload, the client receives `connection_status` from the tracker and
-compares it against the local `SessionState`. There are five cases:
-
-| Tracker says | localStorage has | Action |
-|-------------|-----------------|--------|
-| `has_pairing: true, token: T` | Save with matching `pairingToken: T` | **Restore session.** |
-| `has_pairing: true, token: T` | No save at all | **Unrecognized pairing — request close.** |
-| `has_pairing: true, token: T` | Save with different `pairingToken: T2` | **Close unknown pairing and restore the saved session UI.** Peer remains inactive, so an off-chain restored session cascades on-chain. |
-| `has_pairing: false` | Full save exists | **Restore the saved session UI with no active peer.** If it is still off-chain, the peer-loss cascade calls `goOnChain()`. |
-| `has_pairing: false` | No save | **Idle — wait for new match.** |
-
-The reconciliation handler itself mostly restores local session state, requests
-close for unknown pairings, or marks the peer inactive. On-chain escalation is
-centralized in Shell's cascade rule: off-chain session + lost peer =
-`goOnChain()`. This same cascade is used when a `closed` event arrives
-mid-session.
-
-#### Mid-session reconnect (`activePairingTokenRef` is set)
-
-When the game channel reconnects during an active session, `connection_status` fires
-again. The handler checks whether the tracker still knows about the active
-pairing:
-
-| Tracker says | Action |
-|-------------|--------|
-| `has_pairing: true, token` matches `activePairingTokenRef` | **Continue.** Call `resendUnacked()` to replay un-acked messages. |
-| Any other state (no pairing, or different token) | **Keep local session active and mark peer inactive.** If the session is still off-chain, the peer-loss cascade calls `goOnChain()`. |
-
-The `activePairingTokenRef` is set in `startSession()` and cleared on session
-end or reset.
+On reconnect with an active session peer, the player app resends un-acked
+messages. The tracker has no concept of pairings or session state — reconnect
+reconciliation is purely a client-side concern based on local session saves.
 
 ### Static Asset Layers
 
@@ -1162,5 +1137,5 @@ protocol violations, not to limit concurrency.
 | `front-end/src/services/TrackerConnection.ts` | Game relay WebSocket client (`/ws/game`) |
 | `front-end/src/types/ChiaGaming.ts` | TypeScript types for WASM interface and game data |
 | `lobby/lobby-frontend/src/useLobbySocket.ts` | Lobby channel hook (`useLobbySocket`): lobby WebSocket join/challenge/alias messaging |
-| `lobby/lobby-service/src/index.ts` | Tracker server: lobby, challenges, pairing, message relay, liveness sweep |
-| `lobby/lobby-service/src/lobbyState.ts` | Tracker state: players, challenges, pairings |
+| `lobby/lobby-service/src/index.ts` | Tracker server: lobby, challenges, addressed message relay, liveness sweep |
+| `lobby/lobby-service/src/lobbyState.ts` | Tracker state: players, challenges |

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -21,6 +21,7 @@
     "@walletconnect/sign-client": "2.23.9",
     "@walletconnect/types": "2.23.9",
     "bech32": "^2.0.0",
+    "chia-gaming-bencodex": "file:../shared/bencodex",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "clvm-lib": "1.0.1",

--- a/front-end/pnpm-lock.yaml
+++ b/front-end/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
+      chia-gaming-bencodex:
+        specifier: file:../shared/bencodex
+        version: file:../shared/bencodex
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -1512,6 +1515,9 @@ packages:
 
   chia-bls@1.0.3:
     resolution: {integrity: sha512-RCxRjLZrBPRu1xo6i5USfsCbQ9RTIdF6/o349rWbZQP9sM6ksAezmuFSBDEM6LV1NOAOiSULOQJTRIQK5CX2Yw==}
+
+  chia-gaming-bencodex@file:../shared/bencodex:
+    resolution: {directory: ../shared/bencodex, type: directory}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -4360,6 +4366,8 @@ snapshots:
       chai: 4.5.0
       jssha: 3.3.1
       randombytes: 2.1.0
+
+  chia-gaming-bencodex@file:../shared/bencodex: {}
 
   chokidar@5.0.0:
     dependencies:

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -827,6 +827,7 @@ const Shell = () => {
       pendingAdvisoryRef.current === null &&
       pendingProposalRef.current === null &&
       sessionPeerIdRef.current === null &&
+      !sessionSaveRef.current?.sessionPeerId &&
       pendingMsgHandlerRef2.current === null;
   }, []);
 

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -838,6 +838,7 @@ const Shell = () => {
     pendingMsgHandlerRef2.current = null;
     peerMsgBufferRef.current = [];
     peerConnTargetRef.current = idlePeerConnection();
+    saveSession({ sessionPeerId: undefined });
     markPeerInactive();
   }, [markPeerInactive]);
 
@@ -883,6 +884,7 @@ const Shell = () => {
     }
     sessionPeerIdRef.current = request.peerId;
     peerConnTargetRef.current = buildTrackerPeerConnection(conn, request.peerId);
+    saveSession({ sessionPeerId: request.peerId });
     sessionStartedRef.current = false;
     sessionFinishedCleanupRef.current = false;
     sessionPhaseRef.current = 'none';
@@ -1076,92 +1078,6 @@ const Shell = () => {
     const lobbyUrl = `${origin}/?lobby=true&session=${trackerSessionId}&uniqueId=${uniqueId}`;
     setIframeUrl(lobbyUrl);
 
-    const startSession = (
-      conn: TrackerConnection,
-      iStarted: boolean,
-      amount: bigint,
-      perGame: bigint,
-      token: string,
-      save: SessionState | null,
-      myAlias?: string,
-      opponentAlias?: string,
-      channelTimeout?: bigint,
-      unrollTimeout?: bigint,
-    ) => {
-      console.log('[Shell] startSession: iStarted=%s amount=%s token=%s hasSave=%s channelTimeout=%s unrollTimeout=%s', iStarted, amount, token, !!save, channelTimeout, unrollTimeout);
-      sessionFinishedCleanupRef.current = false;
-      sessionPhaseRef.current = 'none';
-      activePairingTokenRef.current = token;
-      conn.setBusy(save ? sessionSaveStartsBusy(save) : true);
-
-      // Build PeerConnectionResult that sends addressed, reliability-framed messages
-      const peerId = sessionPeerIdRef.current!;
-      const buildFrame = (tag: number, msgno: number, data?: Uint8Array): Uint8Array => {
-        const len = 1 + 4 + (data?.byteLength ?? 0);
-        const frame = new Uint8Array(len);
-        const view = new DataView(frame.buffer);
-        frame[0] = tag;
-        view.setUint32(1, msgno, false);
-        if (data) frame.set(data, 5);
-        return frame;
-      };
-      peerConnTargetRef.current = {
-        sendMessage: (msgno: number, input: Uint8Array) => {
-          conn.sendToPeer(peerId, buildFrame(0x01, msgno, input));
-        },
-        sendAck: (ackMsgno: number) => {
-          conn.sendToPeer(peerId, buildFrame(0x02, ackMsgno));
-        },
-        sendKeepalive: () => {
-          conn.sendToPeer(peerId, new Uint8Array([0x03]));
-        },
-        hostLog: (_msg: string) => {},
-        close: () => {},
-      };
-      if (!save) {
-        setRestoreStatus('idle');
-        setRestoreError(null);
-        setRestoreTrackerReconciled(true);
-        setDashboardSessionModel(null);
-      } else {
-        setDashboardSessionModel(sessionModelFromSave(save, perGame));
-      }
-
-      const alreadyHydrated = !!sessionSaveRef.current;
-      if (!alreadyHydrated) {
-        sessionSaveRef.current = save;
-        const resolvedMyAlias = myAlias ?? save?.myAlias;
-        const resolvedOpponentAlias = opponentAlias ?? save?.opponentAlias;
-        setGameParams({
-          iStarted,
-          amount,
-          perGameAmount: perGame,
-          restoring: save !== null,
-          pairingToken: token,
-          myAlias: resolvedMyAlias,
-          opponentAlias: resolvedOpponentAlias,
-          channelTimeout,
-          unrollTimeout,
-        });
-        setPeerConn(stablePeerConn);
-        if (save) {
-          const savedHistory = humanHistoryFromSave(save);
-          const savedLog = diagnosticLogFromSave(save);
-          if (savedHistory) setHistory(savedHistory);
-          if (savedLog) setLogLines(savedLog);
-          if (save.chatMessages) setChatMessages(save.chatMessages);
-        } else {
-          destroyBlobSingleton();
-          clearSessionPreservingHistory();
-          setChatMessages([]);
-          setActiveTab('game');
-        }
-      } else {
-        console.log('[Shell] startSession: state already hydrated by handleResume, upgrading peer connection only');
-        setPeerConn(stablePeerConn);
-      }
-    };
-
     setTrackerLiveness('reconnecting');
 
     let conn: TrackerConnection;
@@ -1215,6 +1131,7 @@ const Shell = () => {
               return;
             }
             sessionPeerIdRef.current = fromId;
+            saveSession({ sessionPeerId: fromId });
             peerMsgBufferRef.current = [];
             setPendingProposalState({
               from_id: fromId,
@@ -1256,6 +1173,13 @@ const Shell = () => {
           lastTrackerActivityRef.current = Date.now();
           setTrackerLiveness('connected');
           console.log('[Shell] registered as player_id=%s', playerId);
+          // Restore peer relay for a resumed session
+          const save = sessionSaveRef.current;
+          if (!sessionPeerIdRef.current && save?.sessionPeerId && conn) {
+            sessionPeerIdRef.current = save.sessionPeerId;
+            peerConnTargetRef.current = buildTrackerPeerConnection(conn, save.sessionPeerId);
+            setRestoreTrackerReconciled(true);
+          }
           // On reconnect with an active session, re-send un-acked messages
           if (sessionPeerIdRef.current && blobSingleton) {
             blobSingleton.resendUnacked();

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -800,6 +800,7 @@ const Shell = () => {
   }, []);
 
   const markPeerInactive = useCallback(() => {
+    if (peerLivenessRef.current === 'dead') return;
     lastPeerActivityRef.current = 0;
     peerLivenessRef.current = null;
     setPeerLiveness(null);

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -1371,7 +1371,10 @@ const Shell = () => {
 
   const sendChat = useCallback((text: string) => {
     const myAlias = gameParams?.myAlias ?? 'You';
-    trackerConnRef.current?.sendPeerAppMessage(sessionPeerIdRef.current!, { type: 'chat', text, timestamp: BigInt(Date.now()) });
+    const peerId = sessionPeerIdRef.current;
+    if (peerId) {
+      trackerConnRef.current?.sendPeerAppMessage(peerId, { type: 'chat', text, timestamp: BigInt(Date.now()) });
+    }
     setChatMessages(prev => {
       const next = [...prev, { text, fromAlias: myAlias, timestamp: BigInt(Date.now()), isMine: true }];
       if (blobSingleton) { blobSingleton.chatMessages = next; blobSingleton.scheduleSave(); }

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -1100,6 +1100,7 @@ const Shell = () => {
           setActiveTab('game');
         },
         onPeerMessage: (fromId: string, _fromAlias: string, payload: Uint8Array) => {
+          if (peerLivenessRef.current === 'dead') return;
           markPeerActive();
           if (fromId !== sessionPeerIdRef.current) return;
           if (payload.length < 1) return;
@@ -1122,6 +1123,7 @@ const Shell = () => {
           }
         },
         onPeerAppMessage: (fromId: string, fromAlias: string, msg: PeerAppMessage) => {
+          if (peerLivenessRef.current === 'dead') return;
           markPeerActive();
           console.log('[Shell] onPeerAppMessage type=%s from=%s', msg.type, fromId);
           if (msg.type === 'session_proposal') {

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -790,10 +790,12 @@ const Shell = () => {
 
   const clearSessionPreservingHistory = useCallback(() => {
     const humanHistory = historyRef.current;
+    const peerId = sessionPeerIdRef.current;
     clearSession();
-    if (humanHistory.length > 0) {
-      saveSession({ humanHistory });
-    }
+    const preserved: Record<string, unknown> = {};
+    if (humanHistory.length > 0) preserved.humanHistory = humanHistory;
+    if (peerId) preserved.sessionPeerId = peerId;
+    if (Object.keys(preserved).length > 0) saveSession(preserved as any);
   }, []);
 
 

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -4,7 +4,7 @@ import GameSession from './GameSession';
 import { GameSessionErrorBoundary } from './GameSession';
 import { SimulatorSetupModal } from './SimulatorSetupModal';
 import QRCode from 'qrcode';
-import { GameSessionParams, PeerConnectionResult, ChatMessage, InternalBlockchainInterface, ConnectionSetup, TrackerLiveness, SessionPhase, CoinOfInterestEntry } from '../types/ChiaGaming';
+import { GameSessionParams, PeerConnectionResult, ChatMessage, InternalBlockchainInterface, ConnectionSetup, TrackerLiveness, SessionPhase, PeerLiveness, CoinOfInterestEntry } from '../types/ChiaGaming';
 import { TrackerConnection, AdvisoryStartParams, type PeerAppMessage } from '../services/TrackerConnection';
 import { subscribeLog } from '../services/log';
 import {
@@ -541,7 +541,7 @@ const Shell = () => {
 
   const [walletConnected, setWalletConnected] = useState(false);
   const [trackerLiveness, setTrackerLiveness] = useState<TrackerLiveness | null>(null);
-  const [peerConnected, setPeerConnected] = useState<boolean | null>(null);
+  const [peerLiveness, setPeerLiveness] = useState<PeerLiveness>(null);
   const [sessionPhase, setSessionPhase] = useState<SessionPhase>('none');
   const [sessionError, setSessionError] = useState(false);
   const [restoreStatus, setRestoreStatus] = useState<RestoreStatus>('idle');
@@ -757,6 +757,7 @@ const Shell = () => {
   const sessionSaveRef = useRef<SessionState | null>(null);
   const historyRef = useRef<string[]>(history);
   historyRef.current = history;
+  const peerLivenessRef = useRef<PeerLiveness>(null);
   const sessionStartedRef = useRef(false);
   const sessionFinishedCleanupRef = useRef(false);
   const sessionPhaseRef = useRef<SessionPhase>('none');
@@ -792,13 +793,21 @@ const Shell = () => {
 
 
   const markPeerActive = useCallback(() => {
+    if (peerLivenessRef.current === 'dead') return;
     lastPeerActivityRef.current = Date.now();
-    setPeerConnected(true);
+    peerLivenessRef.current = 'connected';
+    setPeerLiveness('connected');
   }, []);
 
   const markPeerInactive = useCallback(() => {
     lastPeerActivityRef.current = 0;
-    setPeerConnected(false);
+    peerLivenessRef.current = null;
+    setPeerLiveness(null);
+  }, []);
+
+  const markPeerDead = useCallback(() => {
+    peerLivenessRef.current = 'dead';
+    setPeerLiveness('dead');
   }, []);
 
   const registerMessageHandler = useCallback((handler: (msgno: number, msg: Uint8Array) => void, ackHandler: (ack: number) => void, keepaliveHandler: () => void) => {
@@ -973,8 +982,13 @@ const Shell = () => {
         if (!trackerWsUpRef.current) return 'reconnecting';
         return activityFresh ? 'connected' : 'inactive';
       });
-      const peerLive = lastPeerActivityRef.current > 0 && now - lastPeerActivityRef.current <= 60_000;
-      setPeerConnected(peerLive);
+      if (peerLivenessRef.current !== 'dead' && peerLivenessRef.current !== null) {
+        const stale = lastPeerActivityRef.current > 0 && now - lastPeerActivityRef.current > 30_000;
+        if (stale && peerLivenessRef.current === 'connected') {
+          peerLivenessRef.current = 'degraded';
+          setPeerLiveness('degraded');
+        }
+      }
     }, 5_000);
     return () => clearInterval(id);
   }, []);
@@ -1214,6 +1228,7 @@ const Shell = () => {
           } else if (msg.type === 'session_reject') {
             console.log('[Shell] session_reject from=%s sessionPeer=%s match=%s', fromId, sessionPeerIdRef.current, sessionPeerIdRef.current === fromId);
             if (sessionPeerIdRef.current === fromId) {
+              markPeerDead();
               cancelAttemptedSession();
             }
           } else if (msg.type === 'chat') {
@@ -1231,7 +1246,9 @@ const Shell = () => {
         onDeliveryFailure: (to: string) => {
           console.warn('[Shell] delivery_failure to=%s', to);
           if (to === sessionPeerIdRef.current) {
-            markPeerInactive();
+            if (peerLivenessRef.current === 'dead') return;
+            peerLivenessRef.current = 'degraded';
+            setPeerLiveness('degraded');
           }
         },
         onRegistered: (playerId: string) => {
@@ -1276,13 +1293,13 @@ const Shell = () => {
   }, [uniqueId, markPeerActive, markPeerInactive, cancelAttemptedSession, clearSessionPreservingHistory, isAvailableForNewSessionPrompt, sendSessionReject, setPendingAdvisoryState, setPendingProposalState]);
 
   const requestTrackerConnect = useCallback((origin: string) => {
-    if (peerConnected && sessionPhase === 'off-chain') {
+    if ((peerLiveness === 'connected' || peerLiveness === 'degraded') && sessionPhase === 'off-chain') {
       setConfirmDialog({
         title: 'Disconnect from tracker?',
         body: 'Disconnecting from this tracker will end your peer connection. Your game stays off-chain — resolve it on-chain from the dashboard if needed.',
         onConfirm: () => { setConfirmDialog(null); connectToTracker(origin, { resetSession: true }); },
       });
-    } else if (peerConnected) {
+    } else if (peerLiveness === 'connected' || peerLiveness === 'degraded') {
       setConfirmDialog({
         title: 'Disconnect from tracker?',
         body: 'This will end your peer connection.',
@@ -1291,7 +1308,7 @@ const Shell = () => {
     } else {
       connectToTracker(origin, { resetSession: true });
     }
-  }, [peerConnected, sessionPhase, connectToTracker]);
+  }, [peerLiveness, sessionPhase, connectToTracker]);
 
   // Auto-connect to saved tracker once this tab owns the app lease. Tracker
   // identity is independent of wallet restore, so do not gate this on userReady.
@@ -1672,13 +1689,13 @@ const Shell = () => {
   }, [markPeerInactive]);
 
   const handleDisconnectTracker = useCallback(() => {
-    if (peerConnected && sessionPhase === 'off-chain') {
+    if ((peerLiveness === 'connected' || peerLiveness === 'degraded') && sessionPhase === 'off-chain') {
       setConfirmDialog({
         title: 'Disconnect from tracker?',
         body: 'Disconnecting from this tracker will end your peer connection. Your game stays off-chain — resolve it on-chain from the dashboard if needed.',
         onConfirm: () => { setConfirmDialog(null); doDisconnectTracker(); },
       });
-    } else if (peerConnected) {
+    } else if (peerLiveness === 'connected' || peerLiveness === 'degraded') {
       setConfirmDialog({
         title: 'Disconnect from tracker?',
         body: 'This will end your peer connection.',
@@ -1687,7 +1704,7 @@ const Shell = () => {
     } else {
       doDisconnectTracker();
     }
-  }, [peerConnected, sessionPhase, doDisconnectTracker]);
+  }, [peerLiveness, sessionPhase, doDisconnectTracker]);
 
   const handleEndPeerConnection = useCallback(() => {
     resetPeerRelayState();
@@ -1742,12 +1759,13 @@ const Shell = () => {
     sessionPhaseRef.current = 'on-chain';
     setSessionPhase('on-chain');
     trackerConnRef.current?.setBusy(false);
+    markPeerDead();
     resetPeerRelayState();
     setDashboardSessionModel(prev => prev
       ? { ...prev, channel: { ...prev.channel, goOnChainPressed: true } }
       : prev
     );
-  }, [resetPeerRelayState]);
+  }, [markPeerDead, resetPeerRelayState]);
 
   const requestDashboardGoOnChain = useCallback(() => {
     const channelState = dashboardSessionModel?.channel.status.state;
@@ -2003,18 +2021,20 @@ const Shell = () => {
                 dotColor = 'var(--color-canvas-text-subtle)';
               } else if (sessionError) {
                 dotColor = 'var(--color-alert-solid)';
-              } else if (sessionPhase === 'on-chain') {
-                dotColor = 'var(--color-warning-solid)';
-              } else if (sessionPhase === 'off-chain' && !peerConnected) {
+              } else if (peerLiveness === 'dead') {
                 dotColor = 'var(--color-alert-solid)';
-              } else if (sessionPhase === 'off-chain' && peerConnected) {
+              } else if (sessionPhase === 'on-chain' || peerLiveness === 'degraded') {
+                dotColor = 'var(--color-warning-solid)';
+              } else if (peerLiveness === 'connected') {
                 dotColor = 'var(--color-success-solid)';
               } else {
                 dotColor = 'var(--color-canvas-text-subtle)';
               }
               break;
             case 'chat':
-              dotColor = peerConnected ? 'var(--color-success-solid)' : 'var(--color-canvas-text-subtle)';
+              dotColor = peerLiveness === 'connected'
+                ? 'var(--color-success-solid)'
+                : 'var(--color-canvas-text-subtle)';
               break;
           }
 
@@ -2365,7 +2385,7 @@ const Shell = () => {
             messages={chatMessages}
             onSend={sendChat}
             myAlias={gameParams?.myAlias ?? 'You'}
-            peerConnected={!!peerConnected}
+            peerConnected={peerLiveness === 'connected'}
             onEndPeer={handleEndPeerConnection}
             opponentAlias={gameParams?.opponentAlias}
           />

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -5,7 +5,7 @@ import { GameSessionErrorBoundary } from './GameSession';
 import { SimulatorSetupModal } from './SimulatorSetupModal';
 import QRCode from 'qrcode';
 import { GameSessionParams, PeerConnectionResult, ChatMessage, InternalBlockchainInterface, ConnectionSetup, TrackerLiveness, SessionPhase, CoinOfInterestEntry } from '../types/ChiaGaming';
-import { TrackerConnection, MatchedParams, ConnectionStatus } from '../services/TrackerConnection';
+import { TrackerConnection, AdvisoryStartParams, type PeerAppMessage } from '../services/TrackerConnection';
 import { subscribeLog } from '../services/log';
 import {
   getPlayerId,
@@ -39,6 +39,7 @@ import {
   claimLease,
   onFenced,
   offFenced,
+  getAlias,
 } from '../hooks/save';
 import { blobSingleton, destroyBlobSingleton } from '../hooks/blobSingleton';
 import { fakeBlockchainInfo } from '../hooks/FakeBlockchainInterface';
@@ -154,6 +155,71 @@ function sessionSaveStartsBusy(save: SessionState | null): boolean {
   if (!save?.serializedCradle && !save?.pairingToken) return false;
   const { perGameAmount } = sessionAmountsFromSave(save, FALLBACK_AMOUNT, FALLBACK_PER_GAME);
   return selectSessionPhase(sessionModelFromSave(save, perGameAmount)) !== 'resolved';
+}
+
+type PendingSessionProposal = {
+  from_id: string;
+  from_alias: string;
+  amount: string;
+  channel_timeout?: string;
+  unroll_timeout?: string;
+};
+
+type SessionStartRequest = {
+  peerId: string;
+  opponentAlias?: string;
+  amount: string;
+  channel_timeout?: string;
+  unroll_timeout?: string;
+  iStarted: boolean;
+  clearBufferedMessages: boolean;
+};
+
+function parseSessionAmount(raw: string): bigint {
+  try {
+    return BigInt(raw);
+  } catch {
+    return FALLBACK_AMOUNT;
+  }
+}
+
+function parseOptionalBigInt(raw: string | undefined): bigint | undefined {
+  if (!raw) return undefined;
+  try {
+    return BigInt(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function buildTrackerPeerConnection(conn: TrackerConnection, peerId: string): PeerConnectionResult {
+  const buildFrame = (tag: number, msgno: number, data?: Uint8Array): Uint8Array => {
+    const len = 1 + 4 + (data?.byteLength ?? 0);
+    const frame = new Uint8Array(len);
+    const view = new DataView(frame.buffer);
+    frame[0] = tag;
+    view.setUint32(1, msgno, false);
+    if (data) frame.set(data, 5);
+    return frame;
+  };
+
+  return {
+    sendMessage: (msgno: number, input: Uint8Array) => { conn.sendToPeer(peerId, buildFrame(0x01, msgno, input)); },
+    sendAck: (ackMsgno: number) => { conn.sendToPeer(peerId, buildFrame(0x02, ackMsgno)); },
+    sendKeepalive: () => { conn.sendToPeer(peerId, new Uint8Array([0x03])); },
+    hostLog: () => {},
+    close: () => {},
+  };
+}
+
+function idlePeerConnection(): PeerConnectionResult {
+  return {
+    sendMessage: () => {},
+    sendAck: () => {},
+    sendKeepalive: () => {},
+    hostLog: () => {},
+    close: () => {},
+  };
 }
 
 const TAB_DEFS: { id: TabId; label: string }[] = [
@@ -420,6 +486,23 @@ const Shell = () => {
   const [cleanShutdownGraceActive, setCleanShutdownGraceActive] = useState(false);
   const cleanShutdownGraceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Consent prompt state for the new tracker protocol
+  const [pendingAdvisory, setPendingAdvisory] = useState<AdvisoryStartParams | null>(null);
+  const pendingAdvisoryRef = useRef<AdvisoryStartParams | null>(null);
+  const setPendingAdvisoryState = useCallback((next: AdvisoryStartParams | null) => {
+    pendingAdvisoryRef.current = next;
+    setPendingAdvisory(next);
+  }, []);
+  const [pendingProposal, setPendingProposal] = useState<PendingSessionProposal | null>(null);
+  const pendingProposalRef = useRef<PendingSessionProposal | null>(null);
+  const setPendingProposalState = useCallback((next: PendingSessionProposal | null) => {
+    pendingProposalRef.current = next;
+    setPendingProposal(next);
+  }, []);
+  const sessionPeerIdRef = useRef<string | null>(null);
+  const pendingMsgHandlerRef2 = useRef<{ handler: (msgno: number, msg: Uint8Array) => void; ackHandler: (ack: number) => void; keepaliveHandler: () => void } | null>(null);
+  const peerMsgBufferRef = useRef<Array<{ tag: number; msgno: number; data: Uint8Array }>>([]);
+
   // The dashboard pulls the protocol-state pretty-print on demand (when its
   // detail view is expanded) rather than having it pushed on every change. The
   // live session registers a getter here; the dashboard reads through it.
@@ -672,6 +755,8 @@ const Shell = () => {
   const activeTabRef = useRef<TabId>(activeTab);
   activeTabRef.current = activeTab;
   const sessionSaveRef = useRef<SessionState | null>(null);
+  const historyRef = useRef<string[]>(history);
+  historyRef.current = history;
   const sessionStartedRef = useRef(false);
   const sessionFinishedCleanupRef = useRef(false);
   const sessionPhaseRef = useRef<SessionPhase>('none');
@@ -689,17 +774,22 @@ const Shell = () => {
     deferStateUpdate(() => {
       setHistory(prev => {
         const next = [...prev, line];
+        historyRef.current = next;
         saveSession({ humanHistory: next });
         return next;
       });
     });
   }, [deferStateUpdate]);
 
-  const pendingMsgHandlerRef = useRef<{
-    handler: (msgno: number, msg: Uint8Array) => void;
-    ackHandler: (ack: number) => void;
-    keepaliveHandler: () => void;
-  } | null>(null);
+  const clearSessionPreservingHistory = useCallback(() => {
+    const humanHistory = historyRef.current;
+    clearSession();
+    if (humanHistory.length > 0) {
+      saveSession({ humanHistory });
+    }
+  }, []);
+
+
 
   const markPeerActive = useCallback(() => {
     lastPeerActivityRef.current = Date.now();
@@ -712,15 +802,155 @@ const Shell = () => {
   }, []);
 
   const registerMessageHandler = useCallback((handler: (msgno: number, msg: Uint8Array) => void, ackHandler: (ack: number) => void, keepaliveHandler: () => void) => {
-    pendingMsgHandlerRef.current = { handler, ackHandler, keepaliveHandler };
-    if (trackerConnRef.current) {
-      trackerConnRef.current.registerMessageHandler(
-        (msgno, msg) => { markPeerActive(); handler(msgno, msg); },
-        (ack) => { markPeerActive(); ackHandler(ack); },
-        () => { markPeerActive(); keepaliveHandler(); },
-      );
+    pendingMsgHandlerRef2.current = { handler, ackHandler, keepaliveHandler };
+    const buffered = peerMsgBufferRef.current.splice(0);
+    for (const item of buffered) {
+      if (item.tag === 0x01) handler(item.msgno, item.data);
+      else if (item.tag === 0x02) ackHandler(item.msgno);
+      else if (item.tag === 0x03) keepaliveHandler();
     }
-  }, [markPeerActive]);
+  }, []);
+
+  const isAvailableForNewSessionPrompt = useCallback(() => {
+    const phase = sessionPhaseRef.current;
+    return (phase === 'none' || phase === 'resolved') &&
+      pendingAdvisoryRef.current === null &&
+      pendingProposalRef.current === null &&
+      sessionPeerIdRef.current === null &&
+      pendingMsgHandlerRef2.current === null;
+  }, []);
+
+  const sendSessionReject = useCallback((peerId: string) => {
+    trackerConnRef.current?.sendPeerAppMessage(peerId, { type: 'session_reject' });
+  }, []);
+
+  const resetPeerRelayState = useCallback(() => {
+    sessionPeerIdRef.current = null;
+    pendingMsgHandlerRef2.current = null;
+    peerMsgBufferRef.current = [];
+    peerConnTargetRef.current = idlePeerConnection();
+    markPeerInactive();
+  }, [markPeerInactive]);
+
+  const cancelAttemptedSession = useCallback(() => {
+    setPendingAdvisoryState(null);
+    setPendingProposalState(null);
+    resetPeerRelayState();
+    destroyBlobSingleton();
+    clearSessionPreservingHistory();
+    try { getActiveBlockchain().stop(); } catch { /* not connected */ }
+    sessionSaveRef.current = null;
+    activePairingTokenRef.current = null;
+    sessionStartedRef.current = false;
+    sessionFinishedCleanupRef.current = false;
+    sessionPhaseRef.current = 'none';
+    if (cleanShutdownGraceTimerRef.current !== null) {
+      clearTimeout(cleanShutdownGraceTimerRef.current);
+      cleanShutdownGraceTimerRef.current = null;
+    }
+    setCleanShutdownGraceActive(false);
+    setSessionPhase('none');
+    setSessionError(false);
+    setGameParams(null);
+    setPeerConn(null);
+    setDashboardSessionModel(null);
+    setRestoreStatus('idle');
+    setRestoreError(null);
+    setRestoreTrackerReconciled(false);
+    trackerConnRef.current?.setBusy(false);
+  }, [clearSessionPreservingHistory, resetPeerRelayState, setPendingAdvisoryState, setPendingProposalState]);
+
+  const startFreshSessionWithPeer = useCallback((request: SessionStartRequest) => {
+    const conn = trackerConnRef.current;
+    if (!conn) return;
+
+    const amount = parseSessionAmount(request.amount);
+    const perGame = amount / 10n || 1n;
+    const token = `peer_${request.peerId}_${Date.now()}`;
+
+    pendingMsgHandlerRef2.current = null;
+    if (request.clearBufferedMessages) {
+      peerMsgBufferRef.current = [];
+    }
+    sessionPeerIdRef.current = request.peerId;
+    peerConnTargetRef.current = buildTrackerPeerConnection(conn, request.peerId);
+    sessionStartedRef.current = false;
+    sessionFinishedCleanupRef.current = false;
+    sessionPhaseRef.current = 'none';
+    activePairingTokenRef.current = token;
+
+    setSessionPhase('none');
+    setSessionError(false);
+    setRestoreStatus('idle');
+    setRestoreError(null);
+    setRestoreTrackerReconciled(true);
+    setDashboardSessionModel(null);
+    destroyBlobSingleton();
+    clearSessionPreservingHistory();
+    try { getActiveBlockchain().start(); } catch { /* not connected */ }
+    setChatMessages([]);
+    setGameParams({
+      iStarted: request.iStarted,
+      amount,
+      perGameAmount: perGame,
+      restoring: false,
+      pairingToken: token,
+      myAlias: undefined,
+      opponentAlias: request.opponentAlias,
+      channelTimeout: parseOptionalBigInt(request.channel_timeout),
+      unrollTimeout: parseOptionalBigInt(request.unroll_timeout),
+    });
+    setPeerConn(stablePeerConn);
+    conn.setBusy(true);
+  }, [clearSessionPreservingHistory, stablePeerConn]);
+
+  const acceptPendingAdvisory = useCallback((advisory: AdvisoryStartParams) => {
+    const conn = trackerConnRef.current;
+    if (!conn) return;
+    setPendingAdvisoryState(null);
+    conn.sendPeerAppMessage(advisory.peer_id, {
+      type: 'session_proposal',
+      amount: advisory.amount,
+      from_alias: getAlias(),
+      channel_timeout: advisory.channel_timeout,
+      unroll_timeout: advisory.unroll_timeout,
+    });
+    startFreshSessionWithPeer({
+      peerId: advisory.peer_id,
+      opponentAlias: advisory.peer_alias,
+      amount: advisory.amount,
+      channel_timeout: advisory.channel_timeout,
+      unroll_timeout: advisory.unroll_timeout,
+      iStarted: true,
+      clearBufferedMessages: true,
+    });
+  }, [setPendingAdvisoryState, startFreshSessionWithPeer]);
+
+  const declinePendingAdvisory = useCallback((advisory: AdvisoryStartParams) => {
+    setPendingAdvisoryState(null);
+    sendSessionReject(advisory.peer_id);
+    trackerConnRef.current?.setBusy(false);
+  }, [sendSessionReject, setPendingAdvisoryState]);
+
+  const acceptPendingProposal = useCallback((proposal: PendingSessionProposal) => {
+    setPendingProposalState(null);
+    startFreshSessionWithPeer({
+      peerId: proposal.from_id,
+      opponentAlias: proposal.from_alias,
+      amount: proposal.amount,
+      channel_timeout: proposal.channel_timeout,
+      unroll_timeout: proposal.unroll_timeout,
+      iStarted: false,
+      clearBufferedMessages: false,
+    });
+  }, [setPendingProposalState, startFreshSessionWithPeer]);
+
+  const declinePendingProposal = useCallback((proposal: PendingSessionProposal) => {
+    setPendingProposalState(null);
+    resetPeerRelayState();
+    sendSessionReject(proposal.from_id);
+    trackerConnRef.current?.setBusy(false);
+  }, [resetPeerRelayState, sendSessionReject, setPendingProposalState]);
 
   useEffect(() => {
     return subscribeLog((line) => {
@@ -849,7 +1079,31 @@ const Shell = () => {
       sessionPhaseRef.current = 'none';
       activePairingTokenRef.current = token;
       conn.setBusy(save ? sessionSaveStartsBusy(save) : true);
-      peerConnTargetRef.current = conn.getPeerConnection();
+
+      // Build PeerConnectionResult that sends addressed, reliability-framed messages
+      const peerId = sessionPeerIdRef.current!;
+      const buildFrame = (tag: number, msgno: number, data?: Uint8Array): Uint8Array => {
+        const len = 1 + 4 + (data?.byteLength ?? 0);
+        const frame = new Uint8Array(len);
+        const view = new DataView(frame.buffer);
+        frame[0] = tag;
+        view.setUint32(1, msgno, false);
+        if (data) frame.set(data, 5);
+        return frame;
+      };
+      peerConnTargetRef.current = {
+        sendMessage: (msgno: number, input: Uint8Array) => {
+          conn.sendToPeer(peerId, buildFrame(0x01, msgno, input));
+        },
+        sendAck: (ackMsgno: number) => {
+          conn.sendToPeer(peerId, buildFrame(0x02, ackMsgno));
+        },
+        sendKeepalive: () => {
+          conn.sendToPeer(peerId, new Uint8Array([0x03]));
+        },
+        hostLog: (_msg: string) => {},
+        close: () => {},
+      };
       if (!save) {
         setRestoreStatus('idle');
         setRestoreError(null);
@@ -884,8 +1138,7 @@ const Shell = () => {
           if (save.chatMessages) setChatMessages(save.chatMessages);
         } else {
           destroyBlobSingleton();
-          clearSession();
-          setHistory([]);
+          clearSessionPreservingHistory();
           setChatMessages([]);
           setActiveTab('game');
         }
@@ -900,114 +1153,101 @@ const Shell = () => {
     let conn: TrackerConnection;
     try {
       conn = new TrackerConnection(origin, trackerSessionId, {
-        onMatched: (matched: MatchedParams) => {
+        onAdvisoryStart: (params: AdvisoryStartParams) => {
           trackerWsUpRef.current = true;
           lastTrackerActivityRef.current = Date.now();
           setTrackerLiveness('connected');
-          markPeerActive();
-          let amount: bigint;
-          try { amount = BigInt(matched.amount); } catch { amount = FALLBACK_AMOUNT; }
-          const perGame = amount / 10n || 1n;
-          let channelTimeout: bigint | undefined;
-          let unrollTimeout: bigint | undefined;
-          try { if (matched.channel_timeout) channelTimeout = BigInt(matched.channel_timeout); } catch {}
-          try { if (matched.unroll_timeout) unrollTimeout = BigInt(matched.unroll_timeout); } catch {}
-          startSession(conn, matched.i_am_initiator, amount, perGame, matched.token, null, matched.my_alias, matched.peer_alias, channelTimeout, unrollTimeout);
-        },
-        onConnectionStatus: (status: ConnectionStatus) => {
-          console.log('[Shell] onConnectionStatus: has_pairing=%s token=%s peer_connected=%s activeToken=%s',
-            status.has_pairing, status.token ?? 'none', status.peer_connected, activePairingTokenRef.current ?? 'null');
-          trackerWsUpRef.current = true;
-          lastTrackerActivityRef.current = Date.now();
-          setTrackerLiveness('connected');
-          if (sessionSaveRef.current?.serializedCradle) {
-            setRestoreTrackerReconciled(true);
-          }
-          if (!status.has_pairing || status.peer_connected === false) {
-            markPeerInactive();
-          } else if (status.peer_connected === true) {
-            markPeerActive();
-          } else {
-            setPeerConnected(null);
-          }
-          if (activePairingTokenRef.current !== null) {
-            if (status.has_pairing && status.token === activePairingTokenRef.current) {
-              console.log('[Shell] mid-session reconnect: token matches, resending un-acked');
-              blobSingleton?.resendUnacked();
-            } else {
-              console.warn('[Shell] mid-session reconnect: pairing lost or mismatched, keeping local session active');
-              markPeerInactive();
-            }
+          console.log('[Shell] advisory_start: peer=%s alias=%s amount=%s', params.peer_id, params.peer_alias, params.amount);
+          if (!isAvailableForNewSessionPrompt()) {
+            console.log('[Shell] advisory_start declined: client unavailable for new session');
+            sendSessionReject(params.peer_id);
             return;
           }
-
-          const save = peekSession();
-          if (status.has_pairing && status.token) {
-            if (save && save.pairingToken === status.token) {
-              const { amount, perGameAmount: perGame } = sessionAmountsFromSave(save, FALLBACK_AMOUNT, FALLBACK_PER_GAME);
-              let chTimeout: bigint | undefined;
-              let unTimeout: bigint | undefined;
-              try { if (status.channel_timeout) chTimeout = BigInt(status.channel_timeout); } catch {}
-              try { if (status.unroll_timeout) unTimeout = BigInt(status.unroll_timeout); } catch {}
-              startSession(conn, status.i_am_initiator!, amount, perGame, status.token, save, status.my_alias, status.peer_alias, chTimeout, unTimeout);
-            } else if (!save) {
-              console.warn('[Shell] connection_status: unrecognized pairing, requesting close');
-              conn.close();
-              clearSession();
-            } else if (save.serializedCradle) {
-              console.warn('[Shell] connection_status: token mismatch (tracker=%s, save=%s), closing unknown pairing', status.token, save.pairingToken);
-              conn.close();
-              const { amount, perGameAmount: perGame } = sessionAmountsFromSave(save, FALLBACK_AMOUNT, FALLBACK_PER_GAME);
-              sessionSaveRef.current = save;
-              setGameParams({
-                iStarted: save.iStarted ?? false,
-                amount,
-                perGameAmount: perGame,
-                restoring: true,
-                pairingToken: save.pairingToken ?? '',
-                myAlias: save.myAlias,
-                opponentAlias: save.opponentAlias,
-              });
-              setPeerConn(conn.getPeerConnection());
-              const savedHistory = humanHistoryFromSave(save);
-              const savedLog = diagnosticLogFromSave(save);
-              if (savedHistory) setHistory(savedHistory);
-              if (savedLog) setLogLines(savedLog);
-              if (save.chatMessages) setChatMessages(save.chatMessages);
+          setPendingAdvisoryState(params);
+          trackerConnRef.current?.setBusy(true);
+          setActiveTab('game');
+        },
+        onPeerMessage: (fromId: string, _fromAlias: string, payload: Uint8Array) => {
+          markPeerActive();
+          if (fromId !== sessionPeerIdRef.current) return;
+          if (payload.length < 1) return;
+          const tag = payload[0];
+          const handler = pendingMsgHandlerRef2.current;
+          if (tag === 0x01 && payload.length >= 5) {
+            const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+            const msgno = view.getUint32(1, false);
+            const msg = payload.slice(5);
+            if (handler) handler.handler(msgno, msg);
+            else peerMsgBufferRef.current.push({ tag, msgno, data: msg });
+          } else if (tag === 0x02 && payload.length >= 5) {
+            const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+            const ack = view.getUint32(1, false);
+            if (handler) handler.ackHandler(ack);
+            else peerMsgBufferRef.current.push({ tag, msgno: ack, data: new Uint8Array(0) });
+          } else if (tag === 0x03) {
+            if (handler) handler.keepaliveHandler();
+            else peerMsgBufferRef.current.push({ tag, msgno: 0, data: new Uint8Array(0) });
+          }
+        },
+        onPeerAppMessage: (fromId: string, fromAlias: string, msg: PeerAppMessage) => {
+          markPeerActive();
+          console.log('[Shell] onPeerAppMessage type=%s from=%s', msg.type, fromId);
+          if (msg.type === 'session_proposal') {
+            const peerAlias = fromAlias || msg.from_alias || fromId;
+            console.log('[Shell] session_proposal from=%s alias=%s amount=%s', fromId, peerAlias, msg.amount);
+            if (!isAvailableForNewSessionPrompt()) {
+              console.log('[Shell] session_proposal declined: client unavailable for new session');
+              sendSessionReject(fromId);
+              return;
             }
-          } else {
-            if (save && save.serializedCradle) {
-              console.warn('[Shell] connection_status: no pairing but have full save, restoring session (peer gone; go on-chain manually to resolve)');
-              const { amount, perGameAmount: perGame } = sessionAmountsFromSave(save, FALLBACK_AMOUNT, FALLBACK_PER_GAME);
-              sessionSaveRef.current = save;
-              setGameParams({
-                iStarted: save.iStarted ?? false,
-                amount,
-                perGameAmount: perGame,
-                restoring: true,
-                pairingToken: save.pairingToken ?? '',
-                myAlias: save.myAlias,
-                opponentAlias: save.opponentAlias,
-              });
-              setPeerConn(conn.getPeerConnection());
-              const savedHistory = humanHistoryFromSave(save);
-              const savedLog = diagnosticLogFromSave(save);
-              if (savedHistory) setHistory(savedHistory);
-              if (savedLog) setLogLines(savedLog);
-              if (save.chatMessages) setChatMessages(save.chatMessages);
+            sessionPeerIdRef.current = fromId;
+            peerMsgBufferRef.current = [];
+            setPendingProposalState({
+              from_id: fromId,
+              from_alias: peerAlias,
+              amount: msg.amount,
+              channel_timeout: msg.channel_timeout,
+              unroll_timeout: msg.unroll_timeout,
+            });
+            trackerConnRef.current?.setBusy(true);
+            setActiveTab('game');
+          } else if (msg.type === 'session_reject') {
+            console.log('[Shell] session_reject from=%s sessionPeer=%s match=%s', fromId, sessionPeerIdRef.current, sessionPeerIdRef.current === fromId);
+            if (sessionPeerIdRef.current === fromId) {
+              cancelAttemptedSession();
+            }
+          } else if (msg.type === 'chat') {
+            const chatMsg: ChatMessage = { text: msg.text, fromAlias: fromAlias, timestamp: msg.timestamp ?? BigInt(Date.now()), isMine: false };
+            setChatMessages(prev => {
+              const next = [...prev, chatMsg];
+              if (blobSingleton) { blobSingleton.chatMessages = next; blobSingleton.scheduleSave(); }
+              return next;
+            });
+            if (activeTabRef.current !== 'chat') {
+              setUnreadChat(true);
             }
           }
         },
-        onPeerReconnected: () => {
-          markPeerActive();
-          blobSingleton?.resendUnacked();
+        onDeliveryFailure: (to: string) => {
+          console.warn('[Shell] delivery_failure to=%s', to);
+          if (to === sessionPeerIdRef.current) {
+            markPeerInactive();
+          }
         },
-        onDataMessage: (_msgno: number, _msg: Uint8Array) => { markPeerActive(); },
-        onAck: (_ack: number) => { markPeerActive(); },
-        onKeepalive: () => { markPeerActive(); },
-        onClosed: () => {
-          console.log('[Shell] peer pairing ended');
-          markPeerInactive();
+        onRegistered: (playerId: string) => {
+          trackerWsUpRef.current = true;
+          lastTrackerActivityRef.current = Date.now();
+          setTrackerLiveness('connected');
+          console.log('[Shell] registered as player_id=%s', playerId);
+          // On reconnect with an active session, re-send un-acked messages
+          if (sessionPeerIdRef.current && blobSingleton) {
+            blobSingleton.resendUnacked();
+          }
+        },
+        onLobbyAttention: () => {
+          if (activeTabRef.current !== 'tracker') {
+            setTrackerAlert(true);
+          }
         },
         onTrackerDisconnected: () => {
           console.log('[Shell] tracker disconnected');
@@ -1023,21 +1263,6 @@ const Shell = () => {
         onTrackerActivity: () => {
           lastTrackerActivityRef.current = Date.now();
         },
-        onChat: (msg: ChatMessage) => {
-          setChatMessages(prev => {
-            const next = [...prev, msg];
-            if (blobSingleton) { blobSingleton.chatMessages = next; blobSingleton.scheduleSave(); }
-            return next;
-          });
-          if (activeTabRef.current !== 'chat') {
-            setUnreadChat(true);
-          }
-        },
-        onLobbyAttention: () => {
-          if (activeTabRef.current !== 'tracker') {
-            setTrackerAlert(true);
-          }
-        },
       }, { initialBusy: sessionSaveStartsBusy(initialSave) });
     } catch (err) {
       console.error('[Shell] TrackerConnection failed for origin=%s', origin, err);
@@ -1048,16 +1273,7 @@ const Shell = () => {
     }
     trackerConnRef.current = conn;
 
-    if (pendingMsgHandlerRef.current) {
-      const { handler, ackHandler, keepaliveHandler } = pendingMsgHandlerRef.current;
-      conn.registerMessageHandler(
-        (msgno, msg) => { markPeerActive(); handler(msgno, msg); },
-        (ack) => { markPeerActive(); ackHandler(ack); },
-        () => { markPeerActive(); keepaliveHandler(); },
-      );
-    }
-
-  }, [uniqueId, markPeerActive, markPeerInactive]);
+  }, [uniqueId, markPeerActive, markPeerInactive, cancelAttemptedSession, clearSessionPreservingHistory, isAvailableForNewSessionPrompt, sendSessionReject, setPendingAdvisoryState, setPendingProposalState]);
 
   const requestTrackerConnect = useCallback((origin: string) => {
     if (peerConnected && sessionPhase === 'off-chain') {
@@ -1167,12 +1383,12 @@ const Shell = () => {
         }
       } else {
         setBlockchainType(undefined);
-        clearSession();
+        clearSessionPreservingHistory();
         setConnectionSetup(null);
         setConnecting(false);
       }
     }
-  }, [uniqueId, completeConnection, setConnecting]);
+  }, [uniqueId, clearSessionPreservingHistory, completeConnection, setConnecting]);
 
   const handleFinalize = useCallback(async () => {
     if (!connectionSetup || !blockchainType) return;
@@ -1204,15 +1420,15 @@ const Shell = () => {
     activeBlockchainRef.current = null;
     setConnectionSetup(null);
     setBlockchainType(undefined);
-    clearSession();
+    clearSessionPreservingHistory();
     setConnecting(false);
     setWalletConnected(false);
     setShowSimModal(false);
-  }, [blockchainType, stopBalancePolling]);
+  }, [blockchainType, clearSessionPreservingHistory, stopBalancePolling]);
 
   const sendChat = useCallback((text: string) => {
     const myAlias = gameParams?.myAlias ?? 'You';
-    trackerConnRef.current?.sendChat(text);
+    trackerConnRef.current?.sendPeerAppMessage(sessionPeerIdRef.current!, { type: 'chat', text, timestamp: BigInt(Date.now()) });
     setChatMessages(prev => {
       const next = [...prev, { text, fromAlias: myAlias, timestamp: BigInt(Date.now()), isMine: true }];
       if (blobSingleton) { blobSingleton.chatMessages = next; blobSingleton.scheduleSave(); }
@@ -1236,15 +1452,23 @@ const Shell = () => {
 
     if (phase !== 'resolved' || sessionFinishedCleanupRef.current) return;
 
-    console.log('[Shell] session resolved; marking not busy');
+    console.log('[Shell] session resolved; tearing down peer connection, stopping poller');
     sessionFinishedCleanupRef.current = true;
     trackerConnRef.current?.setBusy(false);
+    try { getActiveBlockchain().stop(); } catch { /* not connected */ }
+    stopBalancePolling();
     sessionSaveRef.current = null;
     activePairingTokenRef.current = null;
-    if (previousPhase !== 'on-chain' && !hasError) {
-      setActiveTab('tracker');
-    }
-  }, [setActiveTab]);
+    setPendingAdvisoryState(null);
+    setPendingProposalState(null);
+
+    // Tear down the peer connection so keepalives stop flowing and the message
+    // handler is cleared for a potential next session.  We do NOT destroy the
+    // blob singleton here — it's still needed to render the resolved game state.
+    resetPeerRelayState();
+
+    setActiveTab('tracker');
+  }, [stopBalancePolling, resetPeerRelayState, setPendingAdvisoryState, setPendingProposalState]);
 
   const handleRestoreStatusChange = useCallback((status: RestoreStatus, error: string | null) => {
     setRestoreStatus(status);
@@ -1466,9 +1690,9 @@ const Shell = () => {
   }, [peerConnected, sessionPhase, doDisconnectTracker]);
 
   const handleEndPeerConnection = useCallback(() => {
-    trackerConnRef.current?.close();
-    markPeerInactive();
-  }, [markPeerInactive]);
+    resetPeerRelayState();
+    trackerConnRef.current?.setBusy(false);
+  }, [resetPeerRelayState]);
 
   const startCleanShutdownGrace = useCallback(() => {
     if (cleanShutdownGraceTimerRef.current !== null) {
@@ -1482,10 +1706,10 @@ const Shell = () => {
   }, []);
 
   const cancelDashboardSession = useCallback(() => {
-    trackerConnRef.current?.close();
-    markPeerInactive();
+    resetPeerRelayState();
+    trackerConnRef.current?.setBusy(false);
     destroyBlobSingleton();
-    clearSession();
+    clearSessionPreservingHistory();
     sessionSaveRef.current = null;
     activePairingTokenRef.current = null;
     sessionStartedRef.current = false;
@@ -1499,11 +1723,10 @@ const Shell = () => {
     setRestoreStatus('idle');
     setRestoreError(null);
     setRestoreTrackerReconciled(false);
-    setHistory([]);
     setChatMessages([]);
     setActiveTab('tracker');
     trackerConnRef.current?.setBusy(false);
-  }, [markPeerInactive, setActiveTab]);
+  }, [clearSessionPreservingHistory, resetPeerRelayState, setActiveTab]);
 
   const requestDashboardCleanShutdown = useCallback(() => {
     startCleanShutdownGrace();
@@ -1518,13 +1741,13 @@ const Shell = () => {
     blobSingleton?.goOnChain();
     sessionPhaseRef.current = 'on-chain';
     setSessionPhase('on-chain');
-    trackerConnRef.current?.close();
-    markPeerInactive();
+    trackerConnRef.current?.setBusy(false);
+    resetPeerRelayState();
     setDashboardSessionModel(prev => prev
       ? { ...prev, channel: { ...prev.channel, goOnChainPressed: true } }
       : prev
     );
-  }, [markPeerInactive]);
+  }, [resetPeerRelayState]);
 
   const requestDashboardGoOnChain = useCallback(() => {
     const channelState = dashboardSessionModel?.channel.status.state;
@@ -1694,6 +1917,53 @@ const Shell = () => {
     cleanShutdownGraceActive,
   });
   const statusBarBalances = selectStatusBarBalances(dashboardSessionModel);
+  const sessionConsentOverlay = pendingAdvisory ? (
+    <div className='absolute inset-0 flex items-center justify-center bg-canvas-bg/80 backdrop-blur-sm z-50'>
+      <div className='bg-canvas-bg border border-canvas-border rounded-lg p-6 shadow-lg max-w-sm text-center'>
+        <h2 className='text-lg font-semibold text-canvas-text mb-2'>New Session</h2>
+        <p className='text-sm text-canvas-text mb-4'>
+          <strong>{pendingAdvisory.peer_alias}</strong> would like to play for <strong>{pendingAdvisory.amount}</strong> mojos.
+        </p>
+        <div className='flex gap-3 justify-center'>
+          <button
+            onClick={() => acceptPendingAdvisory(pendingAdvisory)}
+            className='px-4 py-2 rounded-md font-medium text-sm bg-primary-solid text-primary-on-primary hover:bg-primary-solid-hover transition-colors'
+          >
+            Accept
+          </button>
+          <button
+            onClick={() => declinePendingAdvisory(pendingAdvisory)}
+            className='px-4 py-2 rounded-md font-medium text-sm border border-canvas-border text-canvas-text hover:bg-canvas-bg-hover transition-colors'
+          >
+            Decline
+          </button>
+        </div>
+      </div>
+    </div>
+  ) : pendingProposal ? (
+    <div className='absolute inset-0 flex items-center justify-center bg-canvas-bg/80 backdrop-blur-sm z-50'>
+      <div className='bg-canvas-bg border border-canvas-border rounded-lg p-6 shadow-lg max-w-sm text-center'>
+        <h2 className='text-lg font-semibold text-canvas-text mb-2'>New Session</h2>
+        <p className='text-sm text-canvas-text mb-4'>
+          <strong>{pendingProposal.from_alias}</strong> is proposing a session for <strong>{pendingProposal.amount}</strong> mojos.
+        </p>
+        <div className='flex gap-3 justify-center'>
+          <button
+            onClick={() => acceptPendingProposal(pendingProposal)}
+            className='px-4 py-2 rounded-md font-medium text-sm bg-primary-solid text-primary-on-primary hover:bg-primary-solid-hover transition-colors'
+          >
+            Accept
+          </button>
+          <button
+            onClick={() => declinePendingProposal(pendingProposal)}
+            className='px-4 py-2 rounded-md font-medium text-sm border border-canvas-border text-canvas-text hover:bg-canvas-bg-hover transition-colors'
+          >
+            Decline
+          </button>
+        </div>
+      </div>
+    </div>
+  ) : null;
 
   // --- Main tabbed app ---
   return (
@@ -2054,30 +2324,36 @@ const Shell = () => {
                 </button>
               </div>
             ) : keepSession ? (
-              <GameSessionErrorBoundary>
-                <GameSession
-                  key={gameParams.pairingToken}
-                  params={gameParams}
-                  peerConn={peerConn}
-                  registerMessageHandler={registerMessageHandler}
-                  appendGameLog={appendHistory}
-                  sessionSave={sessionSaveForReactProps(sessionSaveRef.current)}
-                  onGameActivity={onGameActivity}
-                  onSessionPhaseChange={handleSessionPhaseChange}
-                  onRestoreStatusChange={handleRestoreStatusChange}
-                  onSessionModelChange={handleSessionModelChange}
-                  onProtocolStateProviderChange={handleProtocolStateProviderChange}
-                  onCoinsProviderChange={handleCoinsProviderChange}
-                  suppressPhaseReporting={restoreBlocked}
-                />
-              </GameSessionErrorBoundary>
+              <div className='relative w-full h-full'>
+                <GameSessionErrorBoundary>
+                  <GameSession
+                    key={gameParams.pairingToken}
+                    params={gameParams}
+                    peerConn={peerConn}
+                    registerMessageHandler={registerMessageHandler}
+                    appendGameLog={appendHistory}
+                    sessionSave={sessionSaveForReactProps(sessionSaveRef.current)}
+                    onGameActivity={onGameActivity}
+                    onSessionPhaseChange={handleSessionPhaseChange}
+                    onRestoreStatusChange={handleRestoreStatusChange}
+                    onSessionModelChange={handleSessionModelChange}
+                    onProtocolStateProviderChange={handleProtocolStateProviderChange}
+                    onCoinsProviderChange={handleCoinsProviderChange}
+                    suppressPhaseReporting={restoreBlocked}
+                  />
+                </GameSessionErrorBoundary>
+                {sessionConsentOverlay}
+              </div>
             ) : sessionCanMount ? (
               <div className='w-full h-full flex items-center justify-center text-canvas-solid'>
                 Restoring session...
               </div>
             ) : (
-              <div className='w-full h-full flex items-center justify-center text-canvas-solid'>
-                No active game session
+              <div className='relative w-full h-full'>
+                <div className='w-full h-full flex items-center justify-center text-canvas-solid'>
+                  No active game session
+                </div>
+                {sessionConsentOverlay}
               </div>
             )}
           </div>

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -1212,8 +1212,10 @@ const Shell = () => {
           }
         },
         onClosed: () => {
-          console.log('[Shell] peer pairing ended');
+          console.log('[Shell] tracker connection ended');
+          trackerWsUpRef.current = false;
           markPeerInactive();
+          setTrackerLiveness('disconnected');
         },
         onTrackerDisconnected: () => {
           console.log('[Shell] tracker disconnected');

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -1148,7 +1148,9 @@ const Shell = () => {
             console.log('[Shell] session_reject from=%s sessionPeer=%s match=%s', fromId, sessionPeerIdRef.current, sessionPeerIdRef.current === fromId);
             if (sessionPeerIdRef.current === fromId) {
               markPeerDead();
-              cancelAttemptedSession();
+              if (sessionPhaseRef.current === 'none') {
+                cancelAttemptedSession();
+              }
             }
           } else if (msg.type === 'chat') {
             const chatMsg: ChatMessage = { text: msg.text, fromAlias: fromAlias, timestamp: msg.timestamp ?? BigInt(Date.now()), isMine: false };

--- a/front-end/src/features/calPoker/components/CaliforniaPoker.tsx
+++ b/front-end/src/features/calPoker/components/CaliforniaPoker.tsx
@@ -226,6 +226,7 @@ const CaliforniaPoker: React.FC<CaliforniapokerProps> = ({
     }
     return `${label} ${verb}`;
   };
+  const possessive = (label: string) => label === 'You' ? 'Your' : `${label}'s`;
 
   const doHandleMakeMove = () => {
     if (gameState === GAME_STATES.SELECTING && cardSelections.length > 0) {
@@ -621,7 +622,7 @@ const CaliforniaPoker: React.FC<CaliforniapokerProps> = ({
                     ? resultLabel(opponentLabel, 'wins')
                     : timeoutByUs === false
                       ? `${opponentLabel} ${timeoutForfeited ? 'forfeited' : 'timed out'}`
-                      : `${opponentLabel}'s Hand`}
+                      : `${possessive(opponentLabel)} Hand`}
               </span>
             </div>
             <div className='flex items-center justify-center p-2'>
@@ -655,7 +656,7 @@ const CaliforniaPoker: React.FC<CaliforniapokerProps> = ({
                     ? `${myLabel} ${timeoutForfeited ? 'forfeited' : 'timed out'}`
                     : timeoutByUs === false
                       ? resultLabel(myLabel, 'wins')
-                      : `${myLabel}'s Hand`}
+                      : `${possessive(myLabel)} Hand`}
               </span>
             </div>
             <div className='flex items-center justify-center p-2'>

--- a/front-end/src/features/calPoker/components/CaliforniaPoker.tsx
+++ b/front-end/src/features/calPoker/components/CaliforniaPoker.tsx
@@ -220,6 +220,12 @@ const CaliforniaPoker: React.FC<CaliforniapokerProps> = ({
   const showFinalHeader = gameState === GAME_STATES.FINAL && !!winner && !showSwapAnimation;
   const opponentResultVerb = winner === 'tie' ? 'ties' : winner === 'ai' ? 'wins' : 'loses';
   const playerResultVerb = winner === 'tie' ? 'ties' : winner === 'player' ? 'wins' : 'loses';
+  const resultLabel = (label: string, verb: 'wins' | 'loses' | 'ties') => {
+    if (label === 'You') {
+      return `You ${verb === 'wins' ? 'win' : verb === 'loses' ? 'lose' : 'tie'}`;
+    }
+    return `${label} ${verb}`;
+  };
 
   const doHandleMakeMove = () => {
     if (gameState === GAME_STATES.SELECTING && cardSelections.length > 0) {
@@ -610,9 +616,9 @@ const CaliforniaPoker: React.FC<CaliforniapokerProps> = ({
             <div className='w-full h-8 flex items-center justify-center text-base font-semibold text-canvas-text'>
               <span className='truncate max-w-full'>
                 {showFinalHeader && opponentDisplayText
-                  ? `${opponentLabel} ${opponentResultVerb} (${opponentDisplayText})`
+                  ? `${resultLabel(opponentLabel, opponentResultVerb)} (${opponentDisplayText})`
                   : timeoutByUs === true
-                    ? `${opponentLabel} wins`
+                    ? resultLabel(opponentLabel, 'wins')
                     : timeoutByUs === false
                       ? `${opponentLabel} ${timeoutForfeited ? 'forfeited' : 'timed out'}`
                       : `${opponentLabel}'s Hand`}
@@ -644,11 +650,11 @@ const CaliforniaPoker: React.FC<CaliforniapokerProps> = ({
             <div className='w-full h-8 flex items-center justify-center text-base font-semibold text-canvas-text'>
               <span className='truncate max-w-full'>
                 {showFinalHeader && playerDisplayText
-                  ? `${myLabel} ${playerResultVerb} (${playerDisplayText})`
+                  ? `${resultLabel(myLabel, playerResultVerb)} (${playerDisplayText})`
                   : timeoutByUs === true
                     ? `${myLabel} ${timeoutForfeited ? 'forfeited' : 'timed out'}`
                     : timeoutByUs === false
-                      ? `${myLabel} wins`
+                      ? resultLabel(myLabel, 'wins')
                       : `${myLabel}'s Hand`}
               </span>
             </div>

--- a/front-end/src/hooks/save.ts
+++ b/front-end/src/hooks/save.ts
@@ -160,6 +160,7 @@ export interface SessionState {
   blockchainType?: BlockchainType;
   serializedCradle?: string;
   pairingToken?: string;
+  sessionPeerId?: string;
   messageNumber?: bigint;
   remoteNumber?: bigint;
   channelReady?: boolean;

--- a/front-end/src/lib/tests/bencodex.test.ts
+++ b/front-end/src/lib/tests/bencodex.test.ts
@@ -1,0 +1,55 @@
+import {
+  decode,
+  encode,
+  isDictionary,
+  type BencodexKey,
+  type BencodexValue,
+} from 'chia-gaming-bencodex';
+
+const ascii = new TextDecoder();
+
+function text(bytes: Uint8Array): string {
+  return ascii.decode(bytes);
+}
+
+function expectRoundTrip(value: BencodexValue, encoded: string): void {
+  const bytes = encode(value);
+  expect(text(bytes)).toBe(encoded);
+  expect(decode(bytes)).toEqual(value);
+}
+
+describe('local bencodex codec', () => {
+  it('encodes scalar values using the Rust crate wire forms', () => {
+    expectRoundTrip(null, 'n');
+    expectRoundTrip(true, 't');
+    expectRoundTrip(false, 'f');
+    expectRoundTrip(42n, 'i42e');
+    expectRoundTrip(-3n, 'i-3e');
+    expectRoundTrip('hello', 'u5:hello');
+  });
+
+  it('encodes byte arrays as byte strings', () => {
+    const bytes = new TextEncoder().encode('spam');
+    const encoded = encode(bytes);
+    expect(text(encoded)).toBe('4:spam');
+    expect(decode(encoded)).toEqual(bytes);
+  });
+
+  it('encodes lists and dictionaries with canonical dictionary ordering', () => {
+    expectRoundTrip([1n, 2n, 3n], 'li1ei2ei3ee');
+    expect(text(encode({ z: 1n, a: 2n }))).toBe('du1:ai2eu1:zi1ee');
+  });
+
+  it('sorts byte dictionary keys before text dictionary keys', () => {
+    const value = new Map<BencodexKey, BencodexValue>([
+      ['a', 2n],
+      [new TextEncoder().encode('z'), 1n],
+    ]);
+    const encoded = encode(value);
+    expect(text(encoded)).toBe('d1:zi1eu1:ai2ee');
+
+    const decoded = decode(encoded);
+    expect(isDictionary(decoded)).toBe(true);
+    expect((decoded as Map<BencodexKey, BencodexValue>).get('a')).toBe(2n);
+  });
+});

--- a/front-end/src/lib/tests/tracker_connection.test.ts
+++ b/front-end/src/lib/tests/tracker_connection.test.ts
@@ -1,8 +1,32 @@
+import {
+  decode as decodeBencodex,
+  encode as encodeBencodex,
+  isDictionary,
+  type BencodexValue,
+} from 'chia-gaming-bencodex';
+
 // ---------------------------------------------------------------------------
 // Mock WebSocket
 // ---------------------------------------------------------------------------
 
 type WSHandler = ((ev: any) => void) | null;
+
+function arrayBufferOf(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function toPlainObject(value: BencodexValue): unknown {
+  if (value instanceof Uint8Array) return value;
+  if (Array.isArray(value)) return value.map(toPlainObject);
+  if (isDictionary(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of value.entries()) {
+      out[typeof key === 'string' ? key : new TextDecoder().decode(key as Uint8Array)] = toPlainObject(item);
+    }
+    return out;
+  }
+  return value;
+}
 
 class MockWebSocket {
   static CONNECTING = 0;
@@ -20,6 +44,7 @@ class MockWebSocket {
   onerror: WSHandler = null;
   onclose: WSHandler = null;
   sentJson: unknown[] = [];
+  sentControl: unknown[] = [];
   sentBinary: Uint8Array[] = [];
   closed = false;
 
@@ -37,9 +62,12 @@ class MockWebSocket {
     if (typeof data === 'string') {
       this.sentJson.push(JSON.parse(data));
     } else if (data instanceof Uint8Array) {
-      this.sentBinary.push(data);
+      if (data[0] === 0x64) this.sentControl.push(toPlainObject(decodeBencodex(data) as BencodexValue));
+      else this.sentBinary.push(data);
     } else if (data instanceof ArrayBuffer) {
-      this.sentBinary.push(new Uint8Array(data));
+      const bytes = new Uint8Array(data);
+      if (bytes[0] === 0x64) this.sentControl.push(toPlainObject(decodeBencodex(bytes) as BencodexValue));
+      else this.sentBinary.push(bytes);
     }
   }
 
@@ -49,31 +77,23 @@ class MockWebSocket {
   }
 
   _fire(data: unknown) {
-    this.onmessage?.({ data: JSON.stringify(data) });
+    const bytes = encodeBencodex(data as BencodexValue);
+    this.onmessage?.({ data: arrayBufferOf(bytes) });
   }
 
-  _fireBinary(msgno: number, payload: Uint8Array) {
-    const frame = new ArrayBuffer(1 + 4 + payload.byteLength);
-    const bytes = new Uint8Array(frame);
+  _fireBinaryInbound(fromId: string, payload: Uint8Array, fromAlias?: string) {
+    // Inbound binary format: [4B from_id_len BE][from_id][4B from_alias_len BE][from_alias][payload]
+    const fromIdBuf = new TextEncoder().encode(fromId);
+    const aliasBuf = new TextEncoder().encode(fromAlias ?? fromId);
+    const frame = new ArrayBuffer(4 + fromIdBuf.byteLength + 4 + aliasBuf.byteLength + payload.byteLength);
     const view = new DataView(frame);
-    bytes[0] = 0x01;
-    view.setUint32(1, msgno, false);
-    bytes.set(payload, 5);
-    this.onmessage?.({ data: frame });
-  }
-
-  _fireAck(ackMsgno: number) {
-    const frame = new ArrayBuffer(1 + 4);
     const bytes = new Uint8Array(frame);
-    const view = new DataView(frame);
-    bytes[0] = 0x02;
-    view.setUint32(1, ackMsgno, false);
-    this.onmessage?.({ data: frame });
-  }
-
-  _fireKeepaliveBinary() {
-    const frame = new ArrayBuffer(1);
-    new Uint8Array(frame)[0] = 0x03;
+    let offset = 0;
+    view.setUint32(offset, fromIdBuf.byteLength, false); offset += 4;
+    bytes.set(fromIdBuf, offset); offset += fromIdBuf.byteLength;
+    view.setUint32(offset, aliasBuf.byteLength, false); offset += 4;
+    bytes.set(aliasBuf, offset); offset += aliasBuf.byteLength;
+    bytes.set(payload, offset);
     this.onmessage?.({ data: frame });
   }
 
@@ -97,8 +117,6 @@ const originalWebSocketDescriptor = Object.getOwnPropertyDescriptor(globalThis, 
 import {
   TrackerConnection,
   TrackerConnectionCallbacks,
-  MatchedParams,
-  ConnectionStatus,
 } from '../../services/TrackerConnection';
 
 let trackerDisconnectCount = 0;
@@ -121,20 +139,17 @@ afterAll(() => {
   }
 });
 
-function makeCallbacks(): TrackerConnectionCallbacks {
+function makeCallbacks(): TrackerConnectionCallbacks & Record<string, jest.Mock> {
   return {
-    onMatched: jest.fn(),
-    onConnectionStatus: jest.fn(),
-    onPeerReconnected: jest.fn(),
-    onDataMessage: jest.fn(),
-    onAck: jest.fn(),
-    onKeepalive: jest.fn(),
-    onClosed: jest.fn(),
+    onAdvisoryStart: jest.fn(),
+    onPeerMessage: jest.fn(),
+    onPeerAppMessage: jest.fn(),
+    onDeliveryFailure: jest.fn(),
+    onRegistered: jest.fn(),
+    onLobbyAttention: jest.fn(),
     onTrackerDisconnected: jest.fn(() => { trackerDisconnectCount++; }),
     onTrackerReconnected: jest.fn(),
     onTrackerActivity: jest.fn(),
-    onChat: jest.fn(),
-    onLobbyAttention: jest.fn(),
   };
 }
 
@@ -171,20 +186,20 @@ describe('connection setup', () => {
   it('sends identify with busy=false over ws on open', async () => {
     const cb = makeCallbacks();
     makeConnection('http://t', 's1', cb);
-    await Promise.resolve(); // flush microtasks
+    await Promise.resolve();
 
     const ws = MockWebSocket.instance!;
     expect(ws.url).toBe('ws://t/ws/game');
-    expect(ws.sentJson).toEqual([{ type: 'identify', session_id: 's1', busy: false }]);
+    expect(ws.sentControl).toEqual([{ type: 'identify', session_id: 's1', busy: false }]);
   });
 
   it('sends identify with initial busy=true over ws on open', async () => {
     const cb = makeCallbacks();
     makeConnection('http://t', 's1', cb, { initialBusy: true });
-    await Promise.resolve(); // flush microtasks
+    await Promise.resolve();
 
     const ws = MockWebSocket.instance!;
-    expect(ws.sentJson).toEqual([{ type: 'identify', session_id: 's1', busy: true }]);
+    expect(ws.sentControl).toEqual([{ type: 'identify', session_id: 's1', busy: true }]);
   });
 });
 
@@ -193,69 +208,42 @@ describe('connection setup', () => {
 // ---------------------------------------------------------------------------
 
 describe('event routing', () => {
-  it('routes matched to onMatched', async () => {
+  it('routes advisory_start to onAdvisoryStart', async () => {
     const cb = makeCallbacks();
     makeConnection('http://t', 's1', cb);
     await Promise.resolve();
 
-    const params: MatchedParams = {
-      token: 'tok',
+    MockWebSocket.instance!._fire({
+      type: 'advisory_start',
+      peer_id: 'p2',
+      peer_alias: 'Bob',
       amount: '100',
-      i_am_initiator: true,
-    };
-    MockWebSocket.instance!._fire({ type: 'matched', ...params });
-    expect(cb.onMatched).toHaveBeenCalledWith(params);
+    });
+    expect(cb.onAdvisoryStart).toHaveBeenCalledWith({
+      peer_id: 'p2',
+      peer_alias: 'Bob',
+      amount: '100',
+      channel_timeout: undefined,
+      unroll_timeout: undefined,
+    });
   });
 
-  it('routes connection_status to onConnectionStatus', async () => {
+  it('routes registered to onRegistered', async () => {
     const cb = makeCallbacks();
     makeConnection('http://t', 's1', cb);
     await Promise.resolve();
 
-    const status: ConnectionStatus = { has_pairing: true, token: 'tok', peer_connected: true };
-    MockWebSocket.instance!._fire({ type: 'connection_status', ...status });
-    expect(cb.onConnectionStatus).toHaveBeenCalledWith(status);
+    MockWebSocket.instance!._fire({ type: 'registered', player_id: 'p_abc' });
+    expect(cb.onRegistered).toHaveBeenCalledWith('p_abc');
   });
 
-  it('routes peer_reconnected to onPeerReconnected', async () => {
+  it('routes delivery_failure to onDeliveryFailure', async () => {
     const cb = makeCallbacks();
     makeConnection('http://t', 's1', cb);
     await Promise.resolve();
 
-    MockWebSocket.instance!._fire({ type: 'peer_reconnected' });
-    expect(cb.onPeerReconnected).toHaveBeenCalled();
-  });
-
-  it('routes closed to onClosed', async () => {
-    const cb = makeCallbacks();
-    makeConnection('http://t', 's1', cb);
-    await Promise.resolve();
-
-    MockWebSocket.instance!._fire({ type: 'closed' });
-    expect(cb.onClosed).toHaveBeenCalled();
-  });
-
-  it('sends close immediately when the websocket is open', async () => {
-    const cb = makeCallbacks();
-    const conn = makeConnection('http://t', 's1', cb);
-    await Promise.resolve();
-
-    conn.close();
-
-    expect(MockWebSocket.instance!.sentJson).toContainEqual({ type: 'close', session_id: 's1' });
-  });
-
-  it('sends a pending close after the websocket opens', async () => {
-    const cb = makeCallbacks();
-    const conn = makeConnection('http://t', 's1', cb);
-
-    conn.close();
-    expect(MockWebSocket.instance!.sentJson).toEqual([]);
-
-    await Promise.resolve();
-
-    expect(MockWebSocket.instance!.sentJson).toContainEqual({ type: 'identify', session_id: 's1', busy: false });
-    expect(MockWebSocket.instance!.sentJson).toContainEqual({ type: 'close', session_id: 's1' });
+    MockWebSocket.instance!._fire({ type: 'delivery_failure', to: 'p_target' });
+    expect(cb.onDeliveryFailure).toHaveBeenCalledWith('p_target');
   });
 
   it('fires onTrackerDisconnected on ws error', async () => {
@@ -281,96 +269,39 @@ describe('event routing', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Message discrimination (keepalive vs ack vs data)
+// Binary message relay
 // ---------------------------------------------------------------------------
 
-describe('binary frame discrimination', () => {
-  it('routes keepalive binary frames to onKeepalive', async () => {
+describe('binary message relay', () => {
+  it('dispatches binary peer messages to onPeerMessage', async () => {
     const cb = makeCallbacks();
-    const conn = makeConnection('http://t', 's1', cb);
+    makeConnection('http://t', 's1', cb);
     await Promise.resolve();
-
-    conn.registerMessageHandler(jest.fn(), jest.fn(), jest.fn());
-    MockWebSocket.instance!._fireKeepaliveBinary();
-    expect(cb.onKeepalive).toHaveBeenCalled();
-    expect(cb.onDataMessage).not.toHaveBeenCalled();
-  });
-
-  it('routes ack binary frames to onAck', async () => {
-    const cb = makeCallbacks();
-    const conn = makeConnection('http://t', 's1', cb);
-    await Promise.resolve();
-
-    conn.registerMessageHandler(jest.fn(), jest.fn(), jest.fn());
-    MockWebSocket.instance!._fireAck(5);
-    expect((cb.onAck as jest.Mock)).toHaveBeenCalledWith(5);
-    expect(cb.onDataMessage).not.toHaveBeenCalled();
-  });
-
-  it('routes data binary frames to handler after registerMessageHandler', async () => {
-    const cb = makeCallbacks();
-    const conn = makeConnection('http://t', 's1', cb);
-    await Promise.resolve();
-
-    const handler = jest.fn();
-    conn.registerMessageHandler(handler, jest.fn(), jest.fn());
 
     const payload = new TextEncoder().encode('hello');
-    MockWebSocket.instance!._fireBinary(1, payload);
-    expect(handler).toHaveBeenCalledWith(1, payload);
+    MockWebSocket.instance!._fireBinaryInbound('p_sender', payload);
+    expect(cb.onPeerMessage).toHaveBeenCalledWith('p_sender', 'p_sender', payload);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Message buffering before registerMessageHandler
-// ---------------------------------------------------------------------------
-
-describe('message buffering before registerMessageHandler', () => {
-  it('buffers data messages then delivers them on registration', async () => {
+  it('dispatches bencodex peer app messages to onPeerAppMessage', async () => {
     const cb = makeCallbacks();
-    const conn = makeConnection('http://t', 's1', cb);
+    makeConnection('http://t', 's1', cb);
     await Promise.resolve();
 
-    const first = new TextEncoder().encode('first');
-    const second = new TextEncoder().encode('second');
-    MockWebSocket.instance!._fireBinary(1, first);
-    MockWebSocket.instance!._fireBinary(2, second);
-    expect(cb.onDataMessage).not.toHaveBeenCalled();
-
-    const handler = jest.fn();
-    conn.registerMessageHandler(handler, jest.fn(), jest.fn());
-
-    expect(handler).toHaveBeenCalledTimes(2);
-    expect(handler).toHaveBeenCalledWith(1, first);
-    expect(handler).toHaveBeenCalledWith(2, second);
+    const appMessage = { type: 'session_proposal', amount: '500' };
+    const payload = encodeBencodex(appMessage);
+    MockWebSocket.instance!._fireBinaryInbound('p_sender', payload);
+    expect(cb.onPeerAppMessage).toHaveBeenCalledWith('p_sender', 'p_sender', appMessage);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Close-pending suppresses messages
-// ---------------------------------------------------------------------------
-
-describe('close-pending suppresses messages', () => {
-  it('suppresses messages while close is pending, resumes after closed event', async () => {
+  it('passes distinct alias from binary frame header', async () => {
     const cb = makeCallbacks();
-    const conn = makeConnection('http://t', 's1', cb);
+    makeConnection('http://t', 's1', cb);
     await Promise.resolve();
 
-    const handler = jest.fn();
-    conn.registerMessageHandler(handler, jest.fn(), jest.fn());
-
-    conn.close();
-    expect(MockWebSocket.instance!.sentJson).toContainEqual({ type: 'close', session_id: 's1' });
-
-    MockWebSocket.instance!._fireBinary(1, new TextEncoder().encode('suppressed'));
-    expect(handler).not.toHaveBeenCalled();
-
-    MockWebSocket.instance!._fire({ type: 'closed' });
-    expect(cb.onClosed).toHaveBeenCalled();
-
-    const delivered = new TextEncoder().encode('delivered');
-    MockWebSocket.instance!._fireBinary(2, delivered);
-    expect(handler).toHaveBeenCalledWith(2, delivered);
+    const payload = new TextEncoder().encode('data');
+    MockWebSocket.instance!._fireBinaryInbound('p_sender', payload, 'Alice');
+    expect(cb.onPeerMessage).toHaveBeenCalledWith('p_sender', 'Alice', payload);
   });
 });
 
@@ -379,59 +310,58 @@ describe('close-pending suppresses messages', () => {
 // ---------------------------------------------------------------------------
 
 describe('outbound message format', () => {
-  it('sendMessage posts type-tagged binary frame', async () => {
+  it('sendToPeer posts addressed binary frame', async () => {
     const cb = makeCallbacks();
     const conn = makeConnection('http://t', 's1', cb);
     await Promise.resolve();
     const ws = MockWebSocket.instance!;
     ws.sentBinary = [];
+
     const payload = new TextEncoder().encode('payload');
-    conn.sendMessage(3, payload);
+    conn.sendToPeer('p_target', payload);
     expect(ws.sentBinary).toHaveLength(1);
+
     const frame = ws.sentBinary[0];
-    expect(frame[0]).toBe(0x01);
     const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
-    expect(view.getUint32(1, false)).toBe(3);
-    expect(new Uint8Array(frame.buffer, frame.byteOffset + 5)).toEqual(payload);
+    const targetIdLen = view.getUint32(0, false);
+    expect(targetIdLen).toBe(8); // 'p_target'.length
+    const targetId = new TextDecoder().decode(frame.slice(4, 4 + targetIdLen));
+    expect(targetId).toBe('p_target');
+    const data = frame.slice(4 + targetIdLen);
+    expect(data).toEqual(payload);
   });
 
-  it('sendAck posts ack as binary frame', async () => {
+  it('sendPeerAppMessage encodes bencodex as binary frame', async () => {
     const cb = makeCallbacks();
     const conn = makeConnection('http://t', 's1', cb);
     await Promise.resolve();
     const ws = MockWebSocket.instance!;
     ws.sentBinary = [];
-    conn.sendAck(5);
-    expect(ws.sentBinary).toHaveLength(1);
-    const frame = ws.sentBinary[0];
-    expect(frame[0]).toBe(0x02);
-    const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
-    expect(view.getUint32(1, false)).toBe(5);
-  });
 
-  it('sendKeepalive posts keepalive as binary frame', async () => {
-    const cb = makeCallbacks();
-    const conn = makeConnection('http://t', 's1', cb);
-    await Promise.resolve();
-    const ws = MockWebSocket.instance!;
-    ws.sentBinary = [];
-    conn.sendKeepalive();
+    conn.sendPeerAppMessage('p_target', { type: 'session_proposal', amount: '100' });
     expect(ws.sentBinary).toHaveLength(1);
-    expect(ws.sentBinary[0]).toEqual(new Uint8Array([0x03]));
+
+    const frame = ws.sentBinary[0];
+    const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
+    const targetIdLen = view.getUint32(0, false);
+    const targetId = new TextDecoder().decode(frame.slice(4, 4 + targetIdLen));
+    expect(targetId).toBe('p_target');
+    const payloadBytes = frame.slice(4 + targetIdLen);
+    const parsed = toPlainObject(decodeBencodex(payloadBytes) as BencodexValue);
+    expect(parsed).toEqual({ type: 'session_proposal', amount: '100' });
   });
 });
 
 // ---------------------------------------------------------------------------
-// forceDisconnect does not post close
+// forceDisconnect lifecycle
 // ---------------------------------------------------------------------------
 
 describe('forceDisconnect lifecycle', () => {
-  it('forceDisconnect does not post close', async () => {
+  it('forceDisconnect closes underlying ws', async () => {
     const cb = makeCallbacks();
     const conn = makeConnection('http://t', 's1', cb);
     await Promise.resolve();
     conn.forceDisconnect();
-    expect(MockWebSocket.instance!.sentJson.some((m) => (m as any).type === 'close')).toBe(false);
     expect(MockWebSocket.instance!.closed).toBe(true);
   });
 });
@@ -446,9 +376,9 @@ describe('setBusy', () => {
     const conn = makeConnection('http://t', 's1', cb);
     await Promise.resolve();
     const ws = MockWebSocket.instance!;
-    ws.sentJson = [];
+    ws.sentControl = [];
     conn.setBusy(false);
-    expect(ws.sentJson).toEqual([{ type: 'set_busy', session_id: 's1', busy: false }]);
+    expect(ws.sentControl).toEqual([{ type: 'set_busy', session_id: 's1', busy: false }]);
   });
 
   it('sends set_busy with busy=true', async () => {
@@ -456,9 +386,9 @@ describe('setBusy', () => {
     const conn = makeConnection('http://t', 's1', cb);
     await Promise.resolve();
     const ws = MockWebSocket.instance!;
-    ws.sentJson = [];
+    ws.sentControl = [];
     conn.setBusy(true);
-    expect(ws.sentJson).toEqual([{ type: 'set_busy', session_id: 's1', busy: true }]);
+    expect(ws.sentControl).toEqual([{ type: 'set_busy', session_id: 's1', busy: true }]);
   });
 
   it('includes busy=true in identify on reconnect', async () => {
@@ -476,7 +406,7 @@ describe('setBusy', () => {
 
     const ws2 = MockWebSocket.instance!;
     expect(ws2).not.toBe(ws1);
-    const identifyMsg = ws2.sentJson.find((m: any) => m.type === 'identify') as any;
+    const identifyMsg = ws2.sentControl.find((m: any) => m.type === 'identify') as any;
     expect(identifyMsg).toBeDefined();
     expect(identifyMsg.busy).toBe(true);
     jest.useRealTimers();
@@ -490,14 +420,5 @@ describe('setBusy', () => {
 describe('retry budget', () => {
   it('MAX_RECONNECT_ATTEMPTS is a positive number', () => {
     expect(TrackerConnection.MAX_RECONNECT_ATTEMPTS).toBeGreaterThan(0);
-  });
-
-  it('does not fire onClosed on a normal single close', async () => {
-    const cb = makeCallbacks();
-    expectedTrackerDisconnects = 1;
-    makeConnection('http://t', 's1', cb);
-    await Promise.resolve();
-    MockWebSocket.instance!._fireClose();
-    expect(cb.onClosed).not.toHaveBeenCalled();
   });
 });

--- a/front-end/src/services/TrackerConnection.ts
+++ b/front-end/src/services/TrackerConnection.ts
@@ -1,71 +1,134 @@
-import { PeerConnectionResult, ChatMessage } from '../types/ChiaGaming';
 import { log } from './log';
+import {
+  decode as decodeBencodex,
+  encode as encodeBencodex,
+  getText,
+  isDictionary,
+  type BencodexKey,
+  type BencodexValue,
+} from 'chia-gaming-bencodex';
 
-export interface MatchedParams {
-  token: string;
+export interface AdvisoryStartParams {
+  peer_id: string;
+  peer_alias: string;
   amount: string;
-  i_am_initiator: boolean;
-  my_alias?: string;
-  peer_alias?: string;
-  channel_timeout?: string;
-  unroll_timeout?: string;
-}
-
-export interface ConnectionStatus {
-  has_pairing: boolean;
-  token?: string;
-  amount?: string;
-  i_am_initiator?: boolean;
-  peer_connected?: boolean;
-  my_alias?: string;
-  peer_alias?: string;
   channel_timeout?: string;
   unroll_timeout?: string;
 }
 
 export interface TrackerConnectionCallbacks {
-  onMatched: (params: MatchedParams) => void;
-  onConnectionStatus: (status: ConnectionStatus) => void;
-  onPeerReconnected: () => void;
-  onDataMessage: (msgno: number, msg: Uint8Array) => void;
-  onAck: (ack: number) => void;
-  onKeepalive: () => void;
-  onClosed: () => void;
+  onAdvisoryStart: (params: AdvisoryStartParams) => void;
+  onPeerMessage: (from_id: string, from_alias: string, payload: Uint8Array) => void;
+  onPeerAppMessage: (from_id: string, from_alias: string, data: PeerAppMessage) => void;
+  onDeliveryFailure: (to: string) => void;
+  onRegistered: (player_id: string) => void;
+  onLobbyAttention: () => void;
   onTrackerDisconnected: () => void;
   onTrackerReconnected: () => void;
   onTrackerActivity: () => void;
-  onChat: (msg: ChatMessage) => void;
-  onLobbyAttention: () => void;
 }
 
 export interface TrackerConnectionOptions {
   initialBusy?: boolean;
 }
 
-// Binary frame type tags for peer-to-peer relay (opaque to the tracker).
-const FRAME_DATA = 0x01;
-const FRAME_ACK = 0x02;
-const FRAME_KEEPALIVE = 0x03;
-
 type TrackerEnvelope =
-  | { type: 'connection_status'; has_pairing: boolean; token?: string; amount?: string; i_am_initiator?: boolean; peer_connected?: boolean; my_alias?: string; peer_alias?: string; channel_timeout?: string; unroll_timeout?: string }
-  | { type: 'matched'; token: string; amount: string; i_am_initiator: boolean; my_alias?: string; peer_alias?: string; channel_timeout?: string; unroll_timeout?: string }
-  | { type: 'chat'; text: string; from_alias: string; timestamp: number }
-  | { type: 'peer_reconnected' }
+  | { type: 'advisory_start'; peer_id: string; peer_alias: string; amount: string; channel_timeout?: string; unroll_timeout?: string }
+  | { type: 'registered'; player_id: string }
+  | { type: 'delivery_failure'; to: string }
+  | { type: 'lobby_attention' }
   | { type: 'keepalive' }
-  | { type: 'closed' }
-  | { type: 'error'; error?: string }
-  | { type: 'lobby_attention' };
+  | { type: 'error'; error?: string };
+
+export type PeerAppMessage =
+  | { type: 'session_proposal'; amount: string; from_alias?: string; channel_timeout?: string; unroll_timeout?: string }
+  | { type: 'session_reject' }
+  | { type: 'chat'; text: string; timestamp?: bigint };
+
+function definedBencodexFields(data: Record<string, BencodexValue | undefined>): Record<string, BencodexValue> {
+  const out: Record<string, BencodexValue> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+function optionalText(map: Map<BencodexKey, BencodexValue>, key: string): string | undefined {
+  const value = map.get(key);
+  return typeof value === 'string' ? value : undefined;
+}
+
+function requireText(map: Map<BencodexKey, BencodexValue>, key: string): string {
+  const value = optionalText(map, key);
+  if (value === undefined) throw new Error(`missing text field: ${key}`);
+  return value;
+}
+
+function decodeTrackerEnvelope(input: ArrayBuffer): TrackerEnvelope | null {
+  const decoded = decodeBencodex(input);
+  if (!isDictionary(decoded)) return null;
+  const type = getText(decoded, 'type');
+  if (!type) return null;
+  switch (type) {
+    case 'advisory_start':
+      return {
+        type,
+        peer_id: requireText(decoded, 'peer_id'),
+        peer_alias: requireText(decoded, 'peer_alias'),
+        amount: requireText(decoded, 'amount'),
+        channel_timeout: optionalText(decoded, 'channel_timeout'),
+        unroll_timeout: optionalText(decoded, 'unroll_timeout'),
+      };
+    case 'registered':
+      return { type, player_id: requireText(decoded, 'player_id') };
+    case 'delivery_failure':
+      return { type, to: requireText(decoded, 'to') };
+    case 'lobby_attention':
+    case 'keepalive':
+      return { type };
+    case 'error':
+      return { type, error: optionalText(decoded, 'error') };
+    default:
+      return null;
+  }
+}
+
+function decodePeerAppMessage(payload: Uint8Array): PeerAppMessage | null {
+  const decoded = decodeBencodex(payload);
+  if (!isDictionary(decoded)) return null;
+  const type = getText(decoded, 'type');
+  if (!type) return null;
+  switch (type) {
+    case 'session_proposal':
+      return {
+        type,
+        amount: requireText(decoded, 'amount'),
+        from_alias: optionalText(decoded, 'from_alias'),
+        channel_timeout: optionalText(decoded, 'channel_timeout'),
+        unroll_timeout: optionalText(decoded, 'unroll_timeout'),
+      };
+    case 'session_reject':
+      return { type };
+    case 'chat': {
+      const text = requireText(decoded, 'text');
+      const rawTimestamp = decoded.get('timestamp');
+      return {
+        type,
+        text,
+        timestamp: typeof rawTimestamp === 'bigint' ? rawTimestamp : undefined,
+      };
+    }
+    default:
+      return null;
+  }
+}
 
 export class TrackerConnection {
   private trackerUrl: string;
   private sessionId: string;
   private callbacks: TrackerConnectionCallbacks;
   private ws: WebSocket | null = null;
-  private binaryBuffer: ArrayBuffer[] = [];
-  private handlerRegistered = false;
   private closed = false;
-  private closePending = false;
   private wasDisconnected = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
@@ -73,6 +136,7 @@ export class TrackerConnection {
   static readonly MAX_RECONNECT_ATTEMPTS = 18;
   private reconnectAttempt = 0;
   private busy = false;
+  private myPlayerId: string | null = null;
 
   constructor(trackerUrl: string, sessionId: string, callbacks: TrackerConnectionCallbacks, options: TrackerConnectionOptions = {}) {
     this.trackerUrl = trackerUrl;
@@ -94,7 +158,7 @@ export class TrackerConnection {
   private sendWs(payload: Record<string, unknown>): void {
     const ws = this.ws;
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send(JSON.stringify(payload));
+    ws.send(encodeBencodex(definedBencodexFields(payload as Record<string, BencodexValue | undefined>)));
   }
 
   private connectWs(): void {
@@ -122,9 +186,6 @@ export class TrackerConnection {
       this.ws = ws;
       this.reconnectAttempt = 0;
       this.sendWs({ type: 'identify', session_id: this.sessionId, busy: this.busy });
-      if (this.closePending) {
-        this.sendCloseRequest();
-      }
       if (this.wasDisconnected) {
         log('[tracker] reconnected to tracker');
         this.callbacks.onTrackerReconnected();
@@ -144,80 +205,17 @@ export class TrackerConnection {
       this.callbacks.onTrackerActivity();
 
       if (evt.data instanceof ArrayBuffer) {
-        if (this.closed || this.closePending) return;
-        if (!this.handlerRegistered) {
-          this.binaryBuffer.push(evt.data);
-          return;
+        if (this.closed) return;
+        const bytes = new Uint8Array(evt.data);
+        if (bytes[0] === 0x64) {
+          this.dispatchTrackerEnvelope(evt.data);
+        } else {
+          this.dispatchBinaryFrame(evt.data);
         }
-        this.dispatchBinaryFrame(evt.data);
         return;
       }
 
-      let msg: TrackerEnvelope | null = null;
-      try {
-        msg = JSON.parse(evt.data as string) as TrackerEnvelope;
-      } catch {
-        log('[tracker] recv malformed ws json');
-        return;
-      }
-      if (!msg || typeof msg !== 'object' || !('type' in msg)) {
-        log('[tracker] recv malformed ws envelope');
-        return;
-      }
-
-      switch (msg.type) {
-        case 'connection_status': {
-          const status: ConnectionStatus = {
-            has_pairing: msg.has_pairing,
-            token: msg.token,
-            amount: msg.amount,
-            i_am_initiator: msg.i_am_initiator,
-            peer_connected: msg.peer_connected,
-            my_alias: msg.my_alias,
-            peer_alias: msg.peer_alias,
-            channel_timeout: msg.channel_timeout,
-            unroll_timeout: msg.unroll_timeout,
-          };
-          log(`[tracker] connection_status has_pairing=${status.has_pairing} token=${status.token ?? 'none'} peer=${status.peer_connected ?? 'n/a'}`);
-          this.callbacks.onConnectionStatus(status);
-          break;
-        }
-        case 'matched': {
-          const params: MatchedParams = {
-            token: msg.token,
-            amount: msg.amount,
-            i_am_initiator: msg.i_am_initiator,
-            my_alias: msg.my_alias,
-            peer_alias: msg.peer_alias,
-            channel_timeout: msg.channel_timeout,
-            unroll_timeout: msg.unroll_timeout,
-          };
-          log(`[tracker] matched initiator=${params.i_am_initiator} amount=${params.amount}`);
-          this.callbacks.onMatched(params);
-          break;
-        }
-        case 'chat':
-          this.callbacks.onChat({ text: msg.text, fromAlias: msg.from_alias, timestamp: BigInt(msg.timestamp), isMine: false });
-          break;
-        case 'peer_reconnected':
-          log('[tracker] peer_reconnected');
-          this.callbacks.onPeerReconnected();
-          break;
-        case 'keepalive':
-          break;
-        case 'closed':
-          this.closePending = false;
-          this.callbacks.onClosed();
-          break;
-        case 'lobby_attention':
-          this.callbacks.onLobbyAttention();
-          break;
-        case 'error':
-          log(`[tracker] server error: ${msg.error ?? 'unknown'}`);
-          break;
-        default:
-          break;
-      }
+      log('[tracker] recv unexpected text ws frame');
     };
 
     ws.onerror = () => {
@@ -245,7 +243,6 @@ export class TrackerConnection {
         if (this.reconnectAttempt >= TrackerConnection.MAX_RECONNECT_ATTEMPTS) {
           log('[tracker] reconnect budget exhausted, declaring connection dead');
           this.closed = true;
-          this.callbacks.onClosed();
           return;
         }
         const base = TrackerConnection.RECONNECT_DELAYS[
@@ -262,56 +259,86 @@ export class TrackerConnection {
     };
   }
 
-  sendMessage(msgno: number, input: Uint8Array) {
-    log(`[tracker] send msgno=${msgno} len=${input.byteLength}`);
-    const ws = this.ws;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    const frame = new Uint8Array(1 + 4 + input.byteLength);
-    const view = new DataView(frame.buffer);
-    frame[0] = FRAME_DATA;
-    view.setUint32(1, msgno, false);
-    frame.set(input, 5);
-    ws.send(frame);
-  }
-
-  sendAck(ackMsgno: number) {
-    log(`[tracker] send ack=${ackMsgno}`);
-    const ws = this.ws;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    const frame = new Uint8Array(1 + 4);
-    const view = new DataView(frame.buffer);
-    frame[0] = FRAME_ACK;
-    view.setUint32(1, ackMsgno, false);
-    ws.send(frame);
-  }
-
-  sendKeepalive() {
-    const ws = this.ws;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send(new Uint8Array([FRAME_KEEPALIVE]));
-  }
-
-  hostLog(_msg: string) {
-    // no-op: server-side logging not supported over REST
-  }
-
-  sendChat(text: string) {
-    this.sendWs({ type: 'chat', session_id: this.sessionId, text });
-  }
-
-  close() {
-    if (this.closed) return;
-    if (this.closePending) {
-      this.sendCloseRequest();
+  private dispatchTrackerEnvelope(buf: ArrayBuffer): void {
+    let msg: TrackerEnvelope | null = null;
+    try {
+      msg = decodeTrackerEnvelope(buf);
+    } catch {
+      log('[tracker] recv malformed bencodex envelope');
       return;
     }
-    this.closePending = true;
-    log('[tracker] requesting close');
-    this.sendCloseRequest();
+    if (!msg || typeof msg !== 'object' || !('type' in msg)) {
+      log('[tracker] recv malformed ws envelope');
+      return;
+    }
+
+    switch (msg.type) {
+      case 'advisory_start': {
+        const params: AdvisoryStartParams = {
+          peer_id: msg.peer_id,
+          peer_alias: msg.peer_alias,
+          amount: msg.amount,
+          channel_timeout: msg.channel_timeout,
+          unroll_timeout: msg.unroll_timeout,
+        };
+        log(`[tracker] advisory_start peer=${params.peer_id} alias=${params.peer_alias} amount=${params.amount}`);
+        this.callbacks.onAdvisoryStart(params);
+        break;
+      }
+      case 'registered':
+        this.myPlayerId = msg.player_id;
+        log(`[tracker] registered as player_id=${msg.player_id}`);
+        this.callbacks.onRegistered(msg.player_id);
+        break;
+      case 'delivery_failure':
+        log(`[tracker] delivery_failure to=${msg.to}`);
+        this.callbacks.onDeliveryFailure(msg.to);
+        break;
+      case 'lobby_attention':
+        this.callbacks.onLobbyAttention();
+        break;
+      case 'keepalive':
+        break;
+      case 'error':
+        log(`[tracker] server error: ${msg.error ?? 'unknown'}`);
+        break;
+      default:
+        break;
+    }
   }
 
-  private sendCloseRequest() {
-    this.sendWs({ type: 'close', session_id: this.sessionId });
+  /**
+   * Send a binary payload to a specific peer through the tracker pipe.
+   * Wire format: [4-byte target_id_len BE][target_id UTF-8][payload]
+   */
+  sendToPeer(targetId: string, payload: Uint8Array): void {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    const targetBuf = new TextEncoder().encode(targetId);
+    const frame = new Uint8Array(4 + targetBuf.byteLength + payload.byteLength);
+    const view = new DataView(frame.buffer);
+    view.setUint32(0, targetBuf.byteLength, false);
+    frame.set(targetBuf, 4);
+    frame.set(payload, 4 + targetBuf.byteLength);
+    ws.send(frame);
+    log(`[tracker] send to=${targetId} len=${payload.byteLength}`);
+  }
+
+  /**
+   * Send a bencodex app message to a specific peer through the tracker pipe.
+   */
+  sendPeerAppMessage(targetId: string, data: PeerAppMessage): void {
+    const payload = encodeBencodex(definedBencodexFields(data as Record<string, BencodexValue | undefined>));
+    this.sendToPeer(targetId, payload);
+  }
+
+  getPlayerId(): string | null {
+    return this.myPlayerId;
+  }
+
+  setBusy(busy: boolean) {
+    this.busy = busy;
+    this.sendWs({ type: 'set_busy', session_id: this.sessionId, busy });
   }
 
   forceDisconnect() {
@@ -323,77 +350,6 @@ export class TrackerConnection {
     this.ws = null;
   }
 
-  getPeerConnection(): PeerConnectionResult {
-    return {
-      sendMessage: (msgno: number, input: Uint8Array) => this.sendMessage(msgno, input),
-      sendAck: (ackMsgno: number) => this.sendAck(ackMsgno),
-      sendKeepalive: () => this.sendKeepalive(),
-      hostLog: (msg: string) => this.hostLog(msg),
-      close: () => this.close(),
-    };
-  }
-
-  registerMessageHandler(
-    handler: (msgno: number, msg: Uint8Array) => void,
-    ackHandler: (ack: number) => void,
-    keepaliveHandler: () => void,
-  ) {
-    this.callbacks.onDataMessage = handler;
-    this.callbacks.onAck = ackHandler;
-    this.callbacks.onKeepalive = keepaliveHandler;
-    this.handlerRegistered = true;
-    const buffered = this.binaryBuffer;
-    this.binaryBuffer = [];
-    for (const frame of buffered) {
-      this.dispatchBinaryFrame(frame);
-    }
-  }
-
-  private dispatchBinaryFrame(buf: ArrayBuffer): void {
-    if (buf.byteLength < 1) {
-      log('[tracker] recv binary frame empty');
-      return;
-    }
-    const bytes = new Uint8Array(buf);
-    const tag = bytes[0];
-    switch (tag) {
-      case FRAME_DATA: {
-        if (buf.byteLength < 5) {
-          log('[tracker] recv data frame too short');
-          return;
-        }
-        const view = new DataView(buf);
-        const msgno = view.getUint32(1, false);
-        const msg = new Uint8Array(buf, 5);
-        log(`[tracker] recv msgno=${msgno} len=${msg.byteLength}`);
-        this.callbacks.onDataMessage(msgno, msg);
-        break;
-      }
-      case FRAME_ACK: {
-        if (buf.byteLength < 5) {
-          log('[tracker] recv ack frame too short');
-          return;
-        }
-        const view = new DataView(buf);
-        const ackMsgno = view.getUint32(1, false);
-        log(`[tracker] recv ack=${ackMsgno}`);
-        this.callbacks.onAck(ackMsgno);
-        break;
-      }
-      case FRAME_KEEPALIVE:
-        this.callbacks.onKeepalive();
-        break;
-      default:
-        log(`[tracker] recv unknown binary frame tag=${tag}`);
-        break;
-    }
-  }
-
-  setBusy(busy: boolean) {
-    this.busy = busy;
-    this.sendWs({ type: 'set_busy', session_id: this.sessionId, busy });
-  }
-
   disconnect() {
     this.closed = true;
     this.stopKeepaliveTimer();
@@ -403,6 +359,47 @@ export class TrackerConnection {
     }
     this.ws?.close();
     this.ws = null;
+  }
+
+  private dispatchBinaryFrame(buf: ArrayBuffer): void {
+    // Inbound binary: [4B from_id_len BE][from_id][4B from_alias_len BE][from_alias][payload]
+    if (buf.byteLength < 4) {
+      log('[tracker] recv binary frame too short');
+      return;
+    }
+    const view = new DataView(buf);
+    const fromIdLen = view.getUint32(0, false);
+    if (buf.byteLength < 4 + fromIdLen + 4) {
+      log('[tracker] recv binary frame header incomplete');
+      return;
+    }
+    const fromIdBytes = new Uint8Array(buf, 4, fromIdLen);
+    const fromId = new TextDecoder().decode(fromIdBytes);
+    const aliasOffset = 4 + fromIdLen;
+    const fromAliasLen = view.getUint32(aliasOffset, false);
+    const payloadStart = aliasOffset + 4 + fromAliasLen;
+    if (buf.byteLength < payloadStart) {
+      log('[tracker] recv binary frame alias header incomplete');
+      return;
+    }
+    const fromAliasBytes = new Uint8Array(buf, aliasOffset + 4, fromAliasLen);
+    const fromAlias = new TextDecoder().decode(fromAliasBytes);
+    const payload = new Uint8Array(buf, payloadStart);
+
+    if (payload.length > 0 && payload[0] === 0x64) {
+      try {
+        const data = decodePeerAppMessage(payload);
+        if (data) {
+          this.callbacks.onPeerAppMessage(fromId, fromAlias, data);
+          return;
+        }
+      } catch {
+        // Not a valid app message, fall through to raw peer protocol bytes.
+      }
+    }
+
+    log(`[tracker] recv from=${fromId} len=${payload.byteLength}`);
+    this.callbacks.onPeerMessage(fromId, fromAlias, payload);
   }
 
   private startKeepaliveTimer() {

--- a/front-end/src/services/TrackerConnection.ts
+++ b/front-end/src/services/TrackerConnection.ts
@@ -262,6 +262,7 @@ export class TrackerConnection {
         if (this.reconnectAttempt >= TrackerConnection.MAX_RECONNECT_ATTEMPTS) {
           log('[tracker] reconnect budget exhausted, declaring connection dead');
           this.closed = true;
+          this.callbacks.onClosed();
           return;
         }
         const base = TrackerConnection.RECONNECT_DELAYS[

--- a/front-end/src/types/ChiaGaming.ts
+++ b/front-end/src/types/ChiaGaming.ts
@@ -4,6 +4,8 @@ import { jsonStringify } from '../util/jsonSafe';
 
 export type TrackerLiveness = 'connected' | 'reconnecting' | 'inactive' | 'disconnected';
 
+export type PeerLiveness = 'connected' | 'degraded' | 'dead' | null;
+
 export type SessionPhase = 'none' | 'off-chain' | 'on-chain' | 'resolved';
 
 interface Amount {

--- a/lobby/lobby-frontend/src/useLobbySocket.ts
+++ b/lobby/lobby-frontend/src/useLobbySocket.ts
@@ -304,7 +304,14 @@ export function useLobbySocket(
 
     connect();
 
+    const onBeforeUnload = () => {
+      try { wsRef.current?.close(); } catch { /* ignore */ }
+      try { pendingWsRef.current?.close(); } catch { /* ignore */ }
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+
     return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
       closingRef.current = true;
       lobbyHsLog('connection_cleanup', {
         conn_id: connIdRef.current,

--- a/lobby/lobby-service/package.json
+++ b/lobby/lobby-service/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx,mjs,json}' '*.{ts,js,mjs,json}'"
   },
   "dependencies": {
+    "chia-gaming-bencodex": "file:../../shared/bencodex",
     "cors": "2.8.5",
     "express": "5.1.0",
     "minimist": "1.2.8",

--- a/lobby/lobby-service/src/index.ts
+++ b/lobby/lobby-service/src/index.ts
@@ -754,6 +754,7 @@ function parseGameInbound(raw: Buffer): GameInboundMessage | null {
           type,
           session_id: requireText(decoded, 'session_id'),
           busy: getBoolean(decoded, 'busy'),
+          alias: optionalText(decoded, 'alias'),
         };
       case 'send':
         return { type, to: requireText(decoded, 'to') };
@@ -764,8 +765,11 @@ function parseGameInbound(raw: Buffer): GameInboundMessage | null {
           type,
           session_id: requireText(decoded, 'session_id'),
           busy,
+          alias: optionalText(decoded, 'alias'),
         };
       }
+      case 'close':
+        return { type, session_id: requireText(decoded, 'session_id') };
       case 'keepalive':
         return { type };
       default:

--- a/lobby/lobby-service/src/index.ts
+++ b/lobby/lobby-service/src/index.ts
@@ -4,7 +4,16 @@ import crypto from 'node:crypto';
 import cors from 'cors';
 import express from 'express';
 import minimist from 'minimist';
-import { WebSocketServer, WebSocket } from 'ws';
+import {
+  decode as decodeBencodex,
+  encode as encodeBencodex,
+  getBoolean,
+  getText,
+  isDictionary,
+  type BencodexKey,
+  type BencodexValue,
+} from 'chia-gaming-bencodex';
+import { WebSocketServer, WebSocket, type RawData } from 'ws';
 
 import { Lobby } from './lobbyState';
 
@@ -38,8 +47,7 @@ type LobbyInboundMessage =
 
 type GameInboundMessage =
   | { type: 'identify'; session_id: string; busy?: boolean }
-  | { type: 'chat'; session_id: string; text: string }
-  | { type: 'close'; session_id: string }
+  | { type: 'send'; to: string }
   | { type: 'set_busy'; session_id: string; busy: boolean }
   | { type: 'keepalive' };
 
@@ -75,14 +83,14 @@ httpServer.on('upgrade', (req, socket, head) => {
 });
 
 const lobbyConnections = new Map<string, WebSocket>();
-const gameConnections = new Map<string, WebSocket>(); // keyed by session_id
+const gameConnections = new Map<string, WebSocket>();
 const wsLobbyMeta = new WeakMap<WebSocket, LobbyConnMeta>();
 const wsGameMeta = new WeakMap<WebSocket, GameConnMeta>();
 
 const pendingLobbyLeaves = new Map<string, ReturnType<typeof setTimeout>>();
 const sessionToPlayer = new Map<string, string>();
 const playerToSession = new Map<string, string>();
-const knownAliases = new Map<string, string>(); // keyed by secret session nonce
+const knownAliases = new Map<string, string>();
 const wsLastActivity = new WeakMap<WebSocket, number>();
 const wsIds = new WeakMap<WebSocket, number>();
 const wsKeepaliveTimers = new WeakMap<WebSocket, ReturnType<typeof setInterval>>();
@@ -131,8 +139,6 @@ app.use(
   }),
 );
 
-// Assets under /app/<nonce>/ are immutable (cache-busted by build nonce);
-// everything else (index.html, build-meta.json, favicon) uses no-store.
 app.use((req, res, next) => {
   res.set('Cache-Control',
     req.path.startsWith('/app/')
@@ -153,6 +159,39 @@ function sendWs(ws: WebSocket, type: string, payload: unknown): void {
   }
   ws.send(JSON.stringify({ type, ...((payload as Record<string, unknown>) ?? {}) }));
   logTrackerVerbose('send_ws_ok', { ws_id: wsId(ws), type });
+}
+
+function definedBencodexFields(payload: unknown): Record<string, BencodexValue> {
+  const out: Record<string, BencodexValue> = {};
+  if (!payload || typeof payload !== 'object') return out;
+  for (const [key, value] of Object.entries(payload as Record<string, unknown>)) {
+    if (value === undefined) continue;
+    if (
+      value === null ||
+      typeof value === 'boolean' ||
+      typeof value === 'bigint' ||
+      typeof value === 'string' ||
+      value instanceof Uint8Array
+    ) {
+      out[key] = value;
+      continue;
+    }
+    if (typeof value === 'number' && Number.isSafeInteger(value)) {
+      out[key] = BigInt(value);
+      continue;
+    }
+    throw new Error(`unsupported bencodex payload field ${key}`);
+  }
+  return out;
+}
+
+function sendGameWs(ws: WebSocket, type: string, payload: unknown): void {
+  if (ws.readyState !== WebSocket.OPEN) {
+    logTracker('send_game_ws_drop_not_open', { ws_id: wsId(ws), type, ready_state: ws.readyState });
+    return;
+  }
+  ws.send(encodeBencodex({ type, ...definedBencodexFields(payload) }));
+  logTrackerVerbose('send_game_ws_ok', { ws_id: wsId(ws), type });
 }
 
 function sendLobbyEvent(playerId: string, type: string, payload: unknown): void {
@@ -196,7 +235,16 @@ function sendGameEvent(playerId: string, type: string, payload: unknown): void {
     return;
   }
   logTrackerVerbose('send_game_event', { player_id: playerId, session_id: sessionId, ws_id: wsId(ws), type });
-  sendWs(ws, type, payload);
+  sendGameWs(ws, type, payload);
+}
+
+function sendGameBinary(playerId: string, data: Buffer): boolean {
+  const sessionId = playerToSession.get(playerId);
+  if (!sessionId) return false;
+  const ws = gameConnections.get(sessionId);
+  if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+  ws.send(data);
+  return true;
 }
 
 function broadcastLobbyUpdate(): void {
@@ -220,17 +268,6 @@ function leaveLobby(playerId: string): boolean {
     return true;
   }
   return false;
-}
-
-function computePeerConnected(playerId: string): boolean {
-  const peerId = lobby.getPairedPlayerId(playerId);
-  if (!peerId) return false;
-  const sessionId = playerToSession.get(peerId);
-  if (!sessionId) return false;
-  const ws = gameConnections.get(sessionId);
-  if (!ws || ws.readyState !== WebSocket.OPEN) return false;
-  const lastSeen = wsLastActivity.get(ws) ?? 0;
-  return Date.now() - lastSeen <= CONNECTION_TTL_MS;
 }
 
 function hasActiveGameConnection(playerId: string): boolean {
@@ -258,63 +295,14 @@ function cancelPlayerChallenges(playerId: string): void {
 }
 
 function applyPlayerBusy(playerId: string, busy: boolean): void {
-  const pairing = lobby.getPairingForPlayer(playerId);
-  const opponentAlias = pairing && busy
-    ? aliasForPlayer(pairing.playerA_id === playerId ? pairing.playerB_id : pairing.playerA_id)
-    : undefined;
-  const status = busy
-    ? (pairing ? 'playing' : 'busy')
-    : 'waiting';
-  lobby.setPlayerStatus(playerId, status, opponentAlias);
+  const status = busy ? 'busy' : 'waiting';
+  lobby.setPlayerStatus(playerId, status);
   if (busy) {
     cancelPlayerChallenges(playerId);
   }
 }
 
-function completeGameRegistration(playerId: string): void {
-  const sessionId = playerToSession.get(playerId);
-  const gameWs = sessionId ? gameConnections.get(sessionId) : undefined;
-  const gameMeta = gameWs ? wsGameMeta.get(gameWs) : undefined;
-  if (gameMeta?.busy !== undefined) {
-    applyPlayerBusy(playerId, gameMeta.busy);
-    broadcastLobbyUpdate();
-  }
-  const pairing = lobby.getPairingForPlayer(playerId);
-  if (pairing) {
-    const peerId = pairing.playerA_id === playerId ? pairing.playerB_id : pairing.playerA_id;
-    const peerSessionId = playerToSession.get(peerId);
-    const peerConn = peerSessionId ? gameConnections.get(peerSessionId) : undefined;
-    const myAlias = aliasForPlayer(playerId);
-    const peerAlias = aliasForPlayer(peerId);
-    const peerConnected = computePeerConnected(playerId) && !!peerConn;
-    logTracker('game_registration_status_pairing', {
-      player_id: playerId,
-      peer_id: peerId,
-      has_peer_conn: !!peerConn,
-      peer_connected: peerConnected,
-      token: pairing.token,
-    });
-    const statusPayload: Record<string, unknown> = {
-      has_pairing: true,
-      token: pairing.token,
-      amount: pairing.amount,
-      i_am_initiator: pairing.playerA_id === playerId,
-      peer_connected: peerConnected,
-      my_alias: myAlias,
-      peer_alias: peerAlias,
-    };
-    if (pairing.channel_timeout) statusPayload.channel_timeout = pairing.channel_timeout;
-    if (pairing.unroll_timeout) statusPayload.unroll_timeout = pairing.unroll_timeout;
-    sendGameEvent(playerId, 'connection_status', statusPayload);
-    if (peerConn) {
-      logTracker('game_registration_notify_peer_reconnected', { player_id: playerId, peer_id: peerId });
-      sendGameEvent(peerId, 'peer_reconnected', {});
-    }
-  } else {
-    logTracker('game_registration_status_no_pairing', { player_id: playerId });
-    sendGameEvent(playerId, 'connection_status', { has_pairing: false });
-  }
-}
+// --- Lobby channel handlers ---
 
 function onLobbyJoin(ws: WebSocket, msg: Extract<LobbyInboundMessage, { type: 'join' }>): void {
   const { alias, session_id } = msg;
@@ -350,11 +338,15 @@ function onLobbyJoin(ws: WebSocket, msg: Extract<LobbyInboundMessage, { type: 'j
   broadcastLobbyUpdate();
   replayPendingChallengesToPlayer(playerId);
 
+  // If the game channel was already identified, apply busy status
   const gameWs = gameConnections.get(session_id);
   if (gameWs) {
     const meta = wsGameMeta.get(gameWs);
     if (meta) meta.playerId = playerId;
-    completeGameRegistration(playerId);
+    if (meta?.busy !== undefined) {
+      applyPlayerBusy(playerId, meta.busy);
+      broadcastLobbyUpdate();
+    }
   }
 }
 
@@ -382,7 +374,6 @@ function onChallenge(ws: WebSocket, msg: Extract<LobbyInboundMessage, { type: 'c
   const fromPlayer = senderId ? lobby.players[senderId] : undefined;
   if (!fromPlayer) {
     logTracker('challenge_drop_unknown_sender', { sender_id: senderId ?? null, target_id });
-    console.warn('[tracker] challenge dropped: unknown sender', { senderId, target: target_id });
     sendWs(ws, 'error', { error: 'Unknown challenger. Rejoin lobby and retry.' });
     sendWs(ws, 'challenge_resolved', { challenge_id: null, accepted: false });
     return;
@@ -455,7 +446,6 @@ function onChallengeAccept(ws: WebSocket, msg: Extract<LobbyInboundMessage, { ty
       accepter_id: accepter_id ?? null,
       expected_target_id: challenge?.target_id ?? null,
     });
-    console.warn('[tracker] challenge_accept dropped: invalid accepter', { challenge_id, accepter_id });
     return;
   }
   const challenger = lobby.players[challenge.from_id];
@@ -488,55 +478,35 @@ function onChallengeAccept(ws: WebSocket, msg: Extract<LobbyInboundMessage, { ty
   }
 
   lobby.removeChallenge(challenge_id);
-  const pairing = lobby.createPairing(
-    challenge.from_id,
-    challenge.target_id,
-    challenge.amount,
-    challenge.channel_timeout,
-    challenge.unroll_timeout,
-  );
-  logTracker('pairing_created', {
+  // The clients are authoritative for busy state. The tracker only cleans up
+  // challenge records it knows are now stale.
+  cancelPlayerChallenges(challenge.target_id);
+  cancelPlayerChallenges(challenge.from_id);
+  broadcastLobbyUpdate();
+  logTracker('challenge_accepted_advisory', {
     challenge_id,
-    token: pairing.token,
-    challenger_id: challenge.from_id,
-    accepter_id: challenge.target_id,
+    initiator_id: challenge.from_id,
+    target_id: challenge.target_id,
     amount: challenge.amount,
-    channel_timeout: challenge.channel_timeout,
-    unroll_timeout: challenge.unroll_timeout,
   });
 
   const challengerAlias = lobby.players[challenge.from_id]?.alias ?? challenge.from_id;
-  const accepterAlias = lobby.players[challenge.target_id]?.alias ?? challenge.target_id;
 
-  lobby.setPlayerStatus(challenge.from_id, 'playing', accepterAlias);
-  lobby.setPlayerStatus(challenge.target_id, 'playing', challengerAlias);
-  cancelPlayerChallenges(challenge.from_id);
-  cancelPlayerChallenges(challenge.target_id);
-  broadcastLobbyUpdate();
-
+  // Notify the lobby of the challenger that the challenge was accepted
   sendLobbyEvent(challenge.from_id, 'challenge_resolved', {
     challenge_id,
     accepted: true,
   });
-  const matchedBase: Record<string, unknown> = {
-    token: pairing.token,
+
+  // Send advisory_start to the ACCEPTER (target) who becomes the initiator
+  const advisoryPayload: Record<string, unknown> = {
+    peer_id: challenge.from_id,
+    peer_alias: challengerAlias,
     amount: challenge.amount,
   };
-  if (pairing.channel_timeout) matchedBase.channel_timeout = pairing.channel_timeout;
-  if (pairing.unroll_timeout) matchedBase.unroll_timeout = pairing.unroll_timeout;
-
-  sendGameEvent(challenge.from_id, 'matched', {
-    ...matchedBase,
-    i_am_initiator: true,
-    my_alias: challengerAlias,
-    peer_alias: accepterAlias,
-  });
-  sendGameEvent(challenge.target_id, 'matched', {
-    ...matchedBase,
-    i_am_initiator: false,
-    my_alias: accepterAlias,
-    peer_alias: challengerAlias,
-  });
+  if (challenge.channel_timeout) advisoryPayload.channel_timeout = challenge.channel_timeout;
+  if (challenge.unroll_timeout) advisoryPayload.unroll_timeout = challenge.unroll_timeout;
+  sendGameEvent(challenge.target_id, 'advisory_start', advisoryPayload);
 }
 
 function onChallengeDecline(ws: WebSocket, msg: Extract<LobbyInboundMessage, { type: 'challenge_decline' }>): void {
@@ -558,7 +528,7 @@ function onChallengeDecline(ws: WebSocket, msg: Extract<LobbyInboundMessage, { t
   });
 }
 
-function onChallengeCancel(ws: WebSocket, msg: Extract<LobbyInboundMessage, { type: 'challenge_cancel' }>): void {
+function onChallengeCancel(ws: WebSocket, _msg: Extract<LobbyInboundMessage, { type: 'challenge_cancel' }>): void {
   const senderId = getLobbySenderId(ws);
   if (!senderId) return;
   const toCancel: string[] = [];
@@ -591,116 +561,6 @@ function onChangeAlias(ws: WebSocket, msg: Extract<LobbyInboundMessage, { type: 
   }
 }
 
-function onIdentify(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'identify' }>): void {
-  const playerId = ensureSession(msg.session_id);
-  logTracker('identify', {
-    ws_id: wsId(ws),
-    session_id: msg.session_id,
-    player_id: playerId,
-  });
-  const previousGameConn = gameConnections.get(msg.session_id);
-  if (previousGameConn && previousGameConn !== ws) {
-    logTracker('game_connection_replaced', { ws_id: wsId(previousGameConn), session_id: msg.session_id });
-    try { previousGameConn.close(4001, 'replaced_by_new_connection'); } catch {}
-  }
-  wsGameMeta.set(ws, { sessionId: msg.session_id, playerId, busy: msg.busy });
-  gameConnections.set(msg.session_id, ws);
-  logTracker('identify_complete_registration', { ws_id: wsId(ws), session_id: msg.session_id, player_id: playerId });
-  completeGameRegistration(playerId);
-}
-
-function onGameChat(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'chat' }>): void {
-  const meta = wsGameMeta.get(ws);
-  if (!meta) {
-    logTracker('game_chat_drop_unknown_session', { session_id: msg.session_id });
-    return;
-  }
-  const playerId = meta.playerId;
-  const peerId = lobby.getPairedPlayerId(playerId);
-  if (!peerId) {
-    logTracker('game_chat_drop_unpaired', { player_id: playerId, session_id: msg.session_id });
-    return;
-  }
-  const fromAlias = aliasForPlayer(playerId);
-  logTrackerVerbose('game_chat_relay', { from_player_id: playerId, to_player_id: peerId, session_id: msg.session_id });
-  sendGameEvent(peerId, 'chat', {
-    text: msg.text,
-    from_alias: fromAlias,
-    timestamp: Date.now(),
-  });
-}
-
-function onGameClose(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'close' }>): void {
-  const meta = wsGameMeta.get(ws);
-  if (!meta) {
-    logTracker('game_close_drop_unknown_session', { session_id: msg.session_id });
-    return;
-  }
-  const playerId = meta.playerId;
-  const peerId = lobby.getPairedPlayerId(playerId);
-  logTracker('game_close', { player_id: playerId, peer_id: peerId ?? null, session_id: msg.session_id });
-  if (peerId) sendGameEvent(peerId, 'closed', {});
-  sendGameEvent(playerId, 'closed', {});
-  const pairing = lobby.getPairingForPlayer(playerId);
-  if (pairing) {
-    lobby.setPlayerStatus(pairing.playerA_id, 'waiting');
-    lobby.setPlayerStatus(pairing.playerB_id, 'waiting');
-    lobby.removePairing(pairing.token);
-    broadcastLobbyUpdate();
-    logTracker('pairing_removed_on_close', { token: pairing.token, player_id: playerId, peer_id: peerId ?? null });
-  }
-}
-
-function onSetBusy(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'set_busy' }>): void {
-  const meta = wsGameMeta.get(ws);
-  if (!meta) {
-    logTracker('set_busy_drop_unknown_session', { session_id: msg.session_id });
-    return;
-  }
-  const playerId = meta.playerId;
-  meta.busy = msg.busy;
-  logTracker('set_busy', { player_id: playerId, busy: msg.busy });
-  applyPlayerBusy(playerId, msg.busy);
-  broadcastLobbyUpdate();
-}
-
-function parseLobbyInbound(raw: string): LobbyInboundMessage | null {
-  try {
-    const parsed = JSON.parse(raw) as LobbyInboundMessage;
-    if (!parsed || typeof parsed !== 'object' || !('type' in parsed)) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-function parseGameInbound(raw: string): GameInboundMessage | null {
-  try {
-    const parsed = JSON.parse(raw) as GameInboundMessage;
-    if (!parsed || typeof parsed !== 'object' || !('type' in parsed)) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-function setupKeepalive(ws: WebSocket): void {
-  const kaTimer = setInterval(() => {
-    if (ws.readyState === ws.OPEN) {
-      ws.send(JSON.stringify({ type: 'keepalive' }));
-    }
-  }, 15_000);
-  wsKeepaliveTimers.set(ws, kaTimer);
-}
-
-function clearKeepalive(ws: WebSocket): void {
-  const timer = wsKeepaliveTimers.get(ws);
-  if (timer) {
-    clearInterval(timer);
-    wsKeepaliveTimers.delete(ws);
-  }
-}
-
 function onGetAlias(ws: WebSocket, msg: Extract<LobbyInboundMessage, { type: 'get_alias' }>): void {
   const sessionId = msg.session_id;
   const alias = sessionId ? knownAliases.get(sessionId) ?? null : null;
@@ -722,11 +582,209 @@ function onSetAlias(ws: WebSocket, msg: Extract<LobbyInboundMessage, { type: 'se
   sendWs(ws, 'alias_result', { alias: msg.alias });
 }
 
+// --- Game channel handlers ---
+
+function onIdentify(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'identify' }>): void {
+  const playerId = ensureSession(msg.session_id);
+  logTracker('identify', {
+    ws_id: wsId(ws),
+    session_id: msg.session_id,
+    player_id: playerId,
+  });
+  const previousGameConn = gameConnections.get(msg.session_id);
+  if (previousGameConn && previousGameConn !== ws) {
+    logTracker('game_connection_replaced', { ws_id: wsId(previousGameConn), session_id: msg.session_id });
+    try { previousGameConn.close(4001, 'replaced_by_new_connection'); } catch {}
+  }
+  wsGameMeta.set(ws, { sessionId: msg.session_id, playerId, busy: msg.busy });
+  gameConnections.set(msg.session_id, ws);
+
+  // Apply busy status if lobby player exists
+  if (msg.busy !== undefined && lobby.players[playerId]) {
+    applyPlayerBusy(playerId, msg.busy);
+    broadcastLobbyUpdate();
+  }
+
+  sendGameWs(ws, 'registered', { player_id: playerId });
+  logTracker('identify_registered', { ws_id: wsId(ws), session_id: msg.session_id, player_id: playerId });
+}
+
+function onGameSend(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'send' }>, rawPayload: Buffer | null): void {
+  const meta = wsGameMeta.get(ws);
+  if (!meta?.playerId) {
+    logTracker('game_send_drop_no_player', { ws_id: wsId(ws) });
+    return;
+  }
+  const targetId = msg.to;
+  const targetSessionId = playerToSession.get(targetId);
+  const targetWs = targetSessionId ? gameConnections.get(targetSessionId) : undefined;
+
+  if (!targetWs || targetWs.readyState !== WebSocket.OPEN) {
+    logTracker('game_send_delivery_failure', { from: meta.playerId, to: targetId });
+    sendGameWs(ws, 'delivery_failure', { to: targetId });
+    return;
+  }
+
+  const fromAlias = aliasForPlayer(meta.playerId);
+
+  if (rawPayload) {
+    // Binary payload: [4B from_id_len BE][from_id][4B from_alias_len BE][from_alias][payload]
+    const fromIdBuf = Buffer.from(meta.playerId, 'utf8');
+    const fromAliasBuf = Buffer.from(fromAlias, 'utf8');
+    const header = Buffer.alloc(4 + fromIdBuf.byteLength + 4 + fromAliasBuf.byteLength);
+    let off = 0;
+    header.writeUInt32BE(fromIdBuf.byteLength, off); off += 4;
+    fromIdBuf.copy(header, off); off += fromIdBuf.byteLength;
+    header.writeUInt32BE(fromAliasBuf.byteLength, off); off += 4;
+    fromAliasBuf.copy(header, off);
+    const frame = Buffer.concat([header, rawPayload]);
+    targetWs.send(frame);
+    logTrackerVerbose('game_relay_binary', { from: meta.playerId, to: targetId, payload_bytes: rawPayload.byteLength });
+  } else {
+    logTrackerVerbose('game_relay_json_noop', { from: meta.playerId, to: targetId });
+  }
+}
+
+function onGameBinarySend(ws: WebSocket, targetId: string, payload: Buffer): void {
+  const meta = wsGameMeta.get(ws);
+  if (!meta?.playerId) {
+    logTracker('game_binary_send_drop_no_player', { ws_id: wsId(ws) });
+    return;
+  }
+
+  const targetSessionId = playerToSession.get(targetId);
+  const targetWs = targetSessionId ? gameConnections.get(targetSessionId) : undefined;
+
+  if (!targetWs || targetWs.readyState !== WebSocket.OPEN) {
+    logTracker('game_binary_delivery_failure', { from: meta.playerId, to: targetId });
+    sendGameWs(ws, 'delivery_failure', { to: targetId });
+    return;
+  }
+
+  // Relay binary: [4B from_id_len BE][from_id][4B from_alias_len BE][from_alias][payload]
+  const fromIdBuf = Buffer.from(meta.playerId, 'utf8');
+  const fromAlias = lobby.players[meta.playerId]?.alias ?? meta.playerId;
+  const fromAliasBuf = Buffer.from(fromAlias, 'utf8');
+  const header = Buffer.alloc(4 + fromIdBuf.byteLength + 4 + fromAliasBuf.byteLength);
+  let offset = 0;
+  header.writeUInt32BE(fromIdBuf.byteLength, offset); offset += 4;
+  fromIdBuf.copy(header, offset); offset += fromIdBuf.byteLength;
+  header.writeUInt32BE(fromAliasBuf.byteLength, offset); offset += 4;
+  fromAliasBuf.copy(header, offset);
+  const frame = Buffer.concat([header, payload]);
+  targetWs.send(frame);
+  logTrackerVerbose('game_relay_binary', { from: meta.playerId, to: targetId, payload_bytes: payload.byteLength });
+}
+
+function onSetBusy(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'set_busy' }>): void {
+  const meta = wsGameMeta.get(ws);
+  if (!meta) {
+    logTracker('set_busy_drop_unknown_session', { session_id: msg.session_id });
+    return;
+  }
+  const playerId = meta.playerId;
+  meta.busy = msg.busy;
+  logTracker('set_busy', { player_id: playerId, busy: msg.busy });
+  applyPlayerBusy(playerId, msg.busy);
+  broadcastLobbyUpdate();
+}
+
+// --- Message parsing ---
+
+function parseLobbyInbound(raw: string): LobbyInboundMessage | null {
+  try {
+    const parsed = JSON.parse(raw) as LobbyInboundMessage;
+    if (!parsed || typeof parsed !== 'object' || !('type' in parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function rawDataToBuffer(message: RawData): Buffer {
+  if (Buffer.isBuffer(message)) return message;
+  if (Array.isArray(message)) return Buffer.concat(message);
+  return Buffer.from(message);
+}
+
+function optionalText(map: Map<BencodexKey, BencodexValue>, key: string): string | undefined {
+  const value = map.get(key);
+  return typeof value === 'string' ? value : undefined;
+}
+
+function requireText(map: Map<BencodexKey, BencodexValue>, key: string): string {
+  const value = optionalText(map, key);
+  if (value === undefined) throw new Error(`missing text field: ${key}`);
+  return value;
+}
+
+function parseGameInbound(raw: Buffer): GameInboundMessage | null {
+  try {
+    const decoded = decodeBencodex(raw);
+    if (!isDictionary(decoded)) return null;
+    const type = getText(decoded, 'type');
+    if (!type) return null;
+    switch (type) {
+      case 'identify':
+        return {
+          type,
+          session_id: requireText(decoded, 'session_id'),
+          busy: getBoolean(decoded, 'busy'),
+        };
+      case 'send':
+        return { type, to: requireText(decoded, 'to') };
+      case 'set_busy': {
+        const busy = getBoolean(decoded, 'busy');
+        if (busy === undefined) return null;
+        return {
+          type,
+          session_id: requireText(decoded, 'session_id'),
+          busy,
+        };
+      }
+      case 'keepalive':
+        return { type };
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+function setupLobbyKeepalive(ws: WebSocket): void {
+  const kaTimer = setInterval(() => {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(JSON.stringify({ type: 'keepalive' }));
+    }
+  }, 15_000);
+  wsKeepaliveTimers.set(ws, kaTimer);
+}
+
+function setupGameKeepalive(ws: WebSocket): void {
+  const kaTimer = setInterval(() => {
+    if (ws.readyState === ws.OPEN) {
+      sendGameWs(ws, 'keepalive', {});
+    }
+  }, 15_000);
+  wsKeepaliveTimers.set(ws, kaTimer);
+}
+
+function clearKeepalive(ws: WebSocket): void {
+  const timer = wsKeepaliveTimers.get(ws);
+  if (timer) {
+    clearInterval(timer);
+    wsKeepaliveTimers.delete(ws);
+  }
+}
+
+// --- Lobby WebSocket server ---
+
 lobbyWsServer.on('connection', (ws) => {
   const currentWsId = wsId(ws);
   wsLastActivity.set(ws, Date.now());
   logTracker('lobby_ws_connected', { ws_id: currentWsId });
-  setupKeepalive(ws);
+  setupLobbyKeepalive(ws);
 
   ws.on('message', (message) => {
     wsLastActivity.set(ws, Date.now());
@@ -739,10 +797,9 @@ lobbyWsServer.on('connection', (ws) => {
     logTrackerVerbose('lobby_ws_message', { ws_id: currentWsId, type: parsed.type, bytes: text.length });
 
     switch (parsed.type) {
-      case 'join': {
+      case 'join':
         onLobbyJoin(ws, parsed);
         break;
-      }
       case 'leave':
         onLobbyLeave(ws, parsed);
         break;
@@ -800,55 +857,58 @@ lobbyWsServer.on('connection', (ws) => {
   });
 });
 
+// --- Game WebSocket server ---
+
+// Binary frame format for addressed messaging:
+// Outbound (client -> tracker): [4-byte target_id_len BE][target_id UTF-8][payload]
+// Inbound (tracker -> client):  [4B from_id_len BE][from_id][4B from_alias_len BE][from_alias][payload]
+
 gameWsServer.on('connection', (ws) => {
   const currentWsId = wsId(ws);
   wsLastActivity.set(ws, Date.now());
   logTracker('game_ws_connected', { ws_id: currentWsId });
-  setupKeepalive(ws);
+  setupGameKeepalive(ws);
 
   ws.on('message', (message, isBinary) => {
     wsLastActivity.set(ws, Date.now());
+    const buf = rawDataToBuffer(message);
 
-    if (isBinary) {
-      const buf = Buffer.isBuffer(message) ? message : Buffer.from(message as ArrayBuffer);
-      const meta = wsGameMeta.get(ws);
-      if (!meta?.playerId) {
-        logTracker('game_binary_drop_no_player', { ws_id: currentWsId, bytes: buf.byteLength });
+    if (isBinary && buf[0] !== 0x64) {
+      // Binary frame: addressed message to another peer
+      if (buf.byteLength < 4) {
+        logTracker('game_binary_too_short', { ws_id: currentWsId, bytes: buf.byteLength });
         return;
       }
-      const peerId = lobby.getPairedPlayerId(meta.playerId);
-      if (!peerId) {
-        logTracker('game_binary_drop_unpaired', { ws_id: currentWsId, player_id: meta.playerId, bytes: buf.byteLength });
+      const targetIdLen = buf.readUInt32BE(0);
+      if (buf.byteLength < 4 + targetIdLen) {
+        logTracker('game_binary_header_incomplete', { ws_id: currentWsId, bytes: buf.byteLength, target_id_len: targetIdLen });
         return;
       }
-      const peerSessionId = playerToSession.get(peerId);
-      const peerWs = peerSessionId ? gameConnections.get(peerSessionId) : undefined;
-      if (!peerWs || peerWs.readyState !== WebSocket.OPEN) {
-        logTracker('game_binary_drop_peer_offline', { ws_id: currentWsId, player_id: meta.playerId, peer_id: peerId });
-        return;
-      }
-      logTrackerVerbose('game_binary_relay', { from: meta.playerId, to: peerId, bytes: buf.byteLength });
-      peerWs.send(buf);
+      const targetId = buf.slice(4, 4 + targetIdLen).toString('utf8');
+      const payload = buf.slice(4 + targetIdLen);
+      onGameBinarySend(ws, targetId, payload);
       return;
     }
 
-    const text = typeof message === 'string' ? message : message.toString();
-    const parsed = parseGameInbound(text);
+    if (!isBinary) {
+      const text = typeof message === 'string' ? message : message.toString();
+      logTracker('game_ws_text_frame_drop', { ws_id: currentWsId, bytes: text.length });
+      return;
+    }
+
+    const parsed = parseGameInbound(buf);
     if (!parsed) {
-      logTracker('game_ws_message_parse_drop', { ws_id: currentWsId, bytes: text.length });
+      logTracker('game_ws_message_parse_drop', { ws_id: currentWsId, bytes: buf.byteLength });
       return;
     }
-    logTrackerVerbose('game_ws_message', { ws_id: currentWsId, type: parsed.type, bytes: text.length });
+    logTrackerVerbose('game_ws_message', { ws_id: currentWsId, type: parsed.type, bytes: buf.byteLength });
 
     switch (parsed.type) {
       case 'identify':
         onIdentify(ws, parsed);
         break;
-      case 'chat':
-        onGameChat(ws, parsed);
-        break;
-      case 'close':
-        onGameClose(ws, parsed);
+      case 'send':
+        onGameSend(ws, parsed, null);
         break;
       case 'set_busy':
         onSetBusy(ws, parsed);
@@ -877,6 +937,8 @@ gameWsServer.on('connection', (ws) => {
     }
   });
 });
+
+// --- Sweep / liveness ---
 
 function sweepLobbyConnections(now: number): boolean {
   let changed = false;
@@ -933,7 +995,6 @@ setInterval(() => {
   logTrackerVerbose('state_snapshot', {
     players: Object.keys(lobby.players).length,
     challenges: lobby.challenges.size,
-    pairings: lobby.pairings.size,
     lobby_connections: lobbyConnections.size,
     game_connections: gameConnections.size,
     pending_lobby_leaves: pendingLobbyLeaves.size,
@@ -943,8 +1004,6 @@ setInterval(() => {
 }, 15_000);
 
 const port = process.env.PORT || 5801;
-// Keep HTTP downloads reusable briefly, then close idle sockets by timeout.
-// WebSocket upgrades are long-lived and are not closed by this HTTP keep-alive timeout.
 httpServer.keepAliveTimeout = 5_000;
 httpServer.headersTimeout = 6_000;
 httpServer.listen({ host: '::', port }, () => {

--- a/lobby/lobby-service/src/index.ts
+++ b/lobby/lobby-service/src/index.ts
@@ -611,6 +611,7 @@ function onIdentify(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'ide
   }
   wsGameMeta.set(ws, { sessionId: msg.session_id, playerId, busy: msg.busy });
   gameConnections.set(msg.session_id, ws);
+  rememberGameAlias(msg.session_id, playerId, msg.alias);
 
   // Apply busy status if lobby player exists
   if (msg.busy !== undefined && lobby.players[playerId]) {
@@ -707,6 +708,7 @@ function onSetBusy(ws: WebSocket, msg: Extract<GameInboundMessage, { type: 'set_
     return;
   }
   const playerId = meta.playerId;
+  rememberGameAlias(meta.sessionId, playerId, msg.alias);
   meta.busy = msg.busy;
   logTracker('set_busy', { player_id: playerId, busy: msg.busy });
   applyPlayerBusy(playerId, msg.busy);

--- a/lobby/lobby-service/src/lobbyState.ts
+++ b/lobby/lobby-service/src/lobbyState.ts
@@ -4,7 +4,6 @@ import {
   Player,
   PlayerStatus,
   Challenge,
-  Pairing,
 } from './types/lobby';
 
 function randomHex(): string {
@@ -18,9 +17,6 @@ function listOfObject<T>(object: Record<string, T>): T[] {
 export class Lobby {
   players: Record<string, Player> = {};
   challenges: Map<string, Challenge> = new Map();
-  pairings: Map<string, Pairing> = new Map();
-  // Reverse lookup: player_id -> token for the pairing they're in
-  playerToPairing: Map<string, string> = new Map();
 
   addPlayer(player: Player) {
     this.players[player.id] = player;
@@ -62,43 +58,5 @@ export class Lobby {
 
   removeChallenge(challengeId: string) {
     this.challenges.delete(challengeId);
-  }
-
-  createPairing(playerAId: string, playerBId: string, amount: string, channel_timeout?: string, unroll_timeout?: string): Pairing {
-    const token = randomHex();
-    const pairing: Pairing = {
-      playerA_id: playerAId,
-      playerB_id: playerBId,
-      token,
-      amount,
-      channel_timeout,
-      unroll_timeout,
-    };
-    this.pairings.set(token, pairing);
-    this.playerToPairing.set(playerAId, token);
-    this.playerToPairing.set(playerBId, token);
-    return pairing;
-  }
-
-  getPairingForPlayer(playerId: string): Pairing | undefined {
-    const token = this.playerToPairing.get(playerId);
-    if (!token) return undefined;
-    return this.pairings.get(token);
-  }
-
-  getPairedPlayerId(playerId: string): string | undefined {
-    const pairing = this.getPairingForPlayer(playerId);
-    if (!pairing) return undefined;
-    if (pairing.playerA_id === playerId) return pairing.playerB_id;
-    return pairing.playerA_id;
-  }
-
-  removePairing(token: string) {
-    const pairing = this.pairings.get(token);
-    if (pairing) {
-      this.playerToPairing.delete(pairing.playerA_id);
-      this.playerToPairing.delete(pairing.playerB_id);
-      this.pairings.delete(token);
-    }
   }
 }

--- a/lobby/lobby-service/src/tracker.behavior.test.mjs
+++ b/lobby/lobby-service/src/tracker.behavior.test.mjs
@@ -6,7 +6,10 @@ import path from 'node:path';
 import { createServer } from 'node:net';
 import { test } from 'node:test';
 
+import bencodex from 'chia-gaming-bencodex';
 import { WebSocket } from 'ws';
+
+const { decode: decodeBencodex, encode: encodeBencodex, isDictionary } = bencodex;
 
 async function getFreePort() {
   return new Promise((resolve, reject) => {
@@ -78,6 +81,23 @@ function sendJson(ws, payload) {
   ws.send(JSON.stringify(payload));
 }
 
+function sendGame(ws, payload) {
+  ws.send(encodeBencodex(payload));
+}
+
+function plainBencodex(value) {
+  if (value instanceof Uint8Array) return value;
+  if (Array.isArray(value)) return value.map(plainBencodex);
+  if (isDictionary(value)) {
+    const out = {};
+    for (const [key, item] of value.entries()) {
+      out[typeof key === 'string' ? key : Buffer.from(key).toString('utf8')] = plainBencodex(item);
+    }
+    return out;
+  }
+  return value;
+}
+
 async function nextJson(ws, predicate = () => true, timeoutMs = 2_000) {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -87,6 +107,23 @@ async function nextJson(ws, predicate = () => true, timeoutMs = 2_000) {
     function onMessage(raw) {
       const text = typeof raw === 'string' ? raw : raw.toString();
       const msg = JSON.parse(text);
+      if (!predicate(msg)) return;
+      clearTimeout(timer);
+      ws.off('message', onMessage);
+      resolve(msg);
+    }
+    ws.on('message', onMessage);
+  });
+}
+
+async function nextGame(ws, predicate = () => true, timeoutMs = 2_000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.off('message', onMessage);
+      reject(new Error('timed out waiting for websocket message'));
+    }, timeoutMs);
+    function onMessage(raw) {
+      const msg = plainBencodex(decodeBencodex(raw));
       if (!predicate(msg)) return;
       clearTimeout(timer);
       ws.off('message', onMessage);
@@ -117,8 +154,8 @@ async function joinLobby(origin, sessionId, alias, extra = {}) {
 
 async function identifyGame(origin, sessionId) {
   const game = await openWs(origin, '/ws/game');
-  sendJson(game, { type: 'identify', session_id: sessionId, available: true });
-  await nextJson(game, (msg) => msg.type === 'connection_status');
+  sendGame(game, { type: 'identify', session_id: sessionId, busy: false });
+  await nextGame(game, (msg) => msg.type === 'registered');
   return game;
 }
 
@@ -178,21 +215,30 @@ test('challenge authority and availability come from bound sessions', async () =
     sendJson(alice.lobby, { type: 'challenge', target_id: bob.id, amount: '100' });
     const challenge = await nextJson(bob.lobby, (msg) => msg.type === 'challenge_received');
 
+    // Carol cannot accept Bob's challenge (she's not the target)
     sendJson(carol.lobby, {
       type: 'challenge_accept',
       challenge_id: challenge.challenge_id,
       accepter_id: bob.id,
     });
     await assert.rejects(
-      nextJson(aliceGame, (msg) => msg.type === 'matched', 250),
+      nextGame(bobGame, (msg) => msg.type === 'advisory_start', 250),
       /timed out/,
     );
 
-    const aliceMatched = nextJson(aliceGame, (msg) => msg.type === 'matched');
-    const bobMatched = nextJson(bobGame, (msg) => msg.type === 'matched');
+    // Bob accepts — Bob (accepter/initiator) gets advisory_start
+    const bobAdvisory = nextGame(bobGame, (msg) => msg.type === 'advisory_start');
     sendJson(bob.lobby, { type: 'challenge_accept', challenge_id: challenge.challenge_id });
-    await Promise.all([aliceMatched, bobMatched]);
+    const advisory = await bobAdvisory;
+    assert.equal(advisory.peer_id, alice.id);
+    assert.equal(advisory.amount, '100');
 
+    // Bob's client sets busy (simulating what the frontend does on advisory_start)
+    sendGame(bobGame, { type: 'set_busy', session_id: 'secret-bob-match', busy: true });
+    // Wait for lobby update to propagate
+    await nextJson(carol.lobby, (msg) => msg.type === 'lobby_update');
+
+    // Carol cannot challenge Bob (he's now busy)
     const carolError = nextJson(carol.lobby, (msg) => msg.type === 'error');
     const carolResolved = nextJson(carol.lobby, (msg) => msg.type === 'challenge_resolved');
     sendJson(carol.lobby, { type: 'challenge', target_id: bob.id, amount: '100' });

--- a/lobby/lobby-service/src/types/lobby.ts
+++ b/lobby/lobby-service/src/types/lobby.ts
@@ -17,12 +17,3 @@ export interface Challenge {
   channel_timeout?: string;
   unroll_timeout?: string;
 }
-
-export interface Pairing {
-  playerA_id: string;
-  playerB_id: string;
-  token: string;
-  amount: string;
-  channel_timeout?: string;
-  unroll_timeout?: string;
-}

--- a/lobby/pnpm-lock.yaml
+++ b/lobby/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
 
   lobby-service:
     dependencies:
+      chia-gaming-bencodex:
+        specifier: file:../../shared/bencodex
+        version: file:../shared/bencodex
       cors:
         specifier: 2.8.5
         version: 2.8.5
@@ -592,6 +595,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  chia-gaming-bencodex@file:../shared/bencodex:
+    resolution: {directory: ../shared/bencodex, type: directory}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1572,6 +1578,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  chia-gaming-bencodex@file:../shared/bencodex: {}
 
   chokidar@3.6.0:
     dependencies:

--- a/shared/bencodex/index.d.ts
+++ b/shared/bencodex/index.d.ts
@@ -1,0 +1,20 @@
+export type BencodexKey = string | Uint8Array;
+export type BencodexDictionary = ReadonlyMap<BencodexKey, BencodexValue> | { readonly [key: string]: BencodexValue };
+export type BencodexValue =
+  | null
+  | boolean
+  | bigint
+  | string
+  | Uint8Array
+  | readonly BencodexValue[]
+  | BencodexDictionary;
+
+export class BencodexError extends Error {
+  constructor(message: string);
+}
+
+export function encode(value: BencodexValue): Uint8Array;
+export function decode(bytes: Uint8Array | ArrayBuffer): BencodexValue;
+export function isDictionary(value: BencodexValue): value is Map<BencodexKey, BencodexValue>;
+export function getText(map: Map<BencodexKey, BencodexValue>, key: string): string | undefined;
+export function getBoolean(map: Map<BencodexKey, BencodexValue>, key: string): boolean | undefined;

--- a/shared/bencodex/index.js
+++ b/shared/bencodex/index.js
@@ -1,0 +1,225 @@
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+class BencodexError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'BencodexError';
+  }
+}
+
+function concat(parts) {
+  const total = parts.reduce((sum, p) => sum + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+function ascii(s) {
+  return textEncoder.encode(s);
+}
+
+function encodeBytes(bytes) {
+  return concat([ascii(String(bytes.byteLength)), ascii(':'), bytes]);
+}
+
+function encodeText(text) {
+  const bytes = textEncoder.encode(text);
+  return concat([ascii('u'), ascii(String(bytes.byteLength)), ascii(':'), bytes]);
+}
+
+function keySortValue(key) {
+  if (typeof key === 'string') {
+    return { kind: 1, bytes: textEncoder.encode(key), encoded: encodeText(key) };
+  }
+  if (key instanceof Uint8Array) {
+    return { kind: 0, bytes: key, encoded: encodeBytes(key) };
+  }
+  throw new BencodexError('dictionary keys must be strings or Uint8Array');
+}
+
+function compareBytes(a, b) {
+  const len = Math.min(a.byteLength, b.byteLength);
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return a.byteLength - b.byteLength;
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value) || value instanceof Uint8Array || value instanceof Map) return false;
+  return Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function encode(value) {
+  if (value === null) return ascii('n');
+  if (typeof value === 'boolean') return ascii(value ? 't' : 'f');
+  if (typeof value === 'bigint') return ascii(`i${value.toString()}e`);
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) throw new BencodexError('numbers must be safe integers');
+    return ascii(`i${BigInt(value).toString()}e`);
+  }
+  if (typeof value === 'string') return encodeText(value);
+  if (value instanceof Uint8Array) return encodeBytes(value);
+  if (Array.isArray(value)) {
+    return concat([ascii('l'), ...value.map((item) => encode(item)), ascii('e')]);
+  }
+  if (value instanceof Map || isPlainObject(value)) {
+    const entries = value instanceof Map
+      ? [...value.entries()]
+      : Object.entries(value);
+    const encodedEntries = entries.map(([key, item]) => {
+      const sortKey = keySortValue(key);
+      return { sortKey, value: encode(item) };
+    });
+    encodedEntries.sort((a, b) => {
+      if (a.sortKey.kind !== b.sortKey.kind) return a.sortKey.kind - b.sortKey.kind;
+      return compareBytes(a.sortKey.bytes, b.sortKey.bytes);
+    });
+    const parts = [ascii('d')];
+    for (const entry of encodedEntries) {
+      parts.push(entry.sortKey.encoded, entry.value);
+    }
+    parts.push(ascii('e'));
+    return concat(parts);
+  }
+  throw new BencodexError(`unsupported value type: ${typeof value}`);
+}
+
+class Decoder {
+  constructor(input) {
+    this.input = input instanceof Uint8Array ? input : new Uint8Array(input);
+    this.offset = 0;
+  }
+
+  eof() {
+    return this.offset >= this.input.byteLength;
+  }
+
+  peek() {
+    if (this.eof()) throw new BencodexError('unexpected end of input');
+    return this.input[this.offset];
+  }
+
+  take() {
+    const b = this.peek();
+    this.offset++;
+    return b;
+  }
+
+  readUntil(byte) {
+    const start = this.offset;
+    while (!this.eof() && this.input[this.offset] !== byte) {
+      this.offset++;
+    }
+    if (this.eof()) throw new BencodexError(`missing delimiter 0x${byte.toString(16)}`);
+    const out = this.input.slice(start, this.offset);
+    this.offset++;
+    return out;
+  }
+
+  readLength(prefixAlreadyRead) {
+    const start = prefixAlreadyRead ? this.offset - 1 : this.offset;
+    while (!this.eof()) {
+      const b = this.input[this.offset];
+      if (b === 0x3a) break;
+      if (b < 0x30 || b > 0x39) throw new BencodexError('invalid byte string length');
+      this.offset++;
+    }
+    if (this.eof()) throw new BencodexError("missing ':' in byte string");
+    const raw = textDecoder.decode(this.input.slice(start, this.offset));
+    if (raw.length > 1 && raw.startsWith('0')) throw new BencodexError('invalid byte string length');
+    this.offset++;
+    const len = Number(raw);
+    if (!Number.isSafeInteger(len) || len < 0) throw new BencodexError('invalid byte string length');
+    return len;
+  }
+
+  readBytes(prefixAlreadyRead = false) {
+    const len = this.readLength(prefixAlreadyRead);
+    if (this.input.byteLength < this.offset + len) throw new BencodexError('unexpected end of byte string');
+    const out = this.input.slice(this.offset, this.offset + len);
+    this.offset += len;
+    return out;
+  }
+
+  readInteger() {
+    const rawBytes = this.readUntil(0x65);
+    const raw = textDecoder.decode(rawBytes);
+    if (raw === '' || raw === '-' || raw.startsWith('-0') || (raw.startsWith('0') && raw.length > 1)) {
+      throw new BencodexError('invalid integer encoding');
+    }
+    try {
+      return BigInt(raw);
+    } catch {
+      throw new BencodexError(`cannot parse integer: ${raw}`);
+    }
+  }
+
+  readValue() {
+    const tag = this.take();
+    if (tag === 0x6e) return null;
+    if (tag === 0x74) return true;
+    if (tag === 0x66) return false;
+    if (tag === 0x69) return this.readInteger();
+    if (tag === 0x75) return textDecoder.decode(this.readBytes());
+    if (tag >= 0x30 && tag <= 0x39) return this.readBytes(true);
+    if (tag === 0x6c) {
+      const items = [];
+      while (this.peek() !== 0x65) {
+        items.push(this.readValue());
+      }
+      this.offset++;
+      return items;
+    }
+    if (tag === 0x64) {
+      const items = new Map();
+      while (this.peek() !== 0x65) {
+        const keyTag = this.take();
+        let key;
+        if (keyTag === 0x75) key = textDecoder.decode(this.readBytes());
+        else if (keyTag >= 0x30 && keyTag <= 0x39) key = this.readBytes(true);
+        else throw new BencodexError('dictionary key must be bytes or text');
+        items.set(key, this.readValue());
+      }
+      this.offset++;
+      return items;
+    }
+    throw new BencodexError(`unexpected byte: 0x${tag.toString(16)}`);
+  }
+}
+
+function decode(bytes) {
+  const decoder = new Decoder(bytes);
+  const value = decoder.readValue();
+  if (!decoder.eof()) throw new BencodexError('trailing bytes after value');
+  return value;
+}
+
+function isDictionary(value) {
+  return value instanceof Map;
+}
+
+function getText(map, key) {
+  const value = map.get(key);
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getBoolean(map, key) {
+  const value = map.get(key);
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+module.exports = {
+  BencodexError,
+  decode,
+  encode,
+  getBoolean,
+  getText,
+  isDictionary,
+};

--- a/shared/bencodex/package.json
+++ b/shared/bencodex/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "chia-gaming-bencodex",
+  "version": "0.1.0",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  }
+}

--- a/src/potato_handler/handshake.rs
+++ b/src/potato_handler/handshake.rs
@@ -13,6 +13,8 @@ pub struct HandshakeB {
     pub reward_payout_signature: Aggsig,
     pub channel_key_pop: Aggsig,
     pub unroll_key_pop: Aggsig,
+    pub my_contribution: Amount,
+    pub their_contribution: Amount,
 }
 
 pub type HandshakeA = HandshakeB;

--- a/src/potato_handler/handshake_initiator.rs
+++ b/src/potato_handler/handshake_initiator.rs
@@ -230,6 +230,8 @@ impl HandshakeInitiatorHandler {
             reward_payout_signature: reward_payout_sig,
             channel_key_pop,
             unroll_key_pop,
+            my_contribution: self.my_contribution.clone(),
+            their_contribution: self.their_contribution.clone(),
         }
     }
 
@@ -450,6 +452,19 @@ impl HandshakeInitiatorHandler {
                     return Err(Error::Channel(
                         "Invalid proof-of-possession for unroll key in HandshakeB".to_string(),
                     ));
+                }
+
+                if msg.my_contribution != self.their_contribution {
+                    return Err(Error::Channel(format!(
+                        "HandshakeB contribution mismatch: peer claims my_contribution={:?} but we expect their_contribution={:?}",
+                        msg.my_contribution, self.their_contribution
+                    )));
+                }
+                if msg.their_contribution != self.my_contribution {
+                    return Err(Error::Channel(format!(
+                        "HandshakeB contribution mismatch: peer claims their_contribution={:?} but we expect my_contribution={:?}",
+                        msg.their_contribution, self.my_contribution
+                    )));
                 }
 
                 let our_channel_pk =

--- a/src/potato_handler/handshake_receiver.rs
+++ b/src/potato_handler/handshake_receiver.rs
@@ -338,6 +338,19 @@ impl HandshakeReceiverHandler {
                     ));
                 }
 
+                if msg.my_contribution != self.their_contribution {
+                    return Err(Error::Channel(format!(
+                        "HandshakeA contribution mismatch: peer claims my_contribution={:?} but we expect their_contribution={:?}",
+                        msg.my_contribution, self.their_contribution
+                    )));
+                }
+                if msg.their_contribution != self.my_contribution {
+                    return Err(Error::Channel(format!(
+                        "HandshakeA contribution mismatch: peer claims their_contribution={:?} but we expect my_contribution={:?}",
+                        msg.their_contribution, self.my_contribution
+                    )));
+                }
+
                 let my_hs_info = {
                     let channel_public_key =
                         private_to_public_key(&self.private_keys.my_channel_coin_private_key);
@@ -365,6 +378,8 @@ impl HandshakeReceiverHandler {
                         reward_payout_signature: reward_payout_sig,
                         channel_key_pop,
                         unroll_key_pop,
+                        my_contribution: self.my_contribution.clone(),
+                        their_contribution: self.their_contribution.clone(),
                     }
                 };
 

--- a/src/simulator/service.rs
+++ b/src/simulator/service.rs
@@ -974,6 +974,13 @@ fn ws_send(ws: &mut WebSocket<TcpStream>, text: String) -> Result<(), tungstenit
 }
 
 fn service_main_inner() {
+    // Ensure panics produce full backtraces regardless of env.
+    std::env::set_var("RUST_BACKTRACE", "1");
+    std::panic::set_hook(Box::new(|info| {
+        let bt = std::backtrace::Backtrace::force_capture();
+        eprintln!("[sim] {} PANIC: {info}\n{bt}", sim_ts());
+    }));
+
     let simulator = Simulator::default();
     let coinset_adapter = FullCoinSetAdapter::default();
     let mut game_runner = GameRunner::new(simulator, coinset_adapter)


### PR DESCRIPTION
Cleaned up how the tracker protocol works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Cross-cutting protocol and session-lifecycle changes (matchmaking, relay framing, reconnect, on-chain escalation) affect live games and require coordinated frontend/tracker rollout.
> 
> **Overview**
> Reworks tracker matchmaking and the `/ws/game` wire protocol so the server is a dumb addressed relay instead of owning pairings and auto-starting sessions.
> 
> **Matchmaking:** Challenge accept no longer creates a pairing or broadcasts `matched` to both clients. The tracker sends **`advisory_start` only to the accepter**; peers then exchange bencodex **`session_proposal` / `session_reject`** (and buffer early handshake bytes) before WASM starts. Busy/availability is **client-authoritative** (including while consent prompts are open).
> 
> **Wire format:** Game-channel control envelopes (`identify`, `set_busy`, `registered`, `delivery_failure`, etc.) move from JSON to **bencodex** via new **`chia-gaming-bencodex`**. Peer traffic uses **length-prefixed addressed binary frames**; WASM reliability tags and peer app messages ride inside the payload.
> 
> **Frontend behavior:** `Shell` drops `connection_status` / pairing reconciliation, tracks **`sessionPeerId`**, builds peer send/recv through `sendToPeer`, and adds consent overlays. **Peer liveness** becomes `connected` / `degraded` / `dead` (30s stale, `delivery_failure`); **peer loss no longer auto-triggers go-on-chain**—only explicit go-on-chain or `session_reject` marks the peer dead. Ending a peer session is **`setBusy(false)`**, not tracker `close()`.
> 
> Docs (`CONNECTIVITY.md`, `FRONTEND_ARCHITECTURE.md`) and tests are updated to match; lobby WebSocket stays JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449c495cc25d94199b94670da7218c41daf8a1f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->