### PR TITLE
Notify when claiming an opponent timeout

### DIFF
--- a/front-end/src/hooks/useGameSession.ts
+++ b/front-end/src/hooks/useGameSession.ts
@@ -222,7 +222,7 @@ export function enqueueWasmNotification(
     .then(() => handleNotification(notification))
     .catch(onError);
 }
-export type GameTurnState = 'my-turn' | 'their-turn' | 'playing-on-chain' | 'replaying' | 'opponent-illegal-move' | 'finishing' | 'ended';
+export type GameTurnState = 'my-turn' | 'their-turn' | 'playing-on-chain' | 'replaying' | 'opponent-illegal-move' | 'submitting-timeout' | 'finishing' | 'ended';
 
 export interface GameCoinInfo {
   coinHex: string | null;
@@ -1642,6 +1642,7 @@ export function useGameSession(
 
       const statusId = String(gs.id);
       const hasNewCoinIdentity = gs.coin_id != null;
+      const submittingTimeoutClaim = gs.other_params?.submitting_timeout_claim === true;
       const finishing = isFinishingGameStatus(
         status,
         gs.other_params?.game_finished,
@@ -1673,11 +1674,15 @@ export function useGameSession(
             ...instance,
             coin: {
               ...coinIdentity,
-              turnState: finishing ? 'finishing' : 'their-turn',
+              turnState: finishing
+                ? 'finishing'
+                : submittingTimeoutClaim ? 'submitting-timeout' : 'their-turn',
             },
             handStatus: finishing
               ? 'finishing'
-              : status === 'on-chain-their-turn' ? 'their-turn' : 'active',
+              : submittingTimeoutClaim
+                ? 'submitting-timeout'
+                : status === 'on-chain-their-turn' ? 'their-turn' : 'active',
           };
         }
         if (status === 'replaying') {
@@ -1747,12 +1752,14 @@ export function useGameSession(
           }));
           setHandStatus('finishing');
         } else {
-          turnStateRef.current = 'their-turn';
+          turnStateRef.current = submittingTimeoutClaim ? 'submitting-timeout' : 'their-turn';
           setGameCoin(prev => ({
             ...gameCoinIdentityForGameStatus(prev, status, hasNewCoinIdentity),
-            turnState: 'their-turn',
+            turnState: submittingTimeoutClaim ? 'submitting-timeout' : 'their-turn',
           }));
-          setHandStatus(status === 'on-chain-their-turn' ? 'their-turn' : 'active');
+          setHandStatus(submittingTimeoutClaim
+            ? 'submitting-timeout'
+            : status === 'on-chain-their-turn' ? 'their-turn' : 'active');
         }
       } else if (status === 'replaying') {
         turnStateRef.current = 'replaying';

--- a/front-end/src/lib/session/model.ts
+++ b/front-end/src/lib/session/model.ts
@@ -24,6 +24,7 @@ export type GameTurnState =
   | 'playing-on-chain'
   | 'replaying'
   | 'opponent-illegal-move'
+  | 'submitting-timeout'
   | 'finishing'
   | 'ended';
 
@@ -35,6 +36,7 @@ export type HandStatus =
   | 'playing-move'
   | 'replaying-move'
   | 'slashing'
+  | 'submitting-timeout'
   | 'finishing'
   | 'ended';
 
@@ -426,6 +428,7 @@ const HAND_STATUS_LABELS: Record<HandStatus, string> = {
   'playing-move': 'Playing move',
   'replaying-move': 'Replaying move',
   slashing: 'Slashing cheater',
+  'submitting-timeout': 'Submitting timeout claim',
   finishing: 'Finishing',
   ended: 'Ended',
 };
@@ -727,6 +730,8 @@ function selectHandStatus(model: SessionModel): HandStatus {
       // the slash; surface that explicitly rather than a generic "our turn".
       case 'opponent-illegal-move':
         return 'slashing';
+      case 'submitting-timeout':
+        return 'submitting-timeout';
       case 'their-turn':
         return 'their-turn';
       case 'playing-on-chain':

--- a/front-end/src/lib/tests/session_model.test.ts
+++ b/front-end/src/lib/tests/session_model.test.ts
@@ -370,6 +370,14 @@ describe('session model selectors', () => {
         coin: { coinHex: null, onChain: true, turnState: 'replaying' },
       },
     })).handStatusLabel).toBe('Replaying move');
+
+    expect(selectGameDashboardView(createSessionModel({
+      channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'ResolvedUnrolled' } },
+      game: {
+        activeIds: ['7'],
+        coin: { coinHex: null, onChain: true, turnState: 'submitting-timeout' },
+      },
+    })).handStatusLabel).toBe('Submitting timeout claim');
   });
 
   it('waits for terminal reward enrichment before terminal channel teardown', async () => {

--- a/front-end/src/types/ChiaGaming.ts
+++ b/front-end/src/types/ChiaGaming.ts
@@ -135,6 +135,7 @@ interface GameStatusOtherParams {
   illegal_move_detected?: boolean;
   moved_by_us?: boolean;
   game_finished?: boolean;
+  submitting_timeout_claim?: boolean;
 }
 
 export interface GameStatusPayload {

--- a/src/game_session.rs
+++ b/src/game_session.rs
@@ -1020,15 +1020,12 @@ impl GameSession {
                     .peer
                     .as_any_mut()
                     .downcast_mut::<crate::session_phases::on_chain::OnChainPhase>()
-                    .ok_or_else(|| {
-                        Error::StrErr(
-                            "game timeout claim submitted outside the on-chain phase".to_string(),
-                        )
-                    })?
-                    .timeout_claim_status(id, true)?;
-                self.state
-                    .events
-                    .push_back(GameSessionEvent::Notification(notification));
+                    .and_then(|phase| phase.timeout_claim_status(id, true));
+                if let Some(notification) = notification {
+                    self.state
+                        .events
+                        .push_back(GameSessionEvent::Notification(notification));
+                }
             }
         }
         Ok(())
@@ -1056,15 +1053,12 @@ impl GameSession {
                     .peer
                     .as_any_mut()
                     .downcast_mut::<crate::session_phases::on_chain::OnChainPhase>()
-                    .ok_or_else(|| {
-                        Error::StrErr(
-                            "game timeout claim rearmed outside the on-chain phase".to_string(),
-                        )
-                    })?
-                    .timeout_claim_status(id, false)?;
-                self.state
-                    .events
-                    .push_back(GameSessionEvent::Notification(notification));
+                    .and_then(|phase| phase.timeout_claim_status(id, false));
+                if let Some(notification) = notification {
+                    self.state
+                        .events
+                        .push_back(GameSessionEvent::Notification(notification));
+                }
             }
         }
         Ok(())

--- a/src/game_session.rs
+++ b/src/game_session.rs
@@ -1004,13 +1004,32 @@ impl GameSession {
     ) -> Result<(), Error> {
         use crate::session_phases::spend_channel_coin_phase::SpendChannelCoinPhase;
 
-        let changed = self
-            .peer
-            .as_any_mut()
-            .downcast_mut::<SpendChannelCoinPhase>()
-            .is_some_and(|phase| phase.timeout_claim_submitted(semantic));
-        if changed {
-            self.emit_channel_status_if_changed();
+        match semantic {
+            TimeoutClaimSemantic::ChannelTimeoutFinish => {
+                let changed = self
+                    .peer
+                    .as_any_mut()
+                    .downcast_mut::<SpendChannelCoinPhase>()
+                    .is_some_and(|phase| phase.timeout_claim_submitted(semantic));
+                if changed {
+                    self.emit_channel_status_if_changed();
+                }
+            }
+            TimeoutClaimSemantic::GameOpponentTurn { id } => {
+                let notification = self
+                    .peer
+                    .as_any_mut()
+                    .downcast_mut::<crate::session_phases::on_chain::OnChainPhase>()
+                    .ok_or_else(|| {
+                        Error::StrErr(
+                            "game timeout claim submitted outside the on-chain phase".to_string(),
+                        )
+                    })?
+                    .timeout_claim_status(id, true)?;
+                self.state
+                    .events
+                    .push_back(GameSessionEvent::Notification(notification));
+            }
         }
         Ok(())
     }
@@ -1021,13 +1040,32 @@ impl GameSession {
     ) -> Result<(), Error> {
         use crate::session_phases::spend_channel_coin_phase::SpendChannelCoinPhase;
 
-        let changed = self
-            .peer
-            .as_any_mut()
-            .downcast_mut::<SpendChannelCoinPhase>()
-            .is_some_and(|phase| phase.timeout_claim_rearmed(semantic));
-        if changed {
-            self.emit_channel_status_if_changed();
+        match semantic {
+            TimeoutClaimSemantic::ChannelTimeoutFinish => {
+                let changed = self
+                    .peer
+                    .as_any_mut()
+                    .downcast_mut::<SpendChannelCoinPhase>()
+                    .is_some_and(|phase| phase.timeout_claim_rearmed(semantic));
+                if changed {
+                    self.emit_channel_status_if_changed();
+                }
+            }
+            TimeoutClaimSemantic::GameOpponentTurn { id } => {
+                let notification = self
+                    .peer
+                    .as_any_mut()
+                    .downcast_mut::<crate::session_phases::on_chain::OnChainPhase>()
+                    .ok_or_else(|| {
+                        Error::StrErr(
+                            "game timeout claim rearmed outside the on-chain phase".to_string(),
+                        )
+                    })?
+                    .timeout_claim_status(id, false)?;
+                self.state
+                    .events
+                    .push_back(GameSessionEvent::Notification(notification));
+            }
         }
         Ok(())
     }

--- a/src/session_phases/effects.rs
+++ b/src/session_phases/effects.rs
@@ -94,12 +94,10 @@ pub enum ChannelSemanticPhase {
 }
 
 /// Context for a timeout spend that the transaction manager has submitted.
-///
-/// This is intentionally limited to the channel timeout finish: game timeout
-/// progress continues to be represented by the existing game-status protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TimeoutClaimSemantic {
     ChannelTimeoutFinish,
+    GameOpponentTurn { id: GameID },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -163,6 +161,8 @@ pub struct GameStatusOtherParams {
     pub game_finished: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub forfeited: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub submitting_timeout_claim: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/session_phases/mod.rs
+++ b/src/session_phases/mod.rs
@@ -590,6 +590,7 @@ impl OffChainPhase {
                         moved_by_us: None,
                         game_finished: None,
                         forfeited: None,
+                        submitting_timeout_claim: None,
                     }),
                 }));
             }
@@ -778,6 +779,7 @@ impl OffChainPhase {
                             moved_by_us: None,
                             game_finished: if finished { Some(true) } else { None },
                             forfeited: None,
+                            submitting_timeout_claim: None,
                         }),
                     }));
                     if !move_result.message.is_empty() {

--- a/src/session_phases/on_chain.rs
+++ b/src/session_phases/on_chain.rs
@@ -550,24 +550,15 @@ impl OnChainPhase {
         &self,
         game_id: GameID,
         submitting_timeout_claim: bool,
-    ) -> Result<GameNotification, Error> {
+    ) -> Option<GameNotification> {
         let (coin, state) = self
             .game_map
             .iter()
-            .find(|(_, state)| state.game_id == game_id)
-            .ok_or_else(|| {
-                Error::StrErr(format!(
-                    "timeout claim status: no on-chain game for {:?}",
-                    game_id
-                ))
-            })?;
+            .find(|(_, state)| state.game_id == game_id)?;
         if state.our_turn || state.game_finished {
-            return Err(Error::StrErr(format!(
-                "timeout claim status: game {:?} is not awaiting an opponent timeout",
-                game_id
-            )));
+            return None;
         }
-        Ok(GameNotification::GameStatus {
+        Some(GameNotification::GameStatus {
             id: game_id,
             status: GameStatusKind::OnChainTheirTurn,
             my_reward: None,

--- a/src/session_phases/on_chain.rs
+++ b/src/session_phases/on_chain.rs
@@ -575,11 +575,7 @@ impl OnChainPhase {
                 timeout: gt,
                 name: Some("game coin"),
                 spend: claim,
-                semantic: Self::opponent_timeout_claim_semantic(
-                    game_id,
-                    our_turn,
-                    game_finished,
-                ),
+                semantic: Self::opponent_timeout_claim_semantic(game_id, our_turn, game_finished),
             });
         }
         Ok(effects)
@@ -1077,9 +1073,7 @@ impl OnChainPhase {
                         }),
                         spend: claim,
                         semantic: Self::opponent_timeout_claim_semantic(
-                            game_id,
-                            is_my_turn,
-                            terminal,
+                            game_id, is_my_turn, terminal,
                         ),
                     });
                     if auto_settle {

--- a/src/session_phases/on_chain.rs
+++ b/src/session_phases/on_chain.rs
@@ -546,6 +546,40 @@ impl OnChainPhase {
             .then_some(TimeoutClaimSemantic::GameOpponentTurn { id: game_id })
     }
 
+    pub fn timeout_claim_status(
+        &self,
+        game_id: GameID,
+        submitting_timeout_claim: bool,
+    ) -> Result<GameNotification, Error> {
+        let (coin, state) = self
+            .game_map
+            .iter()
+            .find(|(_, state)| state.game_id == game_id)
+            .ok_or_else(|| {
+                Error::StrErr(format!(
+                    "timeout claim status: no on-chain game for {:?}",
+                    game_id
+                ))
+            })?;
+        if state.our_turn || state.game_finished {
+            return Err(Error::StrErr(format!(
+                "timeout claim status: game {:?} is not awaiting an opponent timeout",
+                game_id
+            )));
+        }
+        Ok(GameNotification::GameStatus {
+            id: game_id,
+            status: GameStatusKind::OnChainTheirTurn,
+            my_reward: None,
+            coin_id: Some(coin.clone()),
+            reason: None,
+            other_params: Some(GameStatusOtherParams {
+                submitting_timeout_claim: Some(submitting_timeout_claim),
+                ..Default::default()
+            }),
+        })
+    }
+
     /// Register every current game coin with the wallet, attaching an eager
     /// timeout claim for each coin we are entitled to claim on timeout.  Used
     /// when first transitioning to on-chain play so the transaction manager owns
@@ -665,6 +699,7 @@ impl OnChainPhase {
                             moved_by_us: Some(true),
                             game_finished: if game_over { Some(true) } else { None },
                             forfeited: None,
+                            submitting_timeout_claim: None,
                         }),
                     }));
                     let claim = self.build_timeout_claim(env, &pending.game_id, &new_coin)?;
@@ -1220,6 +1255,7 @@ impl OnChainPhase {
                             moved_by_us: None,
                             game_finished: finished_flag,
                             forfeited: None,
+                            submitting_timeout_claim: None,
                         }),
                     }));
 
@@ -1236,6 +1272,7 @@ impl OnChainPhase {
                             moved_by_us: None,
                             game_finished: finished_flag,
                             forfeited: None,
+                            submitting_timeout_claim: None,
                         }),
                     }));
                     let claim = self.build_timeout_claim(env, &game_id, &new_coin_string)?;
@@ -1293,6 +1330,7 @@ impl OnChainPhase {
                                 moved_by_us: None,
                                 game_finished: None,
                                 forfeited: None,
+                                submitting_timeout_claim: None,
                             }),
                         }));
                         self.game_map.insert(
@@ -1326,6 +1364,7 @@ impl OnChainPhase {
                                 moved_by_us: None,
                                 game_finished: None,
                                 forfeited: None,
+                                submitting_timeout_claim: None,
                             }),
                         }));
                         if let Some(eff) = self.try_emit_terminal(

--- a/src/session_phases/on_chain.rs
+++ b/src/session_phases/on_chain.rs
@@ -908,7 +908,7 @@ impl OnChainPhase {
                             spend: claim,
                             semantic: Self::opponent_timeout_claim_semantic(
                                 old_definition.game_id,
-                                old_definition.our_turn,
+                                !old_definition.our_turn,
                                 old_definition.game_finished,
                             ),
                         });

--- a/src/session_phases/on_chain.rs
+++ b/src/session_phases/on_chain.rs
@@ -18,7 +18,7 @@ use crate::referee::types::{
 use crate::referee::Referee;
 use crate::session_phases::effects::{
     format_coin, ChannelStatus, ChannelStatusSnapshot, CoinOfInterest, Effect, GameNotification,
-    GameStatusKind, GameStatusOtherParams, ResyncInfo, SettlementOutcome,
+    GameStatusKind, GameStatusOtherParams, ResyncInfo, SettlementOutcome, TimeoutClaimSemantic,
 };
 use crate::session_phases::types::{GameAction, PotatoState};
 
@@ -537,6 +537,15 @@ impl OnChainPhase {
         }))
     }
 
+    fn opponent_timeout_claim_semantic(
+        game_id: GameID,
+        our_turn: bool,
+        game_finished: bool,
+    ) -> Option<TimeoutClaimSemantic> {
+        (!our_turn && !game_finished)
+            .then_some(TimeoutClaimSemantic::GameOpponentTurn { id: game_id })
+    }
+
     /// Register every current game coin with the wallet, attaching an eager
     /// timeout claim for each coin we are entitled to claim on timeout.  Used
     /// when first transitioning to on-chain play so the transaction manager owns
@@ -545,20 +554,32 @@ impl OnChainPhase {
         &mut self,
         env: &mut ChannelEnv<'_>,
     ) -> Result<Vec<Effect>, Error> {
-        let coins: Vec<(CoinString, GameID, Timeout)> = self
+        let coins: Vec<(CoinString, GameID, Timeout, bool, bool)> = self
             .game_map
             .iter()
-            .map(|(coin, st)| (coin.clone(), st.game_id, st.game_timeout.clone()))
+            .map(|(coin, st)| {
+                (
+                    coin.clone(),
+                    st.game_id,
+                    st.game_timeout.clone(),
+                    st.our_turn,
+                    st.game_finished,
+                )
+            })
             .collect();
         let mut effects = Vec::new();
-        for (coin, game_id, gt) in coins {
+        for (coin, game_id, gt, our_turn, game_finished) in coins {
             let claim = self.build_timeout_claim(env, &game_id, &coin)?;
             effects.push(Effect::RegisterCoin {
                 coin,
                 timeout: gt,
                 name: Some("game coin"),
                 spend: claim,
-                semantic: None,
+                semantic: Self::opponent_timeout_claim_semantic(
+                    game_id,
+                    our_turn,
+                    game_finished,
+                ),
             });
         }
         Ok(effects)
@@ -656,7 +677,11 @@ impl OnChainPhase {
                         timeout: gt,
                         name: Some("our on-chain move confirmed"),
                         spend: claim,
-                        semantic: None,
+                        semantic: Self::opponent_timeout_claim_semantic(
+                            pending.game_id,
+                            false,
+                            game_over,
+                        ),
                     });
                     effects.extend(self.process_queued_action(env)?);
                     return Ok((effects, None));
@@ -885,7 +910,11 @@ impl OnChainPhase {
                             timeout: gt,
                             name: Some("timeout-claim-armed game coin advanced by redo"),
                             spend: claim,
-                            semantic: None,
+                            semantic: Self::opponent_timeout_claim_semantic(
+                                old_definition.game_id,
+                                old_definition.our_turn,
+                                old_definition.game_finished,
+                            ),
                         });
                     }
                 }
@@ -1047,7 +1076,11 @@ impl OnChainPhase {
                             "expected spend - their turn"
                         }),
                         spend: claim,
-                        semantic: None,
+                        semantic: Self::opponent_timeout_claim_semantic(
+                            game_id,
+                            is_my_turn,
+                            terminal,
+                        ),
                     });
                     if auto_settle {
                         self.game_action_queue

--- a/src/simulator/tests/session_phases_sim.rs
+++ b/src/simulator/tests/session_phases_sim.rs
@@ -268,6 +268,7 @@ pub enum ExpectedNotification {
     GameSettledOpponentCheated,
     GameStatusMovedByUs,
     GameStatusOnChainTurn,
+    GameStatusSubmittingTimeoutClaim,
     GameStatusEndedError,
     ProposalMade,
     ProposalAccepted,
@@ -415,6 +416,14 @@ fn event_matches(actual: &TestEvent, expected: &ExpectedEvent) -> bool {
                 ) => true,
                 (
                     GameNotification::GameStatus {
+                        status: GameStatusKind::OnChainTheirTurn,
+                        other_params: Some(params),
+                        ..
+                    },
+                    ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                ) => params.submitting_timeout_claim == Some(true),
+                (
+                    GameNotification::GameStatus {
                         status: GameStatusKind::EndedError,
                         ..
                     },
@@ -506,6 +515,9 @@ fn expected_shape(expected: &ExpectedEvent) -> String {
             ExpectedNotification::GameStatusMovedByUs => "Notif(GameStatusMovedByUs)".to_string(),
             ExpectedNotification::GameStatusOnChainTurn => {
                 "Notif(GameStatusOnChainTurn)".to_string()
+            }
+            ExpectedNotification::GameStatusSubmittingTimeoutClaim => {
+                "Notif(GameStatusSubmittingTimeoutClaim)".to_string()
             }
             ExpectedNotification::GameStatusEndedError => "Notif(GameStatusEndedError)".to_string(),
             ExpectedNotification::ProposalMade => "Notif(ProposalMade)".to_string(),
@@ -2992,6 +3004,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                     // step e so Bob never sees her final move.  Alice times out.
                     ExpectedEvent::Notification(ExpectedNotification::GameStatusMovedByUs),
                     ExpectedEvent::Notification(ExpectedNotification::GameStatusMovedByUs),
+                    ExpectedEvent::Notification(
+                        ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                    ),
                     ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
                 ],
                 "piss_off_complete p1",
@@ -3091,6 +3106,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                     ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(
                         ChannelStatus::ResolvedUnrolled,
                     )),
+                    ExpectedEvent::Notification(
+                        ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                    ),
                     ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
                 ],
                 "after_start p1",
@@ -3226,6 +3244,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                     ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(
                         ChannelStatus::ResolvedUnrolled,
                     )),
+                    ExpectedEvent::Notification(
+                        ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                    ),
                     ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
                 ],
                 "timeout p0",
@@ -4199,6 +4220,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(
                     ChannelStatus::ResolvedUnrolled,
                 )),
+                ExpectedEvent::Notification(
+                    ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                ),
                 ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
             ],
             "redo_timeout p1",
@@ -4280,6 +4304,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(ChannelStatus::ResolvedUnrolled)),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusOnChainTurn),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusMovedByUs),
+                ExpectedEvent::Notification(
+                    ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                ),
                 ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
             ], "bob_redo_alice_timeout p1");
         },
@@ -4341,6 +4368,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(
                     ChannelStatus::ResolvedUnrolled,
                 )),
+                ExpectedEvent::Notification(
+                    ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                ),
                 ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
             ],
             "our_turn_timeout p0",
@@ -4739,6 +4769,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(ChannelStatus::ResolvedUnrolled)),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusOnChainTurn),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusMovedByUs),
+                ExpectedEvent::Notification(
+                    ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                ),
                 ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
             ], "nerfed_cheat p1");
         },
@@ -4822,6 +4855,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 )),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusOnChainTurn),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusMovedByUs),
+                ExpectedEvent::Notification(
+                    ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                ),
                 ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
             ],
             "accept_finished p1",
@@ -4930,6 +4966,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(ChannelStatus::Unrolling)),
             ExpectedEvent::Notification(ExpectedNotification::GameStatusOnChainTurn),
             ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(ChannelStatus::ResolvedUnrolled)),
+            ExpectedEvent::Notification(
+                ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+            ),
             ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
         ], "nerfed_accept p0");
         assert_event_sequence(&outcome.local_uis[1].events, &[
@@ -5087,6 +5126,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(
                     ChannelStatus::ResolvedUnrolled,
                 )),
+                ExpectedEvent::Notification(
+                    ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                ),
                 ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
             ],
             "before_any_moves p1",
@@ -5161,6 +5203,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(ChannelStatus::ResolvedUnrolled)),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusOnChainTurn),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusMovedByUs),
+                ExpectedEvent::Notification(
+                    ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                ),
                 ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
             ], "opp_cheated p1");
         },
@@ -5746,6 +5791,9 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 )),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusOnChainTurn),
                 ExpectedEvent::Notification(ExpectedNotification::GameStatusMovedByUs),
+                ExpectedEvent::Notification(
+                    ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                ),
                 ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
             ],
             "go_on_chain_then_move p0",

--- a/src/test_support/calpoker_sim.rs
+++ b/src/test_support/calpoker_sim.rs
@@ -599,6 +599,9 @@ mod sim_tests {
                     ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(
                         ChannelStatus::ResolvedUnrolled,
                     )),
+                    ExpectedEvent::Notification(
+                        ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                    ),
                     ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
                 ],
                 "on_chain_1move_p1 p0",
@@ -657,6 +660,9 @@ mod sim_tests {
                         ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(
                             ChannelStatus::ResolvedUnrolled,
                         )),
+                        ExpectedEvent::Notification(
+                            ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                        ),
                         ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
                     ],
                     "on_chain_1move_p0_lost p0",
@@ -712,6 +718,9 @@ mod sim_tests {
                     ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(
                         ChannelStatus::ResolvedUnrolled,
                     )),
+                    ExpectedEvent::Notification(
+                        ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                    ),
                     ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
                 ],
                 "on_chain_1move_p0 p0",
@@ -794,6 +803,9 @@ mod sim_tests {
                     )),
                     ExpectedEvent::Notification(ExpectedNotification::GameStatusOnChainTurn),
                     ExpectedEvent::Notification(ExpectedNotification::GameStatusMovedByUs),
+                    ExpectedEvent::Notification(
+                        ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                    ),
                     ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
                 ],
                 "on_chain_2moves_p0 p1",
@@ -851,6 +863,9 @@ mod sim_tests {
                     ExpectedEvent::Notification(ExpectedNotification::ChannelStatus(
                         ChannelStatus::ResolvedUnrolled,
                     )),
+                    ExpectedEvent::Notification(
+                        ExpectedNotification::GameStatusSubmittingTimeoutClaim,
+                    ),
                     ExpectedEvent::Notification(ExpectedNotification::GameSettledOpponentSide),
                 ],
                 "on_chain_2moves_p1 p1",

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -949,7 +949,7 @@ mod tests {
     use crate::common::types::{
         Amount, CoinID, CoinSpend, Hash, Program, Puzzle, PuzzleHash, Spend, ToQuotedProgram,
     };
-    use crate::session_phases::effects::GameSessionEvent;
+    use crate::session_phases::effects::{GameSessionEvent, TimeoutClaimSemantic};
     use clvm_traits::ToClvm;
 
     fn test_coin(tag: u8) -> CoinString {
@@ -1139,6 +1139,21 @@ mod tests {
             timeout: Timeout::new(timeout),
             spend: Some(spend),
             semantic: None,
+        }
+    }
+
+    fn watch_event_with_timeout_semantic(
+        coin: &CoinString,
+        timeout: u64,
+        spend: SpendBundle,
+        semantic: TimeoutClaimSemantic,
+    ) -> GameSessionEvent {
+        GameSessionEvent::WatchCoin {
+            coin_name: coin.to_coin_id(),
+            coin_string: coin.clone(),
+            timeout: Timeout::new(timeout),
+            spend: Some(spend),
+            semantic: Some(semantic),
         }
     }
 
@@ -1675,6 +1690,41 @@ mod tests {
         mgr.report_coin_states(&mut allocator, 15, &record)
             .expect("re-mature");
         assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn mature_game_timeout_claim_emits_semantic_notification() {
+        let mut allocator = AllocEncoder::new();
+        let coin = test_coin(12);
+        let game_id = crate::common::types::GameID(42);
+        let mut mock = MockGameSession::default();
+        mock.queue_drain(vec![watch_event_with_timeout_semantic(
+            &coin,
+            5,
+            test_bundle("timeout-claim"),
+            TimeoutClaimSemantic::GameOpponentTurn { id: game_id },
+        )]);
+        let mut mgr = TransactionManager::new(mock);
+        mgr.flush_and_collect(&mut allocator).expect("register");
+
+        let live = vec![CoinStateRecord {
+            coin,
+            created_height: Some(10),
+            spent_height: None,
+        }];
+        mgr.report_coin_states(&mut allocator, 15, &live)
+            .expect("mature claim");
+
+        assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
+        let drain = mgr.flush_and_collect(&mut allocator).expect("drain notification");
+        assert!(matches!(
+            drain.events.as_slices(),
+            ([GameSessionEvent::Notification(
+                GameNotification::TimeoutClaimSubmitted(
+                    TimeoutClaimSemantic::GameOpponentTurn { id }
+                )
+            )], []) if *id == game_id
+        ));
     }
 
     #[test]

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -1693,7 +1693,7 @@ mod tests {
     }
 
     #[test]
-    fn mature_game_timeout_claim_emits_semantic_notification() {
+    fn mature_game_timeout_claim_records_game_submission_semantic() {
         let mut allocator = AllocEncoder::new();
         let coin = test_coin(12);
         let game_id = crate::common::types::GameID(42);
@@ -1716,17 +1716,10 @@ mod tests {
             .expect("mature claim");
 
         assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
-        let drain = mgr
-            .flush_and_collect(&mut allocator)
-            .expect("drain notification");
-        assert!(matches!(
-            drain.events.as_slices(),
-            ([GameSessionEvent::Notification(
-                GameNotification::TimeoutClaimSubmitted(
-                    TimeoutClaimSemantic::GameOpponentTurn { id }
-                )
-            )], []) if *id == game_id
-        ));
+        assert_eq!(
+            mgr.cradle().submitted_timeout_claims,
+            vec![TimeoutClaimSemantic::GameOpponentTurn { id: game_id }]
+        );
     }
 
     #[test]

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -1716,7 +1716,9 @@ mod tests {
             .expect("mature claim");
 
         assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
-        let drain = mgr.flush_and_collect(&mut allocator).expect("drain notification");
+        let drain = mgr
+            .flush_and_collect(&mut allocator)
+            .expect("drain notification");
         assert!(matches!(
             drain.events.as_slices(),
             ([GameSessionEvent::Notification(


### PR DESCRIPTION
## Summary
- attach opponent-turn timeout semantics to eligible on-chain game claims
- surface the existing claiming-timeout UI state when the transaction manager submits a mature claim
- cover maturity notification delivery with a transaction-manager test

## Test plan
- [x] ./ct.sh

Made with [Cursor](https://cursor.com)