### PR TITLE
Improvements to page load times

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -319,18 +319,25 @@ Set `--self` to the hub's public URL. The same `--dir`, `--self`,
 different origins. The lobby loads inside an iframe from the hub's
 origin; same-origin would break the security boundary.
 - **Asset co-location.** WASM files and `.hex` chialisp files must be
-under the same `basePath` as `index.js`. The WASM module fetches `.hex`
-files via relative HTTP paths at runtime.
+under the same `basePath` as `index.js`. The player app prefetches the
+WASM module and game/factory `.hex` (and krunk `.dat`) presets at page
+load — not when a session is accepted — via relative paths under
+`basePath`.
 - `**--self` must match the public URL.** The hub uses it to derive
 WebSocket URLs. Mismatches cause connection failures.
-- **Caching rules.** Configure your production web server (nginx, Caddy,
-CloudFront, etc.) with these headers. The dev servers
-(`static-server.js` and the hub service) already apply
-them automatically.
-  - `index.html` and `build-meta.json`: `**Cache-Control: no-store`** (must
-  always be fresh so the app picks up new nonces).
+- **Caching rules.** Only root URLs (`index.html`, `build-meta.json`,
+favicon, etc.) stay stable across rebuilds; each deploy mints a new
+`/app/<nonce>/` tree. Configure your production web server (nginx,
+Caddy, CloudFront, etc.) with these headers. The dev servers
+(`static-server.js` and the hub service) already apply them
+automatically.
+  - `build-meta.json`: `**Cache-Control: no-store**` (must always be
+  fresh so the app picks up new nonces).
+  - `index.html`: `**Cache-Control: no-cache**` (revalidate; entry shell
+  must pick up the new `basePath`).
+  - Other root static (e.g. favicon): `**Cache-Control: public, max-age=86400**`.
   - Everything under `/app/`: `**Cache-Control: public, max-age=31536000, immutable**`
-  (content-addressed by nonce, never changes).
+  (content-addressed by nonce within a deploy; repeat visits hit cache).
 - **No simulator.** In production there is no simulator. Players connect
 their Chia wallet via WalletConnect and play against real XCH.
 - **CI artifacts.** The

--- a/front-end/public/index.html
+++ b/front-end/public/index.html
@@ -19,6 +19,14 @@
             base.href = meta.basePath;
             document.head.appendChild(base);
 
+            // Start WASM bytes as early as possible (before glue calls loadWasm).
+            var preloadWasm = document.createElement('link');
+            preloadWasm.rel = 'preload';
+            preloadWasm.as = 'fetch';
+            preloadWasm.href = 'chia_gaming_wasm_bg.wasm';
+            preloadWasm.crossOrigin = 'anonymous';
+            document.head.appendChild(preloadWasm);
+
             var css = document.createElement('link');
             css.rel = 'stylesheet';
             css.href = 'index.css';

--- a/front-end/src/hooks/WasmStateInit.ts
+++ b/front-end/src/hooks/WasmStateInit.ts
@@ -5,11 +5,40 @@ import {
   RngId,
 } from '../types/ChiaGaming';
 import { Observable, Subject } from 'rxjs';
-import { SessionController } from './SessionController';
+import { recoverFromMissingDeployAsset, resolveDeployAssetUrl } from '../lib/deployFreshness';
 
 var chia_gaming_init: WasmInitFn | undefined = undefined;
 var cg: WasmConnection | undefined = undefined;
 var logInitialized = false;
+
+/** Manual mirror of native startup loads (game_collection + channel/referee). Not auto-traced. */
+export const PRESET_FILES = [
+  'clsp/unroll/unroll_puzzle_state_channel_unrolling.hex',
+  'clsp/referee/onchain/referee.hex',
+  'clsp/games/calpoker/calpoker_include_calpoker_factory.hex',
+  'clsp/games/spacepoker/spacepoker_include_spacepoker_factory.hex',
+  'clsp/games/krunk/krunk_include_krunk_factory.hex',
+  'clsp/games/krunk/krunk_signed_dict_tree.dat',
+];
+
+const WASM_URL = 'chia_gaming_wasm_bg.wasm';
+
+export async function fetchDeployPreset(fetchUrl: string): Promise<Uint8Array> {
+  const url = resolveDeployAssetUrl(fetchUrl);
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    await recoverFromMissingDeployAsset(
+      'fetchPreset',
+      url,
+      resp.status,
+      resp.statusText,
+    );
+  }
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+let presetFetcher: (key: string) => Promise<Uint8Array> = fetchDeployPreset;
+let loadPromise: Promise<WasmConnection> | null = null;
 
 if (typeof window !== 'undefined') {
   window.loadWasm = (init: WasmInitFn, wasmConn: WasmConnection) => {
@@ -27,103 +56,99 @@ export const waitForReadyToInit = new Observable<boolean>((subscriber) => {
   readyToInit.subscribe(subscriber);
 });
 
-
-
-//    gameStateInit.foo().then()
-export async function storeInitArgs(
+export function storeInitArgs(
   chia_gaming_init_ready: WasmInitFn,
   cg_ready: WasmConnection,
 ) {
-  // Store information we can't get until the window initializes us with valid data
   chia_gaming_init = chia_gaming_init_ready;
   cg = cg_ready;
   readyToInit.next(true);
+  // Kick download/compile as soon as the glue is wired (page load), not on Accept.
+  void ensureWasmLoaded();
 }
 
-const WASM_URL = 'chia_gaming_wasm_bg.wasm';
+async function runWasmLoad(): Promise<WasmConnection> {
+  if (!chia_gaming_init || !cg) {
+    throw new Error('wasm init args not set');
+  }
+  const initFn = chia_gaming_init;
+  const wasmConn = cg;
+
+  const presetFetches = Promise.all(
+    PRESET_FILES.map(async (name) => ({
+      name,
+      content: await presetFetcher(name),
+    })),
+  );
+
+  const [, presets] = await Promise.all([
+    initFn({ module_or_path: WASM_URL }),
+    presetFetches,
+  ]);
+
+  if (!logInitialized) {
+    logInitialized = true;
+    wasmConn.init((msg: string) => console.warn('wasm', msg));
+  }
+
+  for (const { name, content } of presets) {
+    wasmConn.cache_file(name, content);
+  }
+
+  return wasmConn;
+}
+
+/**
+ * Idempotent: starts WASM + CLSP load once and reuses the same promise.
+ * Safe to call from page load and again from session Accept.
+ * Requires storeInitArgs to have run (or waits for it).
+ */
+export function ensureWasmLoaded(): Promise<WasmConnection> {
+  if (!loadPromise) {
+    loadPromise = new Promise<WasmConnection>((resolve, reject) => {
+      const start = () => {
+        runWasmLoad().then(resolve, reject);
+      };
+      if (chia_gaming_init && cg) {
+        start();
+        return;
+      }
+      const sub = waitForReadyToInit.subscribe({
+        next: () => {
+          sub.unsubscribe();
+          start();
+        },
+        error: reject,
+      });
+    });
+  }
+  return loadPromise;
+}
+
+/** Test helper: clear module load state between cases. */
+export function _resetWasmLoadForTests(): void {
+  loadPromise = null;
+  logInitialized = false;
+  chia_gaming_init = undefined;
+  cg = undefined;
+  presetFetcher = fetchDeployPreset;
+}
 
 export class WasmStateInit {
   wasmConnection: WasmConnection | undefined;
   fetchPreset: (key: string) => Promise<Uint8Array>;
-  deferredWasmConnection: Subject<WasmConnection>;
 
   constructor(
     fetchPreset: (key: string) => Promise<Uint8Array>,
   ) {
     this.fetchPreset = fetchPreset;
-    this.deferredWasmConnection = new Subject<WasmConnection>();
-  }
-
-  async internalLoadWasm(
-    chia_gaming_init: WasmInitFn,
-    cg: WasmConnection,
-  ): Promise<WasmConnection> {
-    await chia_gaming_init({ module_or_path: WASM_URL });
-    if (!logInitialized) {
-      logInitialized = true;
-      cg.init((msg: string) => console.warn('wasm', msg));
-    }
-    const presetFiles = [
-      //'resources/p2_delegated_puzzle_or_hidden_puzzle.clsp.hex', -- now loaded by crates.io::chia_puzzles
-      'clsp/unroll/unroll_puzzle_state_channel_unrolling.hex',
-      'clsp/referee/onchain/referee.hex',
-      'clsp/games/calpoker/calpoker_include_calpoker_factory.hex',
-      'clsp/games/spacepoker/spacepoker_include_spacepoker_factory.hex',
-      'clsp/games/krunk/krunk_include_krunk_factory.hex',
-      'clsp/games/krunk/krunk_signed_dict_tree.dat',
-    ];
-    this.wasmConnection = cg;
-    await this.loadPresets(presetFiles);
-
-    this.deferredWasmConnection.next(cg);
-    this.deferredWasmConnection.complete();
-    return cg;
+    presetFetcher = fetchPreset;
   }
 
   getWasmConnection(): Promise<WasmConnection> {
-    waitForReadyToInit.subscribe({
-      next: () => {
-        if (!chia_gaming_init || !cg) throw new Error('wasm init args not set');
-        this.internalLoadWasm(chia_gaming_init, cg);
-      },
-    });
-
-    return new Promise<WasmConnection>((resolve, reject) => {
-      let wcSub = this.deferredWasmConnection.subscribe({
-        next: (wasmConnection) => {
-          resolve(wasmConnection);
-          wcSub.unsubscribe();
-        },
-      });
-    });
-  }
-
-  loadPresets(presetFiles: string[]) {
-    const presetFetches = presetFiles.map((partialUrl) => {
-      return this.fetchPreset(partialUrl).then((bytes) => {
-        return {
-          name: partialUrl,
-          content: bytes,
-        };
-      });
-    });
-    return Promise.all(presetFetches).then((presets) => {
-      presets.forEach((nameAndContent) => {
-        if (!this.wasmConnection) {
-          throw new Error('this.wasmConnection undefined in loadPresets');
-        }
-        this.wasmConnection?.cache_file(
-          nameAndContent.name,
-          nameAndContent.content,
-        );
-      });
-
-      return {
-        setGameConnectionState: {
-          stateIdentifier: 'starting',
-          stateDetail: ['loaded preset files'],
-        },
-      };
+    return ensureWasmLoaded().then((wasmConn) => {
+      this.wasmConnection = wasmConn;
+      return wasmConn;
     });
   }
 
@@ -134,10 +159,6 @@ export class WasmStateInit {
     }
     return undefined;
   }
-
-  // deserializeRng(serializedGame: any) {
-  //   return this.wasmConnection?.deserialize_rng(serializedGame);
-  // }
 
   getChiaIdentity(rngSeed: string) {
     // return this.wasmConnection?.chia_identity(rngSeed);

--- a/front-end/src/hooks/WasmStateInit.ts
+++ b/front-end/src/hooks/WasmStateInit.ts
@@ -99,28 +99,34 @@ async function runWasmLoad(): Promise<WasmConnection> {
 }
 
 /**
- * Idempotent: starts WASM + CLSP load once and reuses the same promise.
- * Safe to call from page load and again from session Accept.
+ * Idempotent while in flight or after success: reuses the same promise.
+ * On failure, clears so a later getWasmConnection / Accept can retry.
  * Requires storeInitArgs to have run (or waits for it).
  */
 export function ensureWasmLoaded(): Promise<WasmConnection> {
   if (!loadPromise) {
-    loadPromise = new Promise<WasmConnection>((resolve, reject) => {
-      const start = () => {
-        runWasmLoad().then(resolve, reject);
-      };
-      if (chia_gaming_init && cg) {
-        start();
-        return;
+    loadPromise = (async () => {
+      try {
+        if (!chia_gaming_init || !cg) {
+          await new Promise<void>((resolve, reject) => {
+            const sub = waitForReadyToInit.subscribe({
+              next: () => {
+                sub.unsubscribe();
+                resolve();
+              },
+              error: (e) => {
+                sub.unsubscribe();
+                reject(e);
+              },
+            });
+          });
+        }
+        return await runWasmLoad();
+      } catch (err) {
+        loadPromise = null;
+        throw err;
       }
-      const sub = waitForReadyToInit.subscribe({
-        next: () => {
-          sub.unsubscribe();
-          start();
-        },
-        error: reject,
-      });
-    });
+    })();
   }
   return loadPromise;
 }

--- a/front-end/src/hooks/blobSingleton.ts
+++ b/front-end/src/hooks/blobSingleton.ts
@@ -1,5 +1,5 @@
 import { SessionController } from './SessionController';
-import { WasmStateInit } from './WasmStateInit';
+import { fetchDeployPreset, WasmStateInit } from './WasmStateInit';
 import {
   PeerConnectionResult,
 } from '../types/ChiaGaming';
@@ -18,7 +18,6 @@ import {
   recentEntries,
   WASM_NOTIFICATION_HISTORY_LIMIT,
 } from '../lib/session/historyLimits';
-import { recoverFromMissingDeployAsset, resolveDeployAssetUrl } from '../lib/deployFreshness';
 
 export var sessionController: SessionController | null = null;
 /** @deprecated alias for sessionController */
@@ -57,20 +56,6 @@ export function destroySessionController(): void {
 }
 /** @deprecated use destroySessionController */
 export { destroySessionController as destroyBlobSingleton };
-
-async function fetchPreset(fetchUrl: string): Promise<Uint8Array> {
-    const url = resolveDeployAssetUrl(fetchUrl);
-    const resp = await fetch(url);
-    if (!resp.ok) {
-        await recoverFromMissingDeployAsset(
-            'fetchPreset',
-            url,
-            resp.status,
-            resp.statusText,
-        );
-    }
-    return new Uint8Array(await resp.arrayBuffer());
-}
 
 export async function configSessionController(
   sc: SessionController,
@@ -182,7 +167,7 @@ export function getOrCreateSessionController(
     return { sessionController };
   }
 
-  const wasmStateInit = new WasmStateInit(fetchPreset);
+  const wasmStateInit = new WasmStateInit(fetchDeployPreset);
 
   sessionController = new SessionController(
     blockchain,

--- a/front-end/src/lib/tests/load_wasm.test.ts
+++ b/front-end/src/lib/tests/load_wasm.test.ts
@@ -15,6 +15,7 @@ import { Subscription } from 'rxjs';
 import {
   WasmStateInit,
   storeInitArgs,
+  _resetWasmLoadForTests,
 } from '../../hooks/WasmStateInit';
 import { getSearchParams, empty, getRandomInt, getEvenHexString } from './testUtil';
 import WholeWasmObject from '../../../node-pkg/chia_gaming_wasm.js';
@@ -162,6 +163,7 @@ beforeAll(() => {
 
 beforeEach(async () => {
   resetSaveState();
+  _resetWasmLoadForTests();
   await new Promise<void>((resolve) => {
     const request = indexedDB.deleteDatabase(SESSION_DB_NAME);
     request.onsuccess = () => resolve();

--- a/front-end/src/lib/tests/wasm_state_init.test.ts
+++ b/front-end/src/lib/tests/wasm_state_init.test.ts
@@ -71,4 +71,25 @@ describe('WasmStateInit eager load', () => {
     expect(initFn).toHaveBeenCalledTimes(1);
     expect(fetchPreset).toHaveBeenCalledTimes(PRESET_FILES.length);
   });
+
+  it('retries after a failed load instead of pinning the rejection', async () => {
+    const wasm = mockWasm();
+    const initFn = jest.fn(async () => {});
+    let failOnce = true;
+    const fetchPreset = jest.fn(async () => {
+      if (failOnce) {
+        failOnce = false;
+        throw new Error('transient preset fetch');
+      }
+      return new Uint8Array([1]);
+    });
+
+    new WasmStateInit(fetchPreset);
+    storeInitArgs(initFn, wasm);
+
+    await expect(ensureWasmLoaded()).rejects.toThrow('transient preset fetch');
+    await expect(ensureWasmLoaded()).resolves.toBe(wasm);
+    expect(initFn).toHaveBeenCalledTimes(2);
+    expect(fetchPreset.mock.calls.length).toBeGreaterThan(PRESET_FILES.length);
+  });
 });

--- a/front-end/src/lib/tests/wasm_state_init.test.ts
+++ b/front-end/src/lib/tests/wasm_state_init.test.ts
@@ -1,0 +1,74 @@
+import {
+  WasmStateInit,
+  ensureWasmLoaded,
+  storeInitArgs,
+  _resetWasmLoadForTests,
+  PRESET_FILES,
+} from '../../hooks/WasmStateInit';
+import type { WasmConnection } from '../../types/ChiaGaming';
+
+describe('WasmStateInit eager load', () => {
+  beforeEach(() => {
+    _resetWasmLoadForTests();
+  });
+
+  afterEach(() => {
+    _resetWasmLoadForTests();
+  });
+
+  function mockWasm(): WasmConnection {
+    return {
+      init: jest.fn(),
+      cache_file: jest.fn(),
+    } as unknown as WasmConnection;
+  }
+
+  it('ensureWasmLoaded is idempotent and loads presets in parallel with init', async () => {
+    const wasm = mockWasm();
+    let initCalls = 0;
+    const initFn = jest.fn(async () => {
+      initCalls += 1;
+    });
+
+    const fetchPreset = jest.fn(async (_key: string) => new Uint8Array([1, 2, 3]));
+
+    new WasmStateInit(fetchPreset);
+    storeInitArgs(initFn, wasm);
+
+    const p1 = ensureWasmLoaded();
+    const p2 = ensureWasmLoaded();
+    expect(p1).toBe(p2);
+
+    const conn = await p1;
+    expect(conn).toBe(wasm);
+    expect(initCalls).toBe(1);
+    expect(initFn).toHaveBeenCalledWith({ module_or_path: 'chia_gaming_wasm_bg.wasm' });
+    expect(fetchPreset).toHaveBeenCalledTimes(PRESET_FILES.length);
+    for (const name of PRESET_FILES) {
+      expect(fetchPreset).toHaveBeenCalledWith(name);
+      expect(wasm.cache_file).toHaveBeenCalledWith(name, expect.any(Uint8Array));
+    }
+
+    const again = await new WasmStateInit(fetchPreset).getWasmConnection();
+    expect(again).toBe(wasm);
+    expect(initCalls).toBe(1);
+    expect(fetchPreset).toHaveBeenCalledTimes(PRESET_FILES.length);
+  });
+
+  it('getWasmConnection waits for storeInitArgs when called first', async () => {
+    const wasm = mockWasm();
+    const initFn = jest.fn(async () => {});
+    const fetchPreset = jest.fn(async () => new Uint8Array([9]));
+
+    const wsi = new WasmStateInit(fetchPreset);
+    const pending = wsi.getWasmConnection();
+
+    // Allow the wait subscription to attach before wiring init args.
+    await Promise.resolve();
+    storeInitArgs(initFn, wasm);
+
+    await expect(pending).resolves.toBe(wasm);
+    expect(initFn).toHaveBeenCalledTimes(1);
+    expect(fetchPreset).toHaveBeenCalledTimes(PRESET_FILES.length);
+  });
+});

--- a/hub/hub-service/src/index.ts
+++ b/hub/hub-service/src/index.ts
@@ -143,10 +143,19 @@ app.use(
 );
 
 app.use((req, res, next) => {
-  res.set('Cache-Control',
-    req.path.startsWith('/app/')
-      ? 'public, max-age=31536000, immutable'
-      : 'no-store');
+  // Nonce /app/* URLs change every rebuild; only root shell/meta are stable.
+  const p = req.path;
+  let cc: string;
+  if (p.startsWith('/app/')) {
+    cc = 'public, max-age=31536000, immutable';
+  } else if (p === '/build-meta.json') {
+    cc = 'no-store';
+  } else if (p === '/' || p === '/index.html' || p.endsWith('.html')) {
+    cc = 'no-cache';
+  } else {
+    cc = 'public, max-age=86400';
+  }
+  res.set('Cache-Control', cc);
   next();
 });
 

--- a/static-server.js
+++ b/static-server.js
@@ -43,6 +43,54 @@ const MIME = {
   '.map': 'application/json',
 };
 
+/** Cache policy for nonce deploy layout (only root URLs are stable across rebuilds). */
+function cacheControlForPath(pathname) {
+  if (pathname.startsWith('/app/')) {
+    return 'public, max-age=31536000, immutable';
+  }
+  if (pathname === '/build-meta.json') {
+    return 'no-store';
+  }
+  if (pathname === '/' || pathname === '/index.html' || pathname.endsWith('.html')) {
+    return 'no-cache';
+  }
+  // favicon and other stable root static
+  return 'public, max-age=86400';
+}
+
+function sendFile(res, filePath, pathname) {
+  const ext = path.extname(filePath);
+  const ct = MIME[ext] || 'application/octet-stream';
+  const headers = {
+    'Content-Type': ct,
+    'Cache-Control': cacheControlForPath(pathname),
+  };
+  if (ext === '.wasm') {
+    headers['SourceMap'] = path.basename(filePath) + '.map';
+  }
+
+  const stream = fs.createReadStream(filePath);
+  stream.on('open', () => {
+    res.writeHead(200, headers);
+    stream.pipe(res);
+  });
+  stream.on('error', (err) => {
+    if (err.code === 'ENOENT') {
+      if (!res.headersSent) {
+        res.writeHead(404);
+        res.end('Not found');
+      }
+      return;
+    }
+    if (!res.headersSent) {
+      res.writeHead(500);
+      res.end('Internal error');
+    } else {
+      res.destroy(err);
+    }
+  });
+}
+
 const server = http.createServer((req, res) => {
   let pathname = new URL(req.url, 'http://localhost').pathname;
   if (pathname === '/') pathname = '/index.html';
@@ -53,37 +101,31 @@ const server = http.createServer((req, res) => {
     return res.end('Forbidden');
   }
 
-  fs.readFile(filePath, (err, data) => {
-    if (err) {
-      // SPA fallback: serve index.html for missing files
-      if (err.code === 'ENOENT' && !path.extname(pathname)) {
-        return fs.readFile(path.join(ROOT, 'index.html'), (err2, html) => {
-          if (err2) { res.writeHead(404); return res.end('Not found'); }
-          res.writeHead(200, { 'Content-Type': 'text/html', 'Cache-Control': 'no-store' });
-          res.end(html);
-        });
-      }
-      res.writeHead(404);
-      return res.end('Not found');
+  fs.stat(filePath, (err, st) => {
+    if (!err && st.isFile()) {
+      return sendFile(res, filePath, pathname);
     }
-    const ext = path.extname(filePath);
-    const ct = MIME[ext] || 'application/octet-stream';
-    const cc = pathname.startsWith('/app/')
-      ? 'public, max-age=31536000, immutable'
-      : 'no-store';
-    const headers = { 'Content-Type': ct, 'Cache-Control': cc };
-    if (ext === '.wasm') {
-      headers['SourceMap'] = path.basename(filePath) + '.map';
+
+    // SPA fallback: serve index.html for missing extensionless paths
+    if (err && err.code === 'ENOENT' && !path.extname(pathname)) {
+      const indexPath = path.join(ROOT, 'index.html');
+      return fs.stat(indexPath, (err2, st2) => {
+        if (err2 || !st2.isFile()) {
+          res.writeHead(404);
+          return res.end('Not found');
+        }
+        return sendFile(res, indexPath, '/index.html');
+      });
     }
-    res.writeHead(200, headers);
-    res.end(data);
+
+    res.writeHead(404);
+    return res.end('Not found');
   });
 });
 
-// Leave HTTP asset connections reusable briefly, then let Node close idle
-// keep-alives. This does not affect upgraded WebSocket connections.
-server.keepAliveTimeout = 5_000;
-server.headersTimeout = 6_000;
+// Keep connections reusable across parallel WASM + CLSP fetches.
+server.keepAliveTimeout = 60_000;
+server.headersTimeout = 61_000;
 
 server.listen(PORT, HOST, () => {
   console.log(`Static server: http://${HOST}:${PORT} -> ${ROOT}`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to load timing, static serving, and cache headers; session logic is simplified but covered by new unit tests and existing integration tests.
> 
> **Overview**
> **Speeds up time-to-play** by starting WASM compile and CLSP preset downloads as soon as the page boots, instead of waiting until the user accepts a session.
> 
> The entry shell adds a **`preload` link** for `chia_gaming_wasm_bg.wasm` right after `build-meta.json` sets `basePath`. **`WasmStateInit`** is refactored around shared **`ensureWasmLoaded()`**: WASM init and all **`PRESET_FILES`** fetches run in **parallel**, triggered from **`storeInitArgs`** when the glue loads; **`getWasmConnection()`** reuses one idempotent promise and **retries** after failures. Preset fetching is centralized in **`fetchDeployPreset`** (moved out of **`blobSingleton`**). New **`wasm_state_init.test.ts`** covers idempotency, ordering, and retry behavior.
> 
> **Deploy caching** is tightened for the nonce layout: **`static-server.js`** and the **hub** now use differentiated **`Cache-Control`** (`no-store` for **`build-meta.json`**, **`no-cache`** for HTML shells, long cache under **`/app/`**, day cache for other root static). The dev static server also **streams** files, extends **keep-alive** to 60s for parallel asset fetches, and **`DEVELOPMENT.md`** documents the updated rules and that presets load at page load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7019fe1daddf5537febc0da54681a9fa7f35a8ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->