### PR TITLE
Fixed bugs and improved behavior in session proposals

### DIFF
--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -202,6 +202,20 @@ const TAB_DEFS: { id: TabId; label: string }[] = [
 const FALLBACK_AMOUNT = 100n;
 const FALLBACK_PER_GAME = 10n;
 
+const PRE_ACTIVE_CHANNEL_STATES: ReadonlySet<string> = new Set([
+  'Handshaking', 'WaitingForHeightToOffer', 'WaitingForHeightToAccept',
+  'MakingOffer', 'MakingOfferAcceptance', 'OfferSent', 'TransactionPending',
+]);
+
+const MIN_TIMEOUT_BLOCKS = 3;
+const MAX_TIMEOUT_BLOCKS = 30;
+
+function isValidTimeoutString(v: string | undefined): boolean {
+  if (v === undefined) return true;
+  const n = Number(v);
+  return Number.isInteger(n) && n >= MIN_TIMEOUT_BLOCKS && n <= MAX_TIMEOUT_BLOCKS;
+}
+
 const TRACKER_LIVENESS_LABELS: Record<TrackerLiveness, string> = {
   connected: 'Connected',
   reconnecting: 'Reconnecting',
@@ -721,6 +735,7 @@ const Shell = () => {
   const sessionStartedRef = useRef(false);
   const sessionFinishedCleanupRef = useRef(false);
   const sessionPhaseRef = useRef<SessionPhase>('none');
+  const dashboardSessionModelRef = useRef<SessionModel | null>(null);
 
   const deferStateUpdate = useCallback((fn: () => void) => {
     if (typeof queueMicrotask === 'function') {
@@ -816,6 +831,7 @@ const Shell = () => {
     setSessionError(false);
     setSessionConfig(null);
     setPeerConn(null);
+    dashboardSessionModelRef.current = null;
     setDashboardSessionModel(null);
     setRestoreStatus('idle');
     setRestoreError(null);
@@ -849,6 +865,7 @@ const Shell = () => {
     setRestoreStatus('idle');
     setRestoreError(null);
     setRestoreTrackerReconciled(true);
+    dashboardSessionModelRef.current = null;
     setDashboardSessionModel(null);
     destroySessionController();
     clearSessionPreservingHistory();
@@ -1055,6 +1072,11 @@ const Shell = () => {
             sendSessionReject(params.peer_id);
             return;
           }
+          if (!isValidTimeoutString(params.channel_timeout) || !isValidTimeoutString(params.unroll_timeout)) {
+            console.log('[Shell] advisory_start declined: timeout out of range channel=%s unroll=%s', params.channel_timeout, params.unroll_timeout);
+            sendSessionReject(params.peer_id);
+            return;
+          }
           setPendingAdvisoryState(params);
           setActiveTab('game');
         },
@@ -1076,6 +1098,11 @@ const Shell = () => {
               sendSessionReject(fromId);
               return;
             }
+            if (!isValidTimeoutString(msg.channel_timeout) || !isValidTimeoutString(msg.unroll_timeout)) {
+              console.log('[Shell] session_proposal declined: timeout out of range channel=%s unroll=%s', msg.channel_timeout, msg.unroll_timeout);
+              sendSessionReject(fromId);
+              return;
+            }
             const proposalSessionId = msg.game_session_id ?? generateSessionId();
             peerSessionRef.current?.destroy();
             peerSessionRef.current = new PeerSession(fromId, proposalSessionId, conn);
@@ -1092,7 +1119,9 @@ const Shell = () => {
             console.log('[Shell] session_reject from=%s sessionPeer=%s match=%s', fromId, ps?.peerId, ps?.peerId === fromId);
             if (ps?.peerId === fromId) {
               markPeerDead();
-              if (sessionPhaseRef.current === 'none') {
+              const channelState = dashboardSessionModelRef.current?.channel.status.state;
+              const isPreActive = !channelState || PRE_ACTIVE_CHANNEL_STATES.has(channelState);
+              if (sessionPhaseRef.current === 'none' || isPreActive) {
                 cancelAttemptedSession();
               }
             }
@@ -1349,6 +1378,7 @@ const Shell = () => {
   }, []);
 
   const handleSessionModelChange = useCallback((model: SessionModel) => {
+    dashboardSessionModelRef.current = model;
     setDashboardSessionModel(model);
   }, []);
 
@@ -1585,6 +1615,8 @@ const Shell = () => {
 
   const cancelDashboardSession = useCallback(() => {
     const alias = sessionConfigRef.current?.myAlias ?? sessionSaveRef.current?.myAlias ?? sessionSaveRef.current?.alias;
+    const peerId = peerSessionRef.current?.peerId ?? sessionSaveRef.current?.sessionPeerId;
+    if (peerId) sendSessionReject(peerId);
     resetPeerRelayState();
     destroySessionController();
     clearSessionPreservingHistory();
@@ -1596,13 +1628,13 @@ const Shell = () => {
     setSessionError(false);
     setSessionConfig(null);
     setPeerConn(null);
+    dashboardSessionModelRef.current = null;
     setDashboardSessionModel(null);
     setRestoreStatus('idle');
     setRestoreError(null);
     setRestoreTrackerReconciled(false);
-    setActiveTab('tracker');
     trackerConnRef.current?.setBusy(false, alias);
-  }, [clearSessionPreservingHistory, resetPeerRelayState, setActiveTab]);
+  }, [clearSessionPreservingHistory, resetPeerRelayState, sendSessionReject]);
 
   const requestDashboardCleanShutdown = useCallback(() => {
     startCleanShutdownGrace();

--- a/lobby/lobby-frontend/src/lobby.tsx
+++ b/lobby/lobby-frontend/src/lobby.tsx
@@ -216,7 +216,8 @@ const LobbyScreen = () => {
               Channel timeout (blocks)
               <input
                 type="number"
-                min="1"
+                min="3"
+                max="30"
                 value={challengeChannelTimeout}
                 onChange={(e) => setChallengeChannelTimeout(e.target.value)}
                 className="mt-1 block w-full px-3 py-2 rounded bg-canvas-bg-subtle text-canvas-text border border-canvas-border outline-none"
@@ -226,7 +227,8 @@ const LobbyScreen = () => {
               Unroll timeout (blocks)
               <input
                 type="number"
-                min="1"
+                min="3"
+                max="30"
                 value={challengeUnrollTimeout}
                 onChange={(e) => setChallengeUnrollTimeout(e.target.value)}
                 className="mt-1 block w-full px-3 py-2 rounded bg-canvas-bg-subtle text-canvas-text border border-canvas-border outline-none"

--- a/lobby/lobby-service/src/index.ts
+++ b/lobby/lobby-service/src/index.ts
@@ -429,6 +429,20 @@ function onChallenge(ws: WebSocket, msg: Extract<LobbyInboundMessage, { type: 'c
     return;
   }
 
+  const MIN_TIMEOUT_BLOCKS = 3;
+  const MAX_TIMEOUT_BLOCKS = 30;
+  for (const field of ['channel_timeout', 'unroll_timeout'] as const) {
+    const raw = msg[field];
+    if (raw !== undefined) {
+      const val = Number(raw);
+      if (!Number.isInteger(val) || val < MIN_TIMEOUT_BLOCKS || val > MAX_TIMEOUT_BLOCKS) {
+        sendWs(ws, 'error', { error: `Invalid ${field}: must be an integer between ${MIN_TIMEOUT_BLOCKS} and ${MAX_TIMEOUT_BLOCKS}.` });
+        sendWs(ws, 'challenge_resolved', { challenge_id: null, accepted: false });
+        return;
+      }
+    }
+  }
+
   const challenge = lobby.createChallenge(
     fromPlayer.id,
     target_id,

--- a/lobby/lobby-service/src/tracker.behavior.test.mjs
+++ b/lobby/lobby-service/src/tracker.behavior.test.mjs
@@ -258,4 +258,39 @@ test('challenge authority and availability come from bound sessions', async () =
   }
 });
 
+test('challenges with out-of-range timeouts are rejected', async () => {
+  const tracker = await startTracker();
+  try {
+    const alice = await joinLobby(tracker.origin, 'secret-alice-timeout', 'Alice');
+    const bob = await joinLobby(tracker.origin, 'secret-bob-timeout', 'Bob');
+    await identifyGame(tracker.origin, 'secret-alice-timeout');
+    await identifyGame(tracker.origin, 'secret-bob-timeout');
+
+    // channel_timeout too low (2 < 3)
+    const err1 = nextJson(alice.lobby, (msg) => msg.type === 'error');
+    const res1 = nextJson(alice.lobby, (msg) => msg.type === 'challenge_resolved');
+    sendJson(alice.lobby, { type: 'challenge', target_id: bob.id, amount: '100', channel_timeout: '2' });
+    assert.match((await err1).error, /channel_timeout/);
+    assert.equal((await res1).accepted, false);
+
+    // unroll_timeout too high (31 > 30)
+    const err2 = nextJson(alice.lobby, (msg) => msg.type === 'error');
+    const res2 = nextJson(alice.lobby, (msg) => msg.type === 'challenge_resolved');
+    sendJson(alice.lobby, { type: 'challenge', target_id: bob.id, amount: '100', unroll_timeout: '31' });
+    assert.match((await err2).error, /unroll_timeout/);
+    assert.equal((await res2).accepted, false);
+
+    // valid timeouts at the boundaries succeed
+    sendJson(alice.lobby, { type: 'challenge', target_id: bob.id, amount: '100', channel_timeout: '3', unroll_timeout: '30' });
+    const challenge = await nextJson(bob.lobby, (msg) => msg.type === 'challenge_received');
+    assert.equal(challenge.channel_timeout, '3');
+    assert.equal(challenge.unroll_timeout, '30');
+
+    await closeWs(alice.lobby);
+    await closeWs(bob.lobby);
+  } finally {
+    await tracker.stop();
+  }
+});
+
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect session negotiation, peer signaling, and on-chain timeout parameters; incorrect handling could abort valid sessions or accept bad timeouts, but scope is limited and covered by new tracker behavior tests.
> 
> **Overview**
> **Channel and unroll timeouts** are now constrained to **3–30 blocks** end-to-end: lobby challenge inputs enforce the range, the tracker rejects invalid challenges with an error, and the game shell declines `advisory_start` / `session_proposal` when timeouts are out of range (sending `session_reject`).
> 
> **Session lifecycle fixes** in `Shell`: a ref mirrors the dashboard session model so `session_reject` can tear down setup while the channel is still in pre-active states (handshake/offer pending), not only when `sessionPhase === 'none'`. **Cancel session** now notifies the peer via `session_reject` and no longer forces a switch to the Tracker tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415344b6959aad51d5ebf6a5c34cca3ba5da183e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->