### PR TITLE
Simulator fixes

### DIFF
--- a/CONNECTIVITY.md
+++ b/CONNECTIVITY.md
@@ -300,9 +300,16 @@ while a previous result remains visible until a new session replaces it.
 
 The app is available for a new session when the broader session phase is `none`
 or `resolved` and there is no consent prompt, reserved peer id, buffered
-handshake, or live message handler. A consent prompt is a temporary unavailable
-state: while it is open, the app sends `set_busy: true` and declines any other
-incoming advisory/proposal. Raw `ChannelStatus` is more detailed than this
+handshake, or live message handler (`isAvailableForNewSessionPrompt()`). A
+consent prompt is a temporary unavailable state for inbound matchmaking even
+though it does not by itself set hub `busy`. While unavailable:
+
+- further `advisory_start` messages are **ignored** (hub-originated; do not
+  `session_reject` the peer);
+- inbound `session_proposal` messages are **rejected** with `session_reject`.
+
+Clients do not negotiate dual-initiator races (no same-peer yield / steal).
+Raw `ChannelStatus` is more detailed than this
 (`Handshaking`, funding/offer states, `Active`, shutdown states, on-chain
 transition states, resolved channel states, `Failed`, etc.) and must not be
 treated as the lobby availability state directly. The broader session phase
@@ -313,7 +320,9 @@ session remains `on-chain` because a hand is still being settled.
 
 Logical bencodex dictionary: `{ type: "set_busy", session_id: "...", busy: true }`.
 
-Sent whenever the broader session phase or consent-prompt availability changes.
+Sent when the user accepts a session start, when restore reconnection reports
+an unresolved session, and when the broader session phase ends or the user
+cancels.
 The same `busy` bit is also included in the initial `identify` message so the
 hub has correct status immediately after a game channel opens, reconnects,
 or restores. This avoids a brief `waiting` flicker for unresolved restored
@@ -345,20 +354,27 @@ The hub does not create a session. It can only advise and relay:
    are stored and sent as `challenge_received` to the target lobby iframe.
 2. If the target accepts in the lobby, the hub removes that challenge,
    cancels stale challenge records involving either player, and sends
-   `advisory_start` to the target player's game channel. The target is now the
-   proposed channel initiator.
+   `advisory_start` to the target player's game channel only. The target is
+   now the proposed channel initiator for that challenge. (A separate reverse
+   challenge accepted while both players are still free can produce a second
+   `advisory_start` on the other side; the hub does not pick a single winner.)
 3. The target player's app checks local availability. If it is in a live
    session, on-chain resolution, restore/handshake, or another consent prompt,
-   it declines by sending `session_reject` to the peer through the relay.
+   it **ignores** the advisory (no `session_reject`).
 4. If the target consents, it marks itself busy, generates a random hex
    `game_session_id`, sends a bencodex `session_proposal` app message (including
    the `game_session_id`) to the challenger through the addressed relay, starts
-   WASM as initiator, and sends binary handshake frames.
+   WASM as initiator, and sends binary handshake frames. Persist of that start
+   is async; `session_reject` / local cancel must abort any in-flight start so
+   it cannot resurrect an orphan handshake.
 5. The challenger app checks local availability before showing the proposal
    prompt. While the prompt is open it reserves that peer id so early
-   `HandshakeA` bytes can buffer, and it marks itself busy. If unavailable or
-   declined, it sends `session_reject` and discards buffered handshake bytes. If
-   accepted, it starts WASM as receiver and drains the buffer.
+   `HandshakeA` bytes can buffer. If unavailable or declined, it sends
+   `session_reject` and discards buffered handshake bytes. Receiving
+   `session_reject` during pre-active matchmaking cancels the attempt
+   (including in-flight async start) and surfaces cancelled/error. If
+   accepted, it marks itself busy, starts WASM as receiver, and drains the
+   buffer.
 
 ---
 
@@ -502,8 +518,10 @@ Clean shutdown does **not** mark the peer dead on its own. Keepalives and the
 small allowlist of shutdown-related peer messages continue until local
 shutdown completes. Successful/terminal session exit does not send
 `session_reject` (that signal means decline/abort). If a `session_reject`
-does arrive, it is still honored as an abort. When the channel reaches a
-terminal state the session exits and the dot goes gray.
+does arrive during pre-active matchmaking, it is honored as an abort: cancel
+the attempt (including any in-flight async session start), surface
+cancelled/error, and do not leave an orphan handshake. When the channel
+reaches a terminal state the session exits and the dot goes gray.
 
 ### Game tab error conditions (red dot)
 

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -121,6 +121,17 @@ When a challenge is accepted, the hub removes that challenge, cancels stale
 pending challenges involving either player, and sends an **advisory_start**
 message to the accepter's game channel only. That advisory is not authority to
 start a session by itself; it asks the accepter's player app whether to initiate.
+Two independent challenge accepts (while both players are still free) can each
+produce an `advisory_start`; the hub does not negotiate a single initiator.
+Local availability is authoritative for what happens next:
+
+- While mid-matchmaking or mid-session (`isAvailableForNewSessionPrompt()` is
+  false): further `advisory_start` messages are **ignored** (no consent UI, no
+  `session_reject` to the peer — advisory is hub-originated, not a peer request).
+  Inbound `session_proposal` messages are **rejected** with `session_reject`.
+- Clients do not special-case same-peer dual-initiator races (no yield / steal /
+  auto-join). Mutual rejects cancel both attempts cleanly.
+
 The player app self-declares whether it is `busy` over the game channel. Busy
 means the app has an active session (the user explicitly accepted a session
 start). The `HubConnection` uses a `getPresence` callback — provided by
@@ -131,8 +142,8 @@ which invents and persists a `Player_*` fallback that can overwrite the
 hub-side lobby name. Explicit `setBusy(true)` is called only when
 the user accepts a session (not when a consent dialog is merely displayed), and
 `setBusy(false)` fires on the session controller's terminal event or when the
-user explicitly ends/cancels a session. Showing a session-consent dialog does not set busy;
-concurrent proposals are silently declined by `isAvailableForNewSessionPrompt()`.
+user explicitly ends/cancels a session. Showing a session-consent dialog does not
+set busy; local availability still gates inbound advisories/proposals as above.
 When the app later reports that it is not busy, the hub sets the player back
 to `'waiting'`.
 
@@ -176,19 +187,24 @@ while WASM protocol frames remain raw bytes with the existing reliability tags.
 5. When a challenge is accepted in the lobby, the hub sends `advisory_start`
    to the accepter's game channel only. The app first checks its local
    availability. If it is already in a session, restoring, handshaking, or
-   showing another consent prompt, it declines by sending `session_reject` to
-   the peer through the pipe.
+   showing another consent prompt, it **ignores** the advisory (no
+   `session_reject`).
 6. If the accepter consents, that app becomes the channel initiator. It marks
    itself busy, generates a random hex `game_session_id`, sends a bencodex
    `session_proposal` app message (including the `game_session_id`) to the peer,
    starts the WASM session as initiator, and then sends the binary handshake
-   frames through the same addressed pipe.
-7. The peer receives the `session_proposal`, stores the `game_session_id` in its
-   PeerSession, reserves that peer id so early handshake bytes can buffer, marks
-   itself busy while the prompt is open, and shows its own consent prompt. If
-   unavailable or declined, it sends `session_reject` and discards any buffered
-   handshake bytes. If accepted, it starts the WASM session as receiver and
-   drains the buffered handshake bytes.
+   frames through the same addressed pipe. Starting persists session state
+   asynchronously; a later `session_reject` (or local cancel) must abort that
+   in-flight start so it cannot resurrect an orphan handshake.
+7. The peer receives the `session_proposal`, checks local availability, stores
+   the `game_session_id` in its PeerSession, reserves that peer id so early
+   handshake bytes can buffer, and shows its own consent prompt. If unavailable
+   or declined, it sends `session_reject` and discards any buffered handshake
+   bytes. Receiving `session_reject` during pre-active matchmaking cancels the
+   attempt (including any in-flight async start) and surfaces cancelled/error —
+   it must not leave an orphan handshake. If accepted, the peer marks itself
+   busy, starts the WASM session as receiver, and drains the buffered handshake
+   bytes.
 8. Both players exchange binary game frames through the addressed hub pipe.
    The reliability layer (msgno/ack/keepalive) is encoded inside the binary
    payload, peer-to-peer — the hub never interprets it.

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -893,6 +893,8 @@ const Shell = () => {
   const sessionFinishedCleanupRef = useRef(false);
   const sessionPhaseRef = useRef<SessionPhase>('none');
   const dashboardSessionModelRef = useRef<SessionModel | null>(null);
+  /** Bumped on cancel so in-flight startFreshSessionWithPeer aborts after awaits. */
+  const sessionStartEpochRef = useRef(0);
 
   const deferStateUpdate = useCallback((fn: () => void) => {
     if (typeof queueMicrotask === 'function') {
@@ -978,7 +980,8 @@ const Shell = () => {
     setPeerLiveness(null);
   }, []);
 
-  const cancelAttemptedSession = useCallback(() => {
+  const cancelAttemptedSession = useCallback((options?: { error?: boolean }) => {
+    sessionStartEpochRef.current += 1;
     setPendingAdvisoryState(null);
     setPendingProposalState(null);
     resetPeerRelayState();
@@ -1003,7 +1006,7 @@ const Shell = () => {
     setAbandonEnabled(false);
     setCleanShutdownGraceActive(false);
     setSessionPhase('none');
-    setSessionError(false);
+    setSessionError(!!options?.error);
     setSessionConfig(null);
     setPeerConn(null);
     dashboardSessionModelRef.current = null;
@@ -1017,6 +1020,7 @@ const Shell = () => {
   const startFreshSessionWithPeer = useCallback(async (request: SessionStartRequest & { gameSessionId?: string }) => {
     const conn = hubConnRef.current;
     if (!conn) return;
+    const epoch = sessionStartEpochRef.current;
 
     let myContribution: bigint;
     let theirContribution: bigint;
@@ -1063,6 +1067,10 @@ const Shell = () => {
       ...(historyRef.current.length > 0 ? { humanHistory: historyRef.current } : {}),
     });
     await flushSessionSave();
+    if (epoch !== sessionStartEpochRef.current) {
+      log(`[Shell] startFreshSessionWithPeer aborted: cancelled during persist peer=${request.peerId}`);
+      return;
+    }
     sessionStartedRef.current = false;
     sessionFinishedCleanupRef.current = false;
     sessionPhaseRef.current = 'none';
@@ -1296,12 +1304,14 @@ const Shell = () => {
           hubWsUpRef.current = true;
           lastHubActivityRef.current = Date.now();
           setHubLiveness('connected');
+          // Hub advisory while we are already mid-matchmaking/session: ignore.
+          // Do not session_reject the peer — advisory is not a peer request.
           if (!isAvailableForNewSessionPrompt()) {
-            sendSessionReject(params.peer_id);
+            log(`[Shell] advisory_start ignored: unavailable peer=${params.peer_id} phase=${sessionPhaseRef.current}`);
             return;
           }
           if (!isValidTimeoutString(params.channel_timeout) || !isValidTimeoutString(params.unroll_timeout)) {
-            sendSessionReject(params.peer_id);
+            log(`[Shell] advisory_start ignored: invalid timeouts peer=${params.peer_id}`);
             return;
           }
           setPendingAdvisoryState(params);
@@ -1319,10 +1329,12 @@ const Shell = () => {
           if (msg.type === 'session_proposal') {
             const peerAlias = fromAlias || msg.from_alias || fromId;
             if (!isAvailableForNewSessionPrompt()) {
+              log(`[Shell] session_reject to=${fromId}: proposal while unavailable phase=${sessionPhaseRef.current}`);
               sendSessionReject(fromId);
               return;
             }
             if (!isValidTimeoutString(msg.channel_timeout) || !isValidTimeoutString(msg.unroll_timeout)) {
+              log(`[Shell] session_reject to=${fromId}: proposal invalid timeouts`);
               sendSessionReject(fromId);
               return;
             }
@@ -1342,10 +1354,11 @@ const Shell = () => {
             setActiveTab('game');
           } else if (msg.type === 'session_reject') {
             if (ps?.peerId === fromId) {
+              log(`[Shell] session_reject from=${fromId}: cancelling attempted session`);
               markPeerDead();
               const channelState = dashboardSessionModelRef.current?.channel.status.state;
               if (shouldCancelOnPeerUnreachable(sessionPhaseRef.current, channelState)) {
-                cancelAttemptedSession();
+                cancelAttemptedSession({ error: true });
               }
             }
           }
@@ -1653,6 +1666,7 @@ const Shell = () => {
   }, []);
 
   const cancelDashboardSession = useCallback((options?: { retainFinishedGuard?: boolean }) => {
+    sessionStartEpochRef.current += 1;
     const alias = sessionConfigRef.current?.myAlias ?? sessionSaveRef.current?.myAlias ?? peekAlias();
     const peerId = peerSessionRef.current?.peerId ?? sessionSaveRef.current?.sessionPeerId;
     // Terminal/clean finish must not send session_reject — that signal means

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -1799,10 +1799,11 @@ const Shell = () => {
   }, []);
 
   const handleTerminal = useCallback(() => {
-    // Phase→resolved owns soft finish (preserves dashboard + sessionError).
-    // Terminal only stops balance polling once the cradle reports done.
-    stopBalancePolling();
-  }, [stopBalancePolling]);
+    // Session end tears down the cradle, not the wallet. Keep balance interest
+    // and nudge an immediate poll so settlement payouts show up promptly.
+    const bcType = blockchainTypeRef.current;
+    if (bcType) startBalancePolling(bcType);
+  }, [startBalancePolling]);
 
   const restoreBlocked = isRestoreBlocked(!!sessionConfig?.restoring, restoreStatus, restoreHubReconciled);
 

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -664,20 +664,16 @@ const Shell = () => {
         if (cancelled) return;
         markSavedSession();
         if (peekAutoResumeOnce()) {
-          console.log('[Shell] boot: stale-deploy auto-resume');
           setBootState({ kind: 'autoResuming' });
           return;
         }
-        console.log('[Shell] boot: wallet/hub/session state present, showing resume dialog');
         setBootState({ kind: 'resumeDialog', loadError: null });
         return;
       }
       if (isLeaseConflict()) {
-        console.log('[Shell] boot: no save but another tab holds the lease, showing tabConflict');
         setBootState({ kind: 'tabConflict', save: null, midSession: false });
         return;
       }
-      console.log('[Shell] boot: no state, no conflict, claiming lease');
       claimLease();
       setBootState({ kind: 'ready' });
     })();
@@ -1300,14 +1296,11 @@ const Shell = () => {
           hubWsUpRef.current = true;
           lastHubActivityRef.current = Date.now();
           setHubLiveness('connected');
-          console.log('[Shell] advisory_start: peer=%s alias=%s my_amount=%s their_amount=%s', params.peer_id, params.peer_alias, params.my_amount, params.their_amount);
           if (!isAvailableForNewSessionPrompt()) {
-            console.log('[Shell] advisory_start declined: client unavailable for new session');
             sendSessionReject(params.peer_id);
             return;
           }
           if (!isValidTimeoutString(params.channel_timeout) || !isValidTimeoutString(params.unroll_timeout)) {
-            console.log('[Shell] advisory_start declined: timeout out of range channel=%s unroll=%s', params.channel_timeout, params.unroll_timeout);
             sendSessionReject(params.peer_id);
             return;
           }
@@ -1323,17 +1316,13 @@ const Shell = () => {
           if (ps && ps.liveness === 'dead') return;
           if (ps) ps.notePeerActivity();
           syncPeerLiveness();
-          console.log('[Shell] onPeerAppMessage type=%s from=%s', msg.type, fromId);
           if (msg.type === 'session_proposal') {
             const peerAlias = fromAlias || msg.from_alias || fromId;
-            console.log('[Shell] session_proposal from=%s alias=%s proposer_amount=%s responder_amount=%s', fromId, peerAlias, msg.proposer_amount, msg.responder_amount);
             if (!isAvailableForNewSessionPrompt()) {
-              console.log('[Shell] session_proposal declined: client unavailable for new session');
               sendSessionReject(fromId);
               return;
             }
             if (!isValidTimeoutString(msg.channel_timeout) || !isValidTimeoutString(msg.unroll_timeout)) {
-              console.log('[Shell] session_proposal declined: timeout out of range channel=%s unroll=%s', msg.channel_timeout, msg.unroll_timeout);
               sendSessionReject(fromId);
               return;
             }
@@ -1352,7 +1341,6 @@ const Shell = () => {
             });
             setActiveTab('game');
           } else if (msg.type === 'session_reject') {
-            console.log('[Shell] session_reject from=%s sessionPeer=%s match=%s', fromId, ps?.peerId, ps?.peerId === fromId);
             if (ps?.peerId === fromId) {
               markPeerDead();
               const channelState = dashboardSessionModelRef.current?.channel.status.state;
@@ -1383,7 +1371,6 @@ const Shell = () => {
           hubWsUpRef.current = true;
           lastHubActivityRef.current = Date.now();
           setHubLiveness('connected');
-          console.log('[Shell] registered as player_id=%s session_id=%s', playerId, getSessionId());
           const save = sessionSaveRef.current;
           const prevMine = save?.myHubPlayerId ?? loadState().myHubPlayerId;
           // Pre-cradle routing is by peer player_id. If *we* remapped (hub
@@ -1434,18 +1421,15 @@ const Shell = () => {
           }
         },
         onClosed: () => {
-          console.log('[Shell] hub connection ended');
           hubWsUpRef.current = false;
           markPeerInactive();
           setHubLiveness('disconnected');
         },
         onHubDisconnected: () => {
-          console.log('[Shell] hub disconnected');
           hubWsUpRef.current = false;
           setHubLiveness('reconnecting');
         },
         onHubReconnected: () => {
-          console.log('[Shell] hub reconnected');
           hubWsUpRef.current = true;
           lastHubActivityRef.current = Date.now();
           setHubLiveness('connected');
@@ -1510,7 +1494,6 @@ const Shell = () => {
       return;
     }
     const url = getHubUrl();
-    console.log('[Shell] hub-reconnect effect: %s hubUrl=%s', bootState.kind, url ?? 'none');
     if (url && !hubConnRef.current) {
       connectToHub(url);
     }
@@ -1527,7 +1510,6 @@ const Shell = () => {
     pollMs: number,
     options: { switchToHub?: boolean } = {},
   ) => {
-    console.log('[Shell] completeConnection: bcType=%s', bcType);
     deactivate();
     const poller = activate(iface, pollMs);
     // Pre-game wallet connection: force Resume/Start Over on reload even
@@ -1868,7 +1850,6 @@ const Shell = () => {
   const performResume = useCallback((save: SessionSave) => {
     setActiveTab('game');
     const bcType = save.blockchainType ?? 'simulator';
-    console.log('[Shell] performResume: bcType=%s token=%s', bcType, save.pairingToken ?? 'none');
     setResuming(true);
     setRestoreStatus('restoring');
     setRestoreError(null);
@@ -1979,7 +1960,6 @@ const Shell = () => {
           setConnecting(false);
         }
       }
-      console.log('[Shell] performResume: blockchain connect task done');
     })();
   }, [uniqueId, completeConnection, stablePeerConn, setActiveTab]);
 
@@ -2017,17 +1997,11 @@ const Shell = () => {
       return;
     }
     if (isLeaseConflict()) {
-      console.log('[Shell] resume: lease conflict, showing tabConflict dialog');
       clearAutoResumeOnce();
       setBootState({ kind: 'tabConflict', save, midSession: false });
       setResuming(false);
       return;
     }
-    console.log(
-      fromAutoResume
-        ? '[Shell] auto-resume: claiming lease and hydrating'
-        : '[Shell] resume: no conflict, claiming lease and hydrating',
-    );
     claimLease();
     // Select the destination tab before any hydrate so the first ready paint
     // is already on the right tab.
@@ -2071,7 +2045,6 @@ const Shell = () => {
     if (bootState.kind !== 'autoResuming') return;
     if (!sessionConfig || !peerConn) return;
     if (restoreStatus === 'failed') {
-      console.log('[Shell] auto-resume: restore failed, showing shell');
       setBootState({ kind: 'ready' });
       return;
     }
@@ -2084,7 +2057,6 @@ const Shell = () => {
       sessionStartedRef.current,
     );
     if (keepSession && !blocked) {
-      console.log('[Shell] auto-resume: presentable, showing shell');
       setBootState({ kind: 'ready' });
     }
   }, [
@@ -2102,7 +2074,6 @@ const Shell = () => {
   const handleTakeOver = useCallback(() => {
     setBootState(prev => {
       if (prev.kind !== 'tabConflict') return prev;
-      console.log('[Shell] takeOver: claiming lease in place (midSession=%s)', prev.midSession);
       claimLease();
       if (prev.midSession) {
         // Our session is already live — just reclaim the lease.
@@ -2463,8 +2434,6 @@ const Shell = () => {
     sessionStartedRef.current,
   );
   if (sessionReadyToStart) sessionStartedRef.current = true;
-  console.log('[Shell] render: sessionConfig=%s peerConn=%s poller=%s walletConnected=%s restoring=%s → keepSession=%s',
-    !!sessionConfig, !!peerConn, !!activeBlockchainPoller, walletConnected, !!sessionConfig?.restoring, keepSession);
 
   const dashboardView: GameDashboardViewModel = selectGameDashboardView(dashboardSessionModel, {
     hasSession: dashboardSessionModel !== null,

--- a/front-end/src/hooks/BlockchainPoller.ts
+++ b/front-end/src/hooks/BlockchainPoller.ts
@@ -216,11 +216,14 @@ export class BlockchainPoller {
     this.refreshCoinInterest();
   }
 
+  /**
+   * Stop game-session height/coin watching. Does not stop wallet balance
+   * interest — that is wallet-lifetime (`stopBalanceInterest` / deactivate).
+   */
   stop() {
     this.running = false;
     this.heightPollingScheduler.stop();
     this.coinPollingScheduler.stop();
-    this.balancePollingScheduler.stop();
   }
 
   private collectGameSessionCoins(): Array<{ c: PollingGameSession; coins: CoinPollInterest[] }> {

--- a/front-end/src/hooks/SessionController.ts
+++ b/front-end/src/hooks/SessionController.ts
@@ -203,11 +203,7 @@ export class SessionController implements PollingGameSession {
       }
     };
     this.beforeUnloadHandler = () => {
-      const hadPending = !!this.saveTimer;
       void this.flushPendingSave();
-      if (hadPending) {
-        console.log('[wasm] beforeunload: flushed pending save');
-      }
     };
     if (typeof window !== 'undefined') {
       window.addEventListener('beforeunload', this.beforeUnloadHandler);

--- a/front-end/src/hooks/WalletConnectRpc.ts
+++ b/front-end/src/hooks/WalletConnectRpc.ts
@@ -85,6 +85,20 @@ function shouldLogRpcError(method: ChiaMethod): boolean {
   return method !== ChiaMethod.GetCoinRecordsByNames;
 }
 
+/** High-frequency poll methods — skip success traces to avoid drowning the log. */
+function shouldLogRpcTraffic(method: ChiaMethod): boolean {
+  return (
+    method !== ChiaMethod.GetCoinRecordsByNames &&
+    method !== ChiaMethod.GetHeightInfo &&
+    method !== ChiaMethod.GetWalletBalance
+  );
+}
+
+function summarizeRpcValue(value: unknown, maxLen = 400): string {
+  const text = toDebugJson(value);
+  return text.length > maxLen ? `${text.slice(0, maxLen)}…` : text;
+}
+
 function deepNumbersToBigInt(value: unknown): unknown {
   if (typeof value === 'number' && Number.isInteger(value)) return BigInt(value);
   if (Array.isArray(value)) return value.map(deepNumbersToBigInt);
@@ -209,13 +223,24 @@ class WalletConnectRpcClient {
 
     await waitForRelayerConnected();
 
+    if (shouldLogRpcTraffic(prepared.method)) {
+      log(
+        `[WC RPC] → ${prepared.method} keys=[${prepared.paramKeys}] params=${summarizeRpcValue(prepared.params)}`,
+      );
+    }
+
     try {
       const raw = await client.request({
         topic: session.topic,
         chainId: walletConnectState.getChainId(),
         request: { method: prepared.method, params: prepared.params },
       });
-      return this.normalizeResult(prepared, raw);
+      const result = this.normalizeResult(prepared, raw);
+      if (shouldLogRpcTraffic(prepared.method)) {
+        const elapsed = Date.now() - prepared.enqueuedAt;
+        log(`[WC RPC] ← ${prepared.method} ok ${elapsed}ms result=${summarizeRpcValue(result)}`);
+      }
+      return result;
     } catch (e) {
       throw e;
     }

--- a/front-end/src/hooks/activeBlockchain.ts
+++ b/front-end/src/hooks/activeBlockchain.ts
@@ -8,6 +8,7 @@ export function activate(
   pollIntervalMs: number,
 ): BlockchainPoller {
   if (active) {
+    active.stopBalanceInterest();
     active.stop();
   }
   active = new BlockchainPoller(blockchain, pollIntervalMs);
@@ -17,6 +18,7 @@ export function activate(
 
 export function deactivate(): void {
   if (active) {
+    active.stopBalanceInterest();
     active.stop();
     active = null;
   }

--- a/front-end/src/hooks/save.ts
+++ b/front-end/src/hooks/save.ts
@@ -568,49 +568,10 @@ function capPersistedHistories(state: SessionSave): void {
   }
 }
 
-function estimateRecordBytes(value: unknown, seen = new Set<object>()): number {
-  if (value === null || value === undefined) return 0;
-  if (typeof value === 'string') return new TextEncoder().encode(value).byteLength;
-  if (typeof value === 'bigint') return value.toString().length;
-  if (typeof value === 'boolean') return 1;
-  if (typeof value !== 'object') return 8;
-  if (ArrayBuffer.isView(value)) return value.byteLength;
-  if (seen.has(value)) return 0;
-  seen.add(value);
-  // Degraded cradles are plain numeric-keyed objects; do not Object.entries them
-  // (enumerating hundreds of thousands of keys can OOM).
-  if (!Array.isArray(value) && isDenseNumericByteObject(value)) {
-    return 4096;
-  }
-  if (Array.isArray(value)) {
-    return value.reduce((total, item) => total + estimateRecordBytes(item, seen), 0);
-  }
-  return Object.entries(value as Record<string, unknown>).reduce(
-    (total, [key, item]) => total + key.length * 2 + estimateRecordBytes(item, seen),
-    0,
-  );
-}
-
-function logPersistenceMetrics(state: SessionSave): void {
-  const developmentRuntime = typeof window === 'undefined'
-    ? process.env.NODE_ENV !== 'production'
-    : window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-  if (!developmentRuntime) return;
-  console.debug('[save] persistence metrics', {
-    rawGameSessionBytes: state.serializedGameSession?.byteLength ?? 0,
-    estimatedIndexedDbRecordBytes: estimateRecordBytes(state),
-    historicalUnrollCount: state.historicalUnrollCount?.toString() ?? 'unavailable',
-    humanHistoryCount: state.humanHistory?.length ?? 0,
-    wasmNotificationHistoryCount: state.wasmNotificationHistory?.length ?? 0,
-    diagnosticLogCount: state.diagnosticLog?.length ?? 0,
-  });
-}
-
 function queueWrite(state: SessionSave): Promise<void> {
   const snapshot = structuredClone(state);
   capPersistedHistories(snapshot);
   assertNoNumbers(snapshot, 'SessionSave');
-  logPersistenceMetrics(snapshot);
   writeChain = writeChain.catch(() => {}).then(async () => {
     if (fenced) return;
     await writeSessionRecord(snapshot);

--- a/front-end/src/hooks/useWalletConnect.ts
+++ b/front-end/src/hooks/useWalletConnect.ts
@@ -86,11 +86,6 @@ class WalletState {
         continue;
       }
 
-      console.log('[WC] restoring existing session', {
-        topic: session.topic,
-        peer: session.peer?.metadata?.name,
-        expiry: session.expiry,
-      });
       this.onSessionConnected(session);
       return true;
     }
@@ -152,14 +147,6 @@ class WalletState {
   }
 
   private async doInit(): Promise<void> {
-    console.log(`[WC] network: ${CHAIN_ID}`);
-    console.log('[WC] init() starting', {
-      projectId: PROJECT_ID,
-      relayUrl: RELAY_URL,
-      chainId: CHAIN_ID,
-      origin: window.location.origin,
-    });
-
     this.observable.next({ stateName: 'initializing', initializing: true });
     log('WalletConnect initializing...');
 
@@ -176,7 +163,6 @@ class WalletState {
         },
       });
 
-      console.log('[WC] Client.init() succeeded');
       this.client = signClient;
 
       signClient.on('session_update', ({ topic, params }) => {
@@ -187,13 +173,11 @@ class WalletState {
       });
 
       signClient.on('session_delete', ({ topic }: { topic: string }) => {
-        console.log('[WC] session deleted by wallet', { topic });
         log(`[WC session] delete topic=${topic}`);
         this.resetSession();
       });
 
       signClient.on('session_expire', ({ topic }: { topic: string }) => {
-        console.log('[WC] session expired', { topic });
         log(`[WC session] expire topic=${topic}`);
         this.resetSession();
       });
@@ -241,11 +225,6 @@ class WalletState {
   }
 
   async startConnect(): Promise<StartConnectResult> {
-    console.log('[WC] startConnect() called', {
-      hasClient: !!this.client,
-      isInitialized: !!this.initPromise,
-    });
-
     if (!this.client) {
       const msg = 'startConnect() called but client is undefined -- init() may have failed';
       console.error('[WC]', msg);
@@ -260,11 +239,6 @@ class WalletState {
     try {
       const { uri, approval } = await this.client.connect({
         requiredNamespaces: REQUIRED_NAMESPACES,
-      });
-
-      console.log('[WC] startConnect() got URI', {
-        uriPrefix: uri?.substring(0, 50),
-        uriLength: uri?.length,
       });
 
       this.observable.next({
@@ -287,14 +261,8 @@ class WalletState {
   }
 
   async connect(approval: () => Promise<SessionTypes.Struct>) {
-    console.log('[WC] connect() waiting for wallet approval...');
     try {
       const session = await approval();
-      console.log('[WC] connect() session approved', {
-        topic: session.topic,
-        peer: session.peer?.metadata?.name,
-        expiry: session.expiry,
-      });
       this.onSessionConnected(session);
     } catch (err) {
       console.error('[WC] connect() approval FAILED or rejected', err);

--- a/front-end/src/lib/tests/blockchain_poller.test.ts
+++ b/front-end/src/lib/tests/blockchain_poller.test.ts
@@ -323,6 +323,35 @@ describe('BlockchainPoller', () => {
     jest.useRealTimers();
   });
 
+  it('keeps balance interest alive across game-session stop()', async () => {
+    jest.useFakeTimers();
+    const balances: bigint[] = [];
+    const rpc = new Proxy(
+      {
+        getBalance: jest.fn()
+          .mockResolvedValueOnce(10n)
+          .mockResolvedValueOnce(20n),
+      } as unknown as InternalBlockchainInterface,
+      {
+        get: (target, prop) =>
+          (target as Record<string, unknown>)[prop as string] ??
+          (() => Promise.resolve(undefined)),
+      },
+    );
+    const poller = new BlockchainPoller(rpc, 1000);
+    poller.start();
+    poller.startBalanceInterest(1000, { onBalance: (value) => balances.push(value) });
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(balances).toEqual([10n]);
+
+    // SessionController calls stop() on cradle terminal — wallet balance must continue.
+    poller.stop();
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(balances).toEqual([10n, 20n]);
+    jest.useRealTimers();
+  });
+
   it('clears registered coin cache when the adapter registration scope changes', async () => {
     let scope = '99';
     const registered: string[][] = [];

--- a/front-end/src/lib/tests/message_protocol.test.ts
+++ b/front-end/src/lib/tests/message_protocol.test.ts
@@ -448,19 +448,24 @@ describe('durability failures', () => {
     const sub = blob.getObservable().subscribe((event) => {
       if (event.type === 'durability-error') warnings.push(event.error);
     });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     clearTestGlobal('indexedDB');
+    try {
+      blob.deliverMessage(1n, enc('trigger'));
+      blob.flushDeferredWork();
+      await expect(blob.flushPendingWork()).rejects.toThrow('IndexedDB is unavailable');
 
-    blob.deliverMessage(1n, enc('trigger'));
-    blob.flushDeferredWork();
-    await expect(blob.flushPendingWork()).rejects.toThrow('IndexedDB is unavailable');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('remain queued');
+      expect(sentMessages).toEqual([]);
+      expect(sentAcks).toEqual([]);
+      expect(blob.unackedMessages).toContainEqual({ msgno: 1n, msg: helloBytes });
+      expect(errorSpy).toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      setTestGlobal('indexedDB', testIndexedDb);
+    }
 
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('remain queued');
-    expect(sentMessages).toEqual([]);
-    expect(sentAcks).toEqual([]);
-    expect(blob.unackedMessages).toContainEqual({ msgno: 1n, msg: helloBytes });
-
-    setTestGlobal('indexedDB', testIndexedDb);
     await blob.flushPendingSave();
     await blob.flushPendingWork();
 

--- a/front-end/src/lib/tests/real_blockchain_interface.test.ts
+++ b/front-end/src/lib/tests/real_blockchain_interface.test.ts
@@ -199,6 +199,7 @@ describe('RealBlockchainInterface', () => {
 
   it('retries remote-wallet setup after a transient getWallets failure', async () => {
     jest.useFakeTimers();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       const address = encodePuzzleHashToBech32m('11'.repeat(32));
       mockGetNextAddress.mockResolvedValue(address);
@@ -218,6 +219,7 @@ describe('RealBlockchainInterface', () => {
       for (let i = 0; i < 10; i++) await Promise.resolve();
       expect(mockGetWallets).toHaveBeenCalledTimes(1);
       expect(events).toEqual([]);
+      expect(warnSpy).toHaveBeenCalled();
 
       // Retry tick starts getWallets #2; the following tick observes remoteWalletId.
       jest.advanceTimersByTime(500);
@@ -228,6 +230,7 @@ describe('RealBlockchainInterface', () => {
       for (let i = 0; i < 10; i++) await Promise.resolve();
       expect(events).toEqual([true]);
     } finally {
+      warnSpy.mockRestore();
       jest.useRealTimers();
     }
   });

--- a/front-end/src/lib/tests/save.test.ts
+++ b/front-end/src/lib/tests/save.test.ts
@@ -317,12 +317,18 @@ describe('session persistence', () => {
   });
 
   it('propagates IndexedDB write failure to durability callers', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
     clearTestGlobal('indexedDB');
-    const scheduled = saveSession(sampleSession);
+    try {
+      const scheduled = saveSession(sampleSession);
 
-    await expect(flushSessionSave()).rejects.toThrow('IndexedDB is unavailable');
-    await expect(scheduled).rejects.toThrow('IndexedDB is unavailable');
-    setTestGlobal('indexedDB', testIndexedDb);
+      await expect(flushSessionSave()).rejects.toThrow('IndexedDB is unavailable');
+      await expect(scheduled).rejects.toThrow('IndexedDB is unavailable');
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+      setTestGlobal('indexedDB', testIndexedDb);
+    }
   });
 
   it('keeps serialized session bytes out of localStorage', async () => {

--- a/front-end/src/lib/tests/save.test.ts
+++ b/front-end/src/lib/tests/save.test.ts
@@ -105,6 +105,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  // Cancel debounced flushes so a late queueWrite cannot run after the suite.
+  _resetForTests();
   clearTestGlobal('localStorage');
   clearTestGlobal('sessionStorage');
 });

--- a/front-end/src/services/HubConnection.ts
+++ b/front-end/src/services/HubConnection.ts
@@ -351,6 +351,7 @@ export class HubConnection {
    * Send a bencodex app message to a specific peer through the hub pipe.
    */
   sendPeerAppMessage(targetId: string, data: PeerAppMessage): void {
+    log(`[hub] send app type=${data.type} to=${targetId}`);
     const payload = encodeBencodex(definedBencodexFields(data as Record<string, BencodexValue | undefined>));
     this.sendToPeer(targetId, payload);
   }
@@ -431,6 +432,7 @@ export class HubConnection {
       try {
         const data = decodePeerAppMessage(payload);
         if (data) {
+          log(`[hub] recv app type=${data.type} from=${fromId}`);
           this.callbacks.onPeerAppMessage(fromId, fromAlias, data);
           return;
         }

--- a/front-end/src/services/PeerSession.ts
+++ b/front-end/src/services/PeerSession.ts
@@ -47,11 +47,13 @@ export class PeerSession implements PeerConnectionResult {
 
   sendMessage(msgno: number, input: Uint8Array): void {
     if (this.destroyed) return;
+    log(`[peer] send msg msgno=${msgno} len=${input.byteLength} to=${this.peerId}`);
     this.hubConn.sendToPeer(this.peerId, buildFrame(0x01, msgno, input));
   }
 
   sendAck(ackMsgno: number): void {
     if (this.destroyed) return;
+    log(`[peer] send ack msgno=${ackMsgno} to=${this.peerId}`);
     this.hubConn.sendToPeer(this.peerId, buildFrame(0x02, ackMsgno));
   }
 
@@ -129,11 +131,13 @@ export class PeerSession implements PeerConnectionResult {
       const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
       const msgno = view.getUint32(1, false);
       const msg = payload.slice(5);
+      log(`[peer] recv msg msgno=${msgno} len=${msg.byteLength} from=${fromId}`);
       if (this.messageHandler) this.messageHandler.handler(msgno, msg);
       else this.messageBuffer.push({ tag, msgno, data: msg });
     } else if (tag === 0x02 && payload.length >= 5) {
       const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
       const ack = view.getUint32(1, false);
+      log(`[peer] recv ack msgno=${ack} from=${fromId}`);
       if (this.messageHandler) this.messageHandler.ackHandler(ack);
       else this.messageBuffer.push({ tag, msgno: ack, data: new Uint8Array(0) });
     } else if (tag === 0x03) {

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -840,21 +840,36 @@ impl Simulator {
             &change_amt,
         );
 
-        let conditions = (
-            (
-                CREATE_COIN,
-                (identity_target.clone(), (target_amt.clone(), ())),
-            ),
+        // Omit zero-value change CREATE_COIN (invalid / useless); used when burning
+        // an entire coin to a sink puzzle hash.
+        let conditions = if change_amt.to_u64() == 0 {
+            // Proper one-element condition list: ((CREATE_COIN ...) .)
             (
                 (
                     CREATE_COIN,
-                    (identity_source.puzzle_hash.clone(), (change_amt, ())),
+                    (identity_target.clone(), (target_amt.clone(), ())),
                 ),
                 (),
-            ),
-        )
-            .to_clvm(allocator)
-            .into_gen()?;
+            )
+                .to_clvm(allocator)
+                .into_gen()?
+        } else {
+            (
+                (
+                    CREATE_COIN,
+                    (identity_target.clone(), (target_amt.clone(), ())),
+                ),
+                (
+                    (
+                        CREATE_COIN,
+                        (identity_source.puzzle_hash.clone(), (change_amt, ())),
+                    ),
+                    (),
+                ),
+            )
+                .to_clvm(allocator)
+                .into_gen()?
+        };
         let quoted_conditions = conditions.to_quoted_program(allocator)?;
         let quoted_conditions_hash = quoted_conditions.sha256tree(allocator);
         let standard_solution = solution_for_conditions(allocator, conditions)?;

--- a/src/simulator/service.rs
+++ b/src/simulator/service.rs
@@ -160,7 +160,8 @@ impl GameRunner {
             self.identities.len()
         ));
         let coinset_adapter = FullCoinSetAdapter::default();
-        let simulator = Simulator::new_strict();
+        // Non-strict: demo/service soft-rejects like a real chain (tests use new_strict).
+        let simulator = Simulator::new(false);
         self.detach_simulator(simulator, coinset_adapter);
         Ok("1\n".to_string())
     }
@@ -1075,7 +1076,8 @@ fn run_game_actor(
     height: Arc<AtomicUsize>,
     ready: std_mpsc::SyncSender<Result<(), String>>,
 ) {
-    let simulator = Simulator::new_strict();
+    // Non-strict: demo/service soft-rejects like a real chain (tests use new_strict).
+    let simulator = Simulator::new(false);
     let coinset_adapter = FullCoinSetAdapter::default();
     let mut game_runner = match GameRunner::new(simulator, coinset_adapter) {
         Ok(runner) => runner,

--- a/src/simulator/service.rs
+++ b/src/simulator/service.rs
@@ -2196,7 +2196,11 @@ mod regression_tests {
         assert!(balance_response["error"].is_null(), "{balance_response}");
         let balance = balance_response["result"]
             .as_u64()
-            .or_else(|| balance_response["result"].as_str().and_then(|s| s.parse().ok()))
+            .or_else(|| {
+                balance_response["result"]
+                    .as_str()
+                    .and_then(|s| s.parse().ok())
+            })
             .expect("get_balance did not return a number");
         assert_eq!(
             balance, 1_000_000,

--- a/src/simulator/service.rs
+++ b/src/simulator/service.rs
@@ -278,24 +278,44 @@ impl GameRunner {
                     .filter_map(|c| c.to_parts().map(|(_, _, amt)| amt.to_u64()))
                     .sum();
                 if total > desired {
+                    // Burn excess to the zero puzzle hash so only `desired` remains
+                    // spendable under this wallet.  Must process every coin: register
+                    // farms both pool and farmer rewards.
+                    let burn_ph = PuzzleHash::from_bytes([0u8; 32]);
+                    let mut keep_left = desired;
                     for c in coins.iter() {
-                        if let Some((_, _, amt)) = c.to_parts() {
-                            if amt.to_u64() > desired {
-                                self.simulator.transfer_coin_amount(
-                                    &mut self.allocator,
-                                    &identity.puzzle_hash,
-                                    &identity,
-                                    c,
-                                    Amount::new(desired),
-                                )?;
-                                self.farm_and_chase()?;
-                                sim_log(&format!(
-                                    "register: trimmed balance name={name} from={total} to={desired}"
-                                ));
-                                break;
-                            }
+                        let Some((_, _, amt)) = c.to_parts() else {
+                            continue;
+                        };
+                        let amt = amt.to_u64();
+                        if keep_left == 0 {
+                            // Burn the entire leftover coin.
+                            self.simulator.transfer_coin_amount(
+                                &mut self.allocator,
+                                &burn_ph,
+                                &identity,
+                                c,
+                                Amount::new(amt),
+                            )?;
+                        } else if amt <= keep_left {
+                            keep_left -= amt;
+                        } else {
+                            // Keep `keep_left` as change; burn the excess.
+                            let excess = amt - keep_left;
+                            self.simulator.transfer_coin_amount(
+                                &mut self.allocator,
+                                &burn_ph,
+                                &identity,
+                                c,
+                                Amount::new(excess),
+                            )?;
+                            keep_left = 0;
                         }
                     }
+                    self.farm_and_chase()?;
+                    sim_log(&format!(
+                        "register: trimmed balance name={name} from={total} to={desired} (burned excess)"
+                    ));
                 }
             }
         }
@@ -2137,6 +2157,51 @@ mod regression_tests {
         assert_eq!(registered_event["records"].as_array().unwrap().len(), 1);
         assert_eq!(unregistered_event["event"], "block");
         assert!(unregistered_event["records"].as_array().unwrap().is_empty());
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn regression_register_burns_excess_to_honor_target_balance() {
+        let harness = ServiceHarness::start().await;
+        let url = format!("ws://{}/ws", harness.listen_addr);
+        let (mut client, _) = connect_async(&url).await.unwrap();
+
+        send_request(
+            &mut client,
+            serde_json::json!({
+                "id": 1,
+                "method": "register",
+                "params": {"name": "burn-trim-wallet", "balance": 1_000_000u64}
+            }),
+        )
+        .await;
+        let register_response = receive_response(&mut client, 1).await;
+        assert!(register_response["error"].is_null(), "{register_response}");
+        let puzzle_hash = register_response["result"]
+            .as_str()
+            .expect("register did not return a puzzle hash")
+            .to_string();
+
+        send_request(
+            &mut client,
+            serde_json::json!({
+                "id": 2,
+                "method": "get_balance",
+                "params": {"user": puzzle_hash}
+            }),
+        )
+        .await;
+        let balance_response = receive_response(&mut client, 2).await;
+        assert!(balance_response["error"].is_null(), "{balance_response}");
+        let balance = balance_response["result"]
+            .as_u64()
+            .or_else(|| balance_response["result"].as_str().and_then(|s| s.parse().ok()))
+            .expect("get_balance did not return a number");
+        assert_eq!(
+            balance, 1_000_000,
+            "register should burn farmed excess so only the requested balance remains"
+        );
 
         harness.shutdown().await;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes matchmaking wire semantics and async session-start cancellation (user-visible during challenges), plus wallet balance polling across session teardown; simulator register balance trimming affects dev/demo wallets.
> 
> **Overview**
> **Matchmaking and session start** behavior is tightened in `Shell` and documented in `CONNECTIVITY.md` / `FRONTEND_ARCHITECTURE.md`. While the client is unavailable (`isAvailableForNewSessionPrompt()` false), hub **`advisory_start` is ignored** (no `session_reject` to the peer); inbound **`session_proposal` still gets `session_reject`**. Pre-active **`session_reject`** now cancels the attempt with **`sessionStartEpochRef`** so async persist/start cannot leave an orphan handshake; invalid advisories/timeouts are ignored rather than rejected.
> 
> **Wallet vs session polling**: `BlockchainPoller.stop()` no longer stops balance interest; **`stopBalanceInterest`** runs on deactivate. Session terminal handling **restarts balance polling** instead of only stopping it. Tests cover balance surviving game-session `stop()`.
> 
> **Observability**: noisy `console.log` in Shell boot/resume/hub paths is removed; hub/peer/WC RPC use **`log()`** with throttling for high-frequency RPC methods. Dev IndexedDB persistence metrics logging in `save.ts` is dropped.
> 
> **Simulator service (Rust)**: demo/service uses **non-strict** `Simulator::new(false)`; **`register` with `balance`** burns excess across all coins to the zero puzzle hash; **`transfer_coin_amount`** omits zero-value change `CREATE_COIN`; regression test for register trim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 356ed5ec9746a22883a66138abf2bebaa9cbfee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->