### PR TITLE
Fixed activity notifications from game tab

### DIFF
--- a/front-end/src/components/GameSession.tsx
+++ b/front-end/src/components/GameSession.tsx
@@ -20,6 +20,7 @@ import { isErrorSettlementOutcome } from '../lib/settlement';
 import {
   channelStateNeedsGameTabAttention,
   gameplayEventNeedsGameTabAttention,
+  peerProposalIdNeedsGameTabAttention,
 } from '../lib/gameTabAttention';
 import {
   DEFAULT_GAME_TIMEOUT_BLOCKS,
@@ -895,6 +896,19 @@ const GameSession: React.FC<GameSessionProps> = ({ params, peerConn, registerMes
       onGameActivity?.();
     }
   }, [session.betweenHandMode, onGameActivity]);
+
+  // Rising edge: proposal cached in decision mode, or replaced while reviewing.
+  // Combined id so promoting cache → review does not double-fire.
+  const attentionProposalId =
+    session.reviewPeerProposal?.id ?? session.cachedPeerProposal?.id ?? null;
+  const prevAttentionProposalId = useRef(attentionProposalId);
+  useEffect(() => {
+    const prev = prevAttentionProposalId.current;
+    prevAttentionProposalId.current = attentionProposalId;
+    if (peerProposalIdNeedsGameTabAttention(prev, attentionProposalId)) {
+      onGameActivity?.();
+    }
+  }, [attentionProposalId, onGameActivity]);
 
   // Rising edge: clean shutdown / going on-chain begins (skip restore and
   // transitions between already-attention channel states).

--- a/front-end/src/components/GameSession.tsx
+++ b/front-end/src/components/GameSession.tsx
@@ -18,6 +18,10 @@ import Krunk from './Krunk';
 import { GAME_REGISTRY, gameDisplayName } from '../lib/gameRegistry';
 import { isErrorSettlementOutcome } from '../lib/settlement';
 import {
+  channelStateNeedsGameTabAttention,
+  gameplayEventNeedsGameTabAttention,
+} from '../lib/gameTabAttention';
+import {
   DEFAULT_GAME_TIMEOUT_BLOCKS,
   selectComposeAmountAfterGameTypeChoice,
   selectHideGameInterfaceForBetweenHandDialog,
@@ -862,7 +866,7 @@ const GameSession: React.FC<GameSessionProps> = ({ params, peerConn, registerMes
   useEffect(() => {
     if (!onGameActivity) return;
     const sub = session.gameplayEvent$.subscribe((evt) => {
-      if ('OpponentMoved' in evt || 'ProposalAccepted' in evt) {
+      if (gameplayEventNeedsGameTabAttention(evt)) {
         onGameActivity();
       }
     });
@@ -878,6 +882,33 @@ const GameSession: React.FC<GameSessionProps> = ({ params, peerConn, registerMes
     prevChannelQueueLen.current = session.channelQueue.length;
     if (grew) onGameActivity?.();
   }, [session.gameQueue.length, session.channelQueue.length, onGameActivity]);
+
+  // Rising edge: peer hand proposal enters review (skip restore/hydration).
+  const prevBetweenHandMode = useRef(session.betweenHandMode);
+  useEffect(() => {
+    const prev = prevBetweenHandMode.current;
+    prevBetweenHandMode.current = session.betweenHandMode;
+    if (
+      session.betweenHandMode === 'review-incoming-proposal'
+      && prev !== 'review-incoming-proposal'
+    ) {
+      onGameActivity?.();
+    }
+  }, [session.betweenHandMode, onGameActivity]);
+
+  // Rising edge: clean shutdown / going on-chain begins (skip restore and
+  // transitions between already-attention channel states).
+  const prevChannelAttention = useRef(
+    channelStateNeedsGameTabAttention(session.channelStatus.state),
+  );
+  useEffect(() => {
+    const next = channelStateNeedsGameTabAttention(session.channelStatus.state);
+    const prev = prevChannelAttention.current;
+    prevChannelAttention.current = next;
+    if (next && !prev) {
+      onGameActivity?.();
+    }
+  }, [session.channelStatus.state, onGameActivity]);
 
   const channelOverlayBoundsRef = useRef<HTMLDivElement | null>(null);
   const gameAreaRef = useRef<HTMLDivElement | null>(null);

--- a/front-end/src/lib/gameTabAttention.ts
+++ b/front-end/src/lib/gameTabAttention.ts
@@ -1,0 +1,30 @@
+import type { GameplayEvent } from '../hooks/useGameSession';
+import type { ChannelStatus } from '../types/ChiaGaming';
+
+/** Outcomes that mean a voluntary game-level accept (not a hand proposal). */
+const SETTLEMENT_ACCEPT_OUTCOMES = new Set([
+  'accept_settlement',
+  'we_accepted',
+]);
+
+/**
+ * Gameplay events that should set the Game tab unread badge when the user
+ * is on another tab. In-game Message / GameMessage is intentionally excluded.
+ */
+export function gameplayEventNeedsGameTabAttention(evt: GameplayEvent): boolean {
+  if ('OpponentMoved' in evt || 'ProposalAccepted' in evt) return true;
+  if ('Settled' in evt) {
+    return SETTLEMENT_ACCEPT_OUTCOMES.has(evt.Settled.outcome);
+  }
+  return false;
+}
+
+/** Channel states that should set the Game tab unread badge (rising edge). */
+export function channelStateNeedsGameTabAttention(state: ChannelStatus): boolean {
+  return (
+    state === 'ShuttingDown'
+    || state === 'ShutdownTransactionPending'
+    || state === 'GoingOnChain'
+    || state === 'Unrolling'
+  );
+}

--- a/front-end/src/lib/gameTabAttention.ts
+++ b/front-end/src/lib/gameTabAttention.ts
@@ -28,3 +28,16 @@ export function channelStateNeedsGameTabAttention(state: ChannelStatus): boolean
     || state === 'Unrolling'
   );
 }
+
+/**
+ * True when a peer hand proposal id newly appears or is replaced.
+ * Used for both decision-mode cache and review-mode proposals so a user on
+ * another tab is notified even when betweenHandMode does not change.
+ * Clearing (non-null → null) and restore/hydration (same id) do not fire.
+ */
+export function peerProposalIdNeedsGameTabAttention(
+  prevId: string | null,
+  nextId: string | null,
+): boolean {
+  return nextId != null && nextId !== prevId;
+}

--- a/front-end/src/lib/tests/game_tab_attention.test.ts
+++ b/front-end/src/lib/tests/game_tab_attention.test.ts
@@ -1,0 +1,50 @@
+import {
+  channelStateNeedsGameTabAttention,
+  gameplayEventNeedsGameTabAttention,
+} from '../gameTabAttention';
+import type { GameplayEvent } from '../../hooks/useGameSession';
+
+describe('gameTabAttention', () => {
+  it('marks opponent moves and proposal accepts as attention', () => {
+    expect(gameplayEventNeedsGameTabAttention({
+      OpponentMoved: { readable: new Uint8Array([1]), moverShare: '0' },
+    })).toBe(true);
+    expect(gameplayEventNeedsGameTabAttention({
+      ProposalAccepted: { id: '1' },
+    })).toBe(true);
+  });
+
+  it('marks settlement accepts as attention', () => {
+    expect(gameplayEventNeedsGameTabAttention({
+      Settled: { gameId: '1', outcome: 'accept_settlement', ourShare: '50' },
+    })).toBe(true);
+    expect(gameplayEventNeedsGameTabAttention({
+      Settled: { gameId: '1', outcome: 'we_accepted', ourShare: '50' },
+    })).toBe(true);
+  });
+
+  it('skips GameMessage and non-accept settlements', () => {
+    expect(gameplayEventNeedsGameTabAttention({
+      GameMessage: { readable: new Uint8Array([1]), gameId: '1' },
+    })).toBe(false);
+    expect(gameplayEventNeedsGameTabAttention({
+      Settled: { gameId: '1', outcome: 'settled_cleanly', ourShare: '50' },
+    })).toBe(false);
+    expect(gameplayEventNeedsGameTabAttention({
+      Settled: { gameId: '1', outcome: 'opponent_timed_out', ourShare: '50' },
+    })).toBe(false);
+    const moveRejected: GameplayEvent = {
+      MoveRejected: { gameId: '1', tag: 'x', message: 'nope' },
+    };
+    expect(gameplayEventNeedsGameTabAttention(moveRejected)).toBe(false);
+  });
+
+  it('marks shutdown and on-chain channel states as attention', () => {
+    expect(channelStateNeedsGameTabAttention('ShuttingDown')).toBe(true);
+    expect(channelStateNeedsGameTabAttention('ShutdownTransactionPending')).toBe(true);
+    expect(channelStateNeedsGameTabAttention('GoingOnChain')).toBe(true);
+    expect(channelStateNeedsGameTabAttention('Unrolling')).toBe(true);
+    expect(channelStateNeedsGameTabAttention('Active')).toBe(false);
+    expect(channelStateNeedsGameTabAttention('ResolvedClean')).toBe(false);
+  });
+});

--- a/front-end/src/lib/tests/game_tab_attention.test.ts
+++ b/front-end/src/lib/tests/game_tab_attention.test.ts
@@ -1,6 +1,7 @@
 import {
   channelStateNeedsGameTabAttention,
   gameplayEventNeedsGameTabAttention,
+  peerProposalIdNeedsGameTabAttention,
 } from '../gameTabAttention';
 import type { GameplayEvent } from '../../hooks/useGameSession';
 
@@ -46,5 +47,13 @@ describe('gameTabAttention', () => {
     expect(channelStateNeedsGameTabAttention('Unrolling')).toBe(true);
     expect(channelStateNeedsGameTabAttention('Active')).toBe(false);
     expect(channelStateNeedsGameTabAttention('ResolvedClean')).toBe(false);
+  });
+
+  it('marks new or replaced peer proposal ids as attention', () => {
+    expect(peerProposalIdNeedsGameTabAttention(null, '5')).toBe(true);
+    expect(peerProposalIdNeedsGameTabAttention('5', '7')).toBe(true);
+    expect(peerProposalIdNeedsGameTabAttention('5', '5')).toBe(false);
+    expect(peerProposalIdNeedsGameTabAttention('5', null)).toBe(false);
+    expect(peerProposalIdNeedsGameTabAttention(null, null)).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only notification logic with explicit exclusions and edge-triggered effects; no security or persistence changes.
> 
> **Overview**
> Refines when the **Game tab unread badge** fires by centralizing rules in `gameTabAttention` and wiring **rising-edge** listeners in `GameSession` so restore/hydration and duplicate state updates do not spam notifications.
> 
> **Gameplay events:** `onGameActivity` now uses `gameplayEventNeedsGameTabAttention`, which still counts opponent moves and proposal accepts but also **voluntary settlement accepts** (`accept_settlement`, `we_accepted`). **In-game `GameMessage`**, move rejections, and other settlement outcomes no longer trigger the badge.
> 
> **New attention sources:** entering `review-incoming-proposal`, a **new or replaced** cached/review peer hand proposal id (without double-firing when cache promotes to review), and the first transition into shutdown/on-chain channel states (`ShuttingDown`, `ShutdownTransactionPending`, `GoingOnChain`, `Unrolling`). Queue growth behavior is unchanged.
> 
> Unit tests cover the helper predicates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df0bd2a5c8d1e644d2bd07b1cc1333bc388dd8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->