### PR TITLE
Added handling of errors from wallet

### DIFF
--- a/front-end/src/hooks/RealBlockchainInterface.ts
+++ b/front-end/src/hooks/RealBlockchainInterface.ts
@@ -424,10 +424,7 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
       if ((response as any)?.error) {
         const errMsg = (response as any).error;
         log(`[wc-blockchain] createOfferForIds daemon error: ${errMsg}`);
-        if (/insufficient funds/i.test(String(errMsg))) {
-          throw new Error(String(errMsg));
-        }
-        return null;
+        throw new Error(String(errMsg));
       }
       const offerStr = (response as any)?.offer;
       if (typeof offerStr === 'string' && offerStr.startsWith('offer')) {
@@ -465,10 +462,7 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
       const errorMsg = (parsedError as any)?.data?.error
         ?? (parsedError as any)?.data?.structuredError?.message
         ?? '';
-      if (/insufficient funds/i.test(errorMsg) || /insufficient funds/i.test(errorText)) {
-        throw new Error(errorMsg || errorText);
-      }
-      return null;
+      throw new Error(errorMsg || errorText || 'createOfferForIds failed');
     }
   }
 

--- a/front-end/src/hooks/SessionController.ts
+++ b/front-end/src/hooks/SessionController.ts
@@ -401,8 +401,11 @@ export class SessionController implements PollingCradle {
     } catch (e) {
       this.launcherProvided = false;
       diagStack('handleNeedLauncherCoin error', e);
-      log(`[wasm] handleNeedLauncherCoin error: ${String(e)}`);
-      this.rxjsEmitter?.next({ type: 'error', error: extractErrorMessage(e) });
+      const msg = extractErrorMessage(e);
+      log(`[wasm] handleNeedLauncherCoin error: ${msg}`);
+      this.rxjsEmitter?.next({ type: 'error', error: msg });
+      const failResult = this.cradle?.wallet_callback_failed(msg);
+      this.processResult(failResult);
     }
   }
 
@@ -429,7 +432,11 @@ export class SessionController implements PollingCradle {
         maxHeight,
       );
       if (!bundle) {
-        console.error('[wasm] createOfferForIds returned null');
+        const msg = 'Wallet createOfferForIds failed (returned null)';
+        log(`[wasm] ${msg}`);
+        this.rxjsEmitter?.next({ type: 'error', error: msg });
+        const failResult = this.cradle?.wallet_callback_failed(msg);
+        this.processResult(failResult);
         return;
       }
 
@@ -453,6 +460,8 @@ export class SessionController implements PollingCradle {
         msg = 'Wallet reports insufficient funds. It may be that your wallet has enough balance but some coins are locked. Free up locked coins in your wallet and try again.';
       }
       this.rxjsEmitter?.next({ type: 'error', error: msg });
+      const failResult = this.cradle?.wallet_callback_failed(msg);
+      this.processResult(failResult);
     }
   }
 
@@ -493,8 +502,14 @@ export class SessionController implements PollingCradle {
         log(`[wasm] submitTransaction ignored benign rejection: ${message}`);
         return;
       }
+      const coinDescs = (tx.spends ?? [])
+        .map((cs: any) => {
+          const coinHex = typeof cs.coin === 'string' ? cs.coin : '';
+          return coinHex.length >= 64 ? coinHex.slice(0, 64) : coinHex || 'unknown';
+        })
+        .join(', ');
       diagStack('submitTransaction failed', e);
-      log(`[wasm] submitTransaction failed: ${message}`);
+      log(`[wasm] submitTransaction failed: ${message} coins=[${coinDescs}]`);
       this.rxjsEmitter?.next({ type: 'error', error: message });
     }
   }
@@ -671,7 +686,12 @@ export class SessionController implements PollingCradle {
       return;
     }
     try {
-      const ps = await blockchain.rpc.getPuzzleAndSolution(coinHex);
+      let ps = await blockchain.rpc.getPuzzleAndSolution(coinHex);
+      if (!ps) {
+        log(`[wasm] getPuzzleAndSolution returned null, retrying after 5s`);
+        await new Promise(r => setTimeout(r, 5000));
+        ps = await blockchain.rpc.getPuzzleAndSolution(coinHex);
+      }
       if (this.cradle) {
         const result = ps
           ? this.cradle.report_puzzle_and_solution(coinHex, ps[0], ps[1])

--- a/front-end/src/types/ChiaGaming.ts
+++ b/front-end/src/types/ChiaGaming.ts
@@ -209,6 +209,7 @@ export interface WasmConnection {
   provide_launcher_coin: (cid: number, hex_launcher_coin: string) => WasmResult | undefined;
   provide_coin_spend_bundle: (cid: number, bundle_json: string) => WasmResult | undefined;
   provide_offer_bech32: (cid: number, offer_bech32: string) => WasmResult | undefined;
+  wallet_callback_failed: (cid: number, reason: string) => WasmResult | undefined;
   get_channel_puzzle_hash: (cid: number) => string | null;
   new_block: (
     cid: number,
@@ -402,6 +403,14 @@ export class ChiaGame {
 
   provide_offer_bech32(offer_bech32: string): any {
     return this.wasm.provide_offer_bech32(this.cradle, offer_bech32);
+  }
+
+  wallet_callback_failed(reason: string): WasmResult | undefined {
+    const maybeFail = (
+      this.wasm as unknown as { wallet_callback_failed?: (cid: number, reason: string) => WasmResult | undefined }
+    ).wallet_callback_failed;
+    if (typeof maybeFail !== 'function') return undefined;
+    return maybeFail(this.cradle, reason);
   }
 
   get_channel_puzzle_hash(): string | null {

--- a/src/peer_container.rs
+++ b/src/peer_container.rs
@@ -189,8 +189,7 @@ pub trait PeerHandler {
         None
     }
 
-    fn wallet_callback_failed(&mut self, _reason: String) {
-    }
+    fn wallet_callback_failed(&mut self, _reason: String) {}
 
     fn has_active_on_chain_games(&self) -> bool {
         false

--- a/src/peer_container.rs
+++ b/src/peer_container.rs
@@ -189,6 +189,9 @@ pub trait PeerHandler {
         None
     }
 
+    fn wallet_callback_failed(&mut self, _reason: String) {
+    }
+
     fn has_active_on_chain_games(&self) -> bool {
         false
     }
@@ -447,6 +450,15 @@ pub trait GameCradle {
         allocator: &mut AllocEncoder,
         coin_id: &CoinString,
         puzzle_and_solution: Option<(&Program, &Program)>,
+    ) -> Result<(), Error>;
+
+    /// Report that a wallet callback (selectCoins, createOfferForIds) failed
+    /// during the handshake.  The handshake handler transitions to Failed with
+    /// the reason as an advisory.
+    fn wallet_callback_failed(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        reason: String,
     ) -> Result<(), Error>;
 
     /// Get the reward puzzle hash
@@ -874,6 +886,16 @@ impl SynchronousGameCradle {
             self.peer.provide_coin_spend_bundle(&mut env, bundle)?
         };
         self.process_effects(effects, allocator)?;
+        Ok(())
+    }
+
+    pub fn wallet_callback_failed(
+        &mut self,
+        _allocator: &mut AllocEncoder,
+        reason: String,
+    ) -> Result<(), Error> {
+        self.peer.wallet_callback_failed(reason);
+        self.detect_phase_transition();
         Ok(())
     }
 
@@ -1580,6 +1602,14 @@ impl GameCradle for SynchronousGameCradle {
         }
         self.process_effects(reported_effects, allocator)?;
         Ok(())
+    }
+
+    fn wallet_callback_failed(
+        &mut self,
+        allocator: &mut AllocEncoder,
+        reason: String,
+    ) -> Result<(), Error> {
+        self.wallet_callback_failed(allocator, reason)
     }
 }
 

--- a/src/potato_handler/handshake_initiator.rs
+++ b/src/potato_handler/handshake_initiator.rs
@@ -97,6 +97,8 @@ pub struct HandshakeInitiatorHandler {
     last_channel_coin_spend_info: Option<ChannelCoinSpendInfo>,
 
     failed: bool,
+    #[serde(default)]
+    failure_advisory: Option<String>,
 
     #[serde(skip)]
     replacement: Option<Box<PotatoHandler>>,
@@ -127,6 +129,7 @@ impl HandshakeInitiatorHandler {
             incoming_messages: VecDeque::new(),
             last_channel_coin_spend_info: None,
             failed: false,
+            failure_advisory: None,
             replacement: None,
         }
     }
@@ -723,6 +726,10 @@ impl PeerHandler for HandshakeInitiatorHandler {
         self.failed = true;
         Ok(vec![])
     }
+    fn wallet_callback_failed(&mut self, reason: String) {
+        self.failed = true;
+        self.failure_advisory = Some(reason);
+    }
     fn new_block(&mut self, height: u64) -> Result<Vec<Effect>, Error> {
         self.last_height = height;
         if self.pending_coin_spend && self.last_height > 0 {
@@ -817,7 +824,7 @@ impl PeerHandler for HandshakeInitiatorHandler {
         if self.failed {
             return Some(ChannelStatusSnapshot {
                 state: ChannelState::Failed,
-                advisory: None,
+                advisory: self.failure_advisory.clone(),
                 coin: self
                     .channel_handler
                     .as_ref()

--- a/src/potato_handler/handshake_receiver.rs
+++ b/src/potato_handler/handshake_receiver.rs
@@ -92,6 +92,8 @@ pub struct HandshakeReceiverHandler {
     last_channel_coin_spend_info: Option<ChannelCoinSpendInfo>,
 
     failed: bool,
+    #[serde(default)]
+    failure_advisory: Option<String>,
 
     #[serde(skip)]
     replacement: Option<Box<PotatoHandler>>,
@@ -121,6 +123,7 @@ impl HandshakeReceiverHandler {
             incoming_messages: VecDeque::new(),
             last_channel_coin_spend_info: None,
             failed: false,
+            failure_advisory: None,
             replacement: None,
         }
     }
@@ -700,6 +703,10 @@ impl PeerHandler for HandshakeReceiverHandler {
         self.failed = true;
         Ok(vec![])
     }
+    fn wallet_callback_failed(&mut self, reason: String) {
+        self.failed = true;
+        self.failure_advisory = Some(reason);
+    }
     fn new_block(&mut self, height: u64) -> Result<Vec<Effect>, Error> {
         self.last_height = height;
         if self.pending_coin_spend && self.last_height > 0 {
@@ -765,7 +772,7 @@ impl PeerHandler for HandshakeReceiverHandler {
         if self.failed {
             return Some(ChannelStatusSnapshot {
                 state: ChannelState::Failed,
-                advisory: None,
+                advisory: self.failure_advisory.clone(),
                 coin: self
                     .channel_handler
                     .as_ref()

--- a/wasm/src/mod.rs
+++ b/wasm/src/mod.rs
@@ -770,6 +770,16 @@ mod gaming_wasm {
     }
 
     #[wasm_bindgen]
+    pub fn wallet_callback_failed(cid: i32, reason: &str) -> Result<JsValue, JsValue> {
+        let reason = reason.to_string();
+        with_game_drain(cid, move |cradle: &mut JsCradle| {
+            cradle
+                .cradle
+                .wallet_callback_failed(&mut cradle.allocator, reason)
+        })
+    }
+
+    #[wasm_bindgen]
     pub fn convert_offer_to_coinset_org(offer_bech32: &str) -> Result<JsValue, JsValue> {
         let bundle = decode_offer_to_spend_bundle(offer_bech32)
             .map_err(|e| JsValue::from_str(&format!("offer decode error: {e}")))?;


### PR DESCRIPTION
Now handles fatal wallet error messages with report to user and going into error state as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes handshake failure and wallet-offer error paths that affect whether a session stalls or reaches Failed with the right advisory; happy-path logic is mostly unchanged.
> 
> **Overview**
> **Wallet RPC errors during channel setup are no longer swallowed.** `createOfferForIds` in `RealBlockchainInterface` always **throws** on daemon or parse failures (it no longer returns `null`, including for non–insufficient-funds cases).
> 
> When launcher selection or offer creation fails, **`SessionController`** still emits UI errors but also calls the new WASM hook **`wallet_callback_failed(reason)`** so the Rust handshake handlers can exit cleanly. The same path runs when `createOfferForIds` returns null (defensive) and on caught exceptions (with a friendlier message for insufficient funds).
> 
> **Backend:** `wallet_callback_failed` is wired through `PeerHandler` / `GameCradle`, WASM, and **`SynchronousGameCradle`** (phase transition + status). Initiator and receiver handshake handlers set **`failed`** and store **`failure_advisory`**, which is exposed on **`ChannelStatus`** when state is **Failed**.
> 
> **Minor:** `getPuzzleAndSolution` retries once after 5s if null; failed transaction submits log coin prefixes for debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 591c7698299dd6d5537f62b7b2e7f3a9e8c65982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->