### PR TITLE
Added test to make "tracker busy" state more clear.

### DIFF
--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -53,7 +53,7 @@ import {
 } from '../hooks/BlockchainPoller';
 import { RestoreStatus } from '../hooks/SessionController';
 import { useThemeSyncToIframe } from '../hooks/useThemeSyncToIframe';
-import { isRestoreBlocked, shouldMountGameSession, shouldSwitchToTrackerOnResolved } from '../lib/restoreLifecycle';
+import { isRestoreBlocked, shouldMountGameSession, shouldReportTrackerBusy, shouldSwitchToTrackerOnResolved } from '../lib/restoreLifecycle';
 import {
   selectGameDashboardView,
   selectStatusBarBalances,
@@ -1164,7 +1164,7 @@ const Shell = () => {
           lastTrackerActivityRef.current = Date.now();
         },
         getPresence: () => ({
-          busy: sessionPhaseRef.current !== 'none' && sessionPhaseRef.current !== 'resolved',
+          busy: shouldReportTrackerBusy(sessionPhaseRef.current),
           alias: sessionConfigRef.current?.myAlias ?? sessionSaveRef.current?.myAlias ?? sessionSaveRef.current?.alias,
         }),
       });
@@ -1600,7 +1600,7 @@ const Shell = () => {
 
   const handleEndPeerConnection = useCallback(() => {
     resetPeerRelayState();
-    trackerConnRef.current?.setBusy(false);
+    trackerConnRef.current?.setBusy(shouldReportTrackerBusy(sessionPhaseRef.current));
   }, [resetPeerRelayState]);
 
   const startCleanShutdownGrace = useCallback(() => {
@@ -1649,7 +1649,7 @@ const Shell = () => {
     sessionController?.goOnChain();
     sessionPhaseRef.current = 'on-chain';
     setSessionPhase('on-chain');
-    trackerConnRef.current?.setBusy(false);
+    trackerConnRef.current?.setBusy(shouldReportTrackerBusy('on-chain'));
     peerSessionRef.current?.markDead();
     syncPeerLiveness();
     setDashboardSessionModel(prev => prev

--- a/front-end/src/lib/restoreLifecycle.ts
+++ b/front-end/src/lib/restoreLifecycle.ts
@@ -30,6 +30,10 @@ export function shouldAdvertiseAvailable(
   }), sessionPhase);
 }
 
+export function shouldReportTrackerBusy(sessionPhase: SessionPhase): boolean {
+  return sessionPhase !== 'none' && sessionPhase !== 'resolved';
+}
+
 export function shouldMountGameSession(
   sessionCanMount: boolean,
   walletConnected: boolean,

--- a/front-end/src/lib/tests/restore_lifecycle.test.ts
+++ b/front-end/src/lib/tests/restore_lifecycle.test.ts
@@ -2,6 +2,7 @@ import {
   isRestoreBlocked,
   shouldAdvertiseAvailable,
   shouldMountGameSession,
+  shouldReportTrackerBusy,
   shouldSwitchToTrackerOnResolved,
 } from '../restoreLifecycle';
 
@@ -21,6 +22,13 @@ describe('restore lifecycle gates', () => {
     expect(shouldAdvertiseAvailable('none', false)).toBe(true);
     expect(shouldAdvertiseAvailable('resolved', false)).toBe(true);
     expect(shouldAdvertiseAvailable('off-chain', false)).toBe(false);
+  });
+
+  it('keeps tracker presence busy until the session is resolved', () => {
+    expect(shouldReportTrackerBusy('none')).toBe(false);
+    expect(shouldReportTrackerBusy('resolved')).toBe(false);
+    expect(shouldReportTrackerBusy('off-chain')).toBe(true);
+    expect(shouldReportTrackerBusy('on-chain')).toBe(true);
   });
 
   it('mounts a saved session without requiring a live blockchain connection', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small refactor with one intentional behavior fix (on-chain and post–end-peer busy flags); covered by new unit tests and no broader session logic changes.
> 
> **Overview**
> Introduces **`shouldReportTrackerBusy`** in `restoreLifecycle` so tracker “busy” means the session phase is anything except `none` or `resolved`, matching the rule already used for lobby presence.
> 
> **Shell** routes tracker presence and explicit `setBusy` updates through that helper: `getPresence`, ending the peer connection from chat, and **go on-chain** now derive busy from phase instead of hard-coding `false` in places where the channel can still be active (e.g. **on-chain** stays busy).
> 
> Adds unit tests that spell out busy vs available for each phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1256a9fd07975e1db7352d67361d24ca187c905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->