### PR TITLE
Workaround for WalletConnect's safejsonparse bug: decimalize negative…

### DIFF
--- a/front-end/src/hooks/WalletConnectRpc.ts
+++ b/front-end/src/hooks/WalletConnectRpc.ts
@@ -98,6 +98,20 @@ function deepNumbersToBigInt(value: unknown): unknown {
   return value;
 }
 
+/** WC wire hack: negative BigInt → decimal string (avoids WC "-100n" leftover). Positives stay bigint. */
+function negativeBigintsToDecimalStrings(value: unknown): unknown {
+  if (typeof value === 'bigint') return value < 0n ? value.toString() : value;
+  if (Array.isArray(value)) return value.map(negativeBigintsToDecimalStrings);
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = negativeBigintsToDecimalStrings(v);
+    }
+    return out;
+  }
+  return value;
+}
+
 async function waitForRelayerConnected(): Promise<void> {
   const client = walletConnectState.getClient();
   if (!client) throw new Error('WalletConnect is not initialized');
@@ -171,10 +185,10 @@ class WalletConnectRpcClient {
       throw new Error('walletconnect fingerprint is not a valid integer');
     }
 
-    const params: Record<string, unknown> = {
+    const params = negativeBigintsToDecimalStrings({
       ...data,
       fingerprint,
-    };
+    }) as Record<string, unknown>;
     const paramKeys = Object.keys(params).join(',');
     const enqueuedAt = Date.now();
 

--- a/front-end/src/lib/tests/walletconnect_rpc.test.ts
+++ b/front-end/src/lib/tests/walletconnect_rpc.test.ts
@@ -59,6 +59,28 @@ describe('WalletConnect RPC adapter', () => {
     await expect(rpc.getWalletBalance({ walletId: 1n })).resolves.toMatchObject({
       confirmedWalletBalance: 11n,
     });
+
+    expect(requestMock.mock.calls[0][0].request.params).toMatchObject({
+      walletId: 1n,
+      fingerprint: 123,
+    });
+  });
+
+  it('rewrites only negative request bigints to decimal strings for the WC wire', async () => {
+    requestMock.mockResolvedValueOnce({ success: true });
+
+    await rpc.createOfferForIds({
+      offer: { '1': 100n, '2': -50n },
+      fee: 1n,
+      driverDict: {},
+    });
+
+    expect(requestMock.mock.calls[0][0].request.params).toEqual({
+      offer: { '1': 100n, '2': '-50' },
+      fee: 1n,
+      driverDict: {},
+      fingerprint: 123,
+    });
   });
 
   it('rejects WalletConnect error payloads with method context', async () => {


### PR DESCRIPTION
… bigints.

Decimalizing all bigints would cause problems but this more narrowly works around the exact bug and doesn't happen to break anything currently.

A PR for a proper upstream fix has been submitted: https://github.com/WalletConnect/walletconnect-utils/pull/274

Unfortunately safejsonparse mangles any string which happens to match the ending in n format into an int and reduces the precision of any int which happens to be greater than javascript's maxint..

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow serialization tweak on the WC request path with unit tests; no auth or persistence changes, though offer/RPC payloads with negative bigints depend on the wallet accepting string form.
> 
> **Overview**
> WalletConnect RPC requests now run outgoing params through **`negativeBigintsToDecimalStrings`** before they hit the wire. **Negative** `bigint` values become decimal strings (e.g. `-50n` → `'-50'`) to avoid WalletConnect `safejsonparse` mangling; **non-negative** bigints are unchanged.
> 
> This is applied in **`prepareRpc`** for all methods (including **`createOfferForIds`** offers with negative amounts). Tests assert positive params stay `bigint` and only negatives are rewritten.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3c9cc1be89993e0300fd4425fce29d94cd5794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->