### PR TITLE
Pause wallet polling while disconnected

### DIFF
--- a/front-end/src/hooks/BlockchainPoller.ts
+++ b/front-end/src/hooks/BlockchainPoller.ts
@@ -56,6 +56,7 @@ export class BlockchainPoller {
   private coinPollingScheduler: AsyncPollingScheduler;
   private balancePollingScheduler: AsyncPollingScheduler;
   private connectionUnsubscribe: (() => void) | null = null;
+  private connectionActive = true;
 
   constructor(blockchain: InternalBlockchainInterface, pollIntervalMs: number, maxBackoffMs?: number) {
     this.adapter = blockchain;
@@ -211,7 +212,7 @@ export class BlockchainPoller {
     this.balanceCallbacks = callbacks;
     this.balancePollIntervalMs = intervalMs;
     this.ensureConnectionListener();
-    if (this.adapter.isConnected()) {
+    if (this.isConnected()) {
       this.balancePollingScheduler.start(intervalMs);
     }
   }
@@ -235,6 +236,7 @@ export class BlockchainPoller {
   private ensureConnectionListener(): void {
     if (this.connectionUnsubscribe) return;
     const unsubscribe = this.adapter.onConnectionChange((connected) => {
+      this.connectionActive = connected;
       if (connected) {
         this.resumePollingIfConnected();
       } else {
@@ -275,7 +277,7 @@ export class BlockchainPoller {
   }
 
   private isConnected(): boolean {
-    return this.adapter.isConnected();
+    return this.connectionActive && this.adapter.isConnected();
   }
 
   /**

--- a/front-end/src/hooks/BlockchainPoller.ts
+++ b/front-end/src/hooks/BlockchainPoller.ts
@@ -154,6 +154,7 @@ export class BlockchainPoller {
             reject(e);
           }
         },
+        onDiscard: () => reject(new Error(`RPC request discarded during disconnect: ${label}`)),
       };
       if (foreground) {
         this.requestLane.enqueueFront(job);
@@ -256,6 +257,10 @@ export class BlockchainPoller {
     this.coinPollingScheduler.stop();
     this.balancePollingScheduler.stop();
     this.requestLane.clearQueued();
+    // Remote wallet coin registrations are lost with the connection. Clear the
+    // local cache even when a reconnect reuses the same registration scope key.
+    this.registrationScopeKey = undefined;
+    this.registeredNames.clear();
   }
 
   private resumePollingIfConnected(): void {

--- a/front-end/src/hooks/BlockchainPoller.ts
+++ b/front-end/src/hooks/BlockchainPoller.ts
@@ -50,10 +50,12 @@ export class BlockchainPoller {
   private previousPeakForCoinReport = 0n;
   private registrationScopeKey: string | undefined;
   private balanceCallbacks: BalanceCallbacks | null = null;
+  private balancePollIntervalMs = BALANCE_POLL_INTERVAL_MS;
   private requestLane: AsyncJobQueue;
   private heightPollingScheduler: AsyncPollingScheduler;
   private coinPollingScheduler: AsyncPollingScheduler;
   private balancePollingScheduler: AsyncPollingScheduler;
+  private connectionUnsubscribe: (() => void) | null = null;
 
   constructor(blockchain: InternalBlockchainInterface, pollIntervalMs: number, maxBackoffMs?: number) {
     this.adapter = blockchain;
@@ -206,12 +208,17 @@ export class BlockchainPoller {
 
   startBalanceInterest(intervalMs: number, callbacks: BalanceCallbacks): void {
     this.balanceCallbacks = callbacks;
-    this.balancePollingScheduler.start(intervalMs);
+    this.balancePollIntervalMs = intervalMs;
+    this.ensureConnectionListener();
+    if (this.adapter.isConnected()) {
+      this.balancePollingScheduler.start(intervalMs);
+    }
   }
 
   stopBalanceInterest(): void {
     this.balancePollingScheduler.stop();
     this.balanceCallbacks = null;
+    this.releaseConnectionListenerIfIdle();
   }
 
   start() {
@@ -220,8 +227,50 @@ export class BlockchainPoller {
     this.firstTick = true;
     this.startedAt = performance.now();
     log(`[blockchain-poller] started, pollMs=${this.pollIntervalMs}`);
-    this.heightPollingScheduler.start(this.pollIntervalMs);
-    this.refreshCoinInterest();
+    this.ensureConnectionListener();
+    this.resumePollingIfConnected();
+  }
+
+  private ensureConnectionListener(): void {
+    if (this.connectionUnsubscribe) return;
+    const unsubscribe = this.adapter.onConnectionChange((connected) => {
+      if (connected) {
+        this.resumePollingIfConnected();
+      } else {
+        this.pausePollingForDisconnect();
+      }
+    });
+    if (typeof unsubscribe === 'function') {
+      this.connectionUnsubscribe = unsubscribe;
+    }
+  }
+
+  private releaseConnectionListenerIfIdle(): void {
+    if (this.running || this.balanceCallbacks || !this.connectionUnsubscribe) return;
+    this.connectionUnsubscribe();
+    this.connectionUnsubscribe = null;
+  }
+
+  private pausePollingForDisconnect(): void {
+    this.heightPollingScheduler.stop();
+    this.coinPollingScheduler.stop();
+    this.balancePollingScheduler.stop();
+    this.requestLane.clearQueued();
+  }
+
+  private resumePollingIfConnected(): void {
+    if (!this.adapter.isConnected()) return;
+    if (this.running) {
+      this.heightPollingScheduler.start(this.pollIntervalMs);
+      this.refreshCoinInterest();
+    }
+    if (this.balanceCallbacks) {
+      this.balancePollingScheduler.start(this.balancePollIntervalMs);
+    }
+  }
+
+  private isConnected(): boolean {
+    return this.adapter.isConnected();
   }
 
   /**
@@ -232,6 +281,7 @@ export class BlockchainPoller {
     this.running = false;
     this.heightPollingScheduler.stop();
     this.coinPollingScheduler.stop();
+    this.releaseConnectionListenerIfIdle();
   }
 
   private collectGameSessionCoins(): Array<{ c: PollingGameSession; coins: CoinPollInterest[] }> {
@@ -239,7 +289,10 @@ export class BlockchainPoller {
   }
 
   private refreshCoinInterest(): void {
-    if (!this.running) return;
+    if (!this.running || !this.isConnected()) {
+      this.coinPollingScheduler.stop();
+      return;
+    }
     const hasCoins = this.collectGameSessionCoins().some(({ coins }) => coins.length > 0);
     if (hasCoins) {
       this.coinPollingScheduler.start(this.pollIntervalMs);
@@ -274,6 +327,7 @@ export class BlockchainPoller {
   }
 
   private async runHeightPoll(): Promise<void> {
+    if (!this.isConnected()) return;
     try {
       // Report the latest height even when it decreases: a drop signals a reorg,
       // which the transaction manager detects via height < last_height. Clamping
@@ -304,6 +358,7 @@ export class BlockchainPoller {
   }
 
   private async runCoinPoll(): Promise<void> {
+    if (!this.isConnected()) return;
     try {
       const perSession = this.collectGameSessionCoins();
 
@@ -334,7 +389,7 @@ export class BlockchainPoller {
   }
 
   private async runBalancePoll(): Promise<void> {
-    if (!this.balanceCallbacks) return;
+    if (!this.balanceCallbacks || !this.isConnected()) return;
     try {
       const balance = await this.adapter.getBalance();
       if (this.balancePollingScheduler.isInterested()) {

--- a/front-end/src/hooks/BlockchainPoller.ts
+++ b/front-end/src/hooks/BlockchainPoller.ts
@@ -57,6 +57,8 @@ export class BlockchainPoller {
   private balancePollingScheduler: AsyncPollingScheduler;
   private connectionUnsubscribe: (() => void) | null = null;
   private connectionActive = true;
+  private connectionEpoch = 0;
+  private pendingRpcRejects = new Set<() => void>();
 
   constructor(blockchain: InternalBlockchainInterface, pollIntervalMs: number, maxBackoffMs?: number) {
     this.adapter = blockchain;
@@ -145,17 +147,39 @@ export class BlockchainPoller {
   }
 
   private enqueueRpc<T>(label: string, run: () => Promise<T> | T, foreground = false): Promise<T> {
+    if (!this.isConnected()) {
+      return Promise.reject(new Error(`RPC request discarded during disconnect: ${label}`));
+    }
+    const connectionEpoch = this.connectionEpoch;
     return new Promise<T>((resolve, reject) => {
+      let settled = false;
+      const rejectForDisconnect = () => settle(reject, new Error(`RPC request discarded during disconnect: ${label}`));
+      const settle = <V>(complete: (value: V) => void, value: V) => {
+        if (settled) return;
+        settled = true;
+        this.pendingRpcRejects.delete(rejectForDisconnect);
+        complete(value);
+      };
+      this.pendingRpcRejects.add(rejectForDisconnect);
       const job: AsyncQueueJob = {
         label,
         run: async () => {
+          if (!this.isConnectionEpochActive(connectionEpoch)) {
+            rejectForDisconnect();
+            return;
+          }
           try {
-            resolve(await run());
+            const result = await run();
+            if (!this.isConnectionEpochActive(connectionEpoch)) {
+              rejectForDisconnect();
+              return;
+            }
+            settle(resolve, result);
           } catch (e) {
-            reject(e);
+            settle(reject, e);
           }
         },
-        onDiscard: () => reject(new Error(`RPC request discarded during disconnect: ${label}`)),
+        onDiscard: rejectForDisconnect,
       };
       if (foreground) {
         this.requestLane.enqueueFront(job);
@@ -255,9 +279,11 @@ export class BlockchainPoller {
   }
 
   private pausePollingForDisconnect(): void {
+    this.connectionEpoch++;
     this.heightPollingScheduler.stop();
     this.coinPollingScheduler.stop();
     this.balancePollingScheduler.stop();
+    for (const reject of [...this.pendingRpcRejects]) reject();
     this.requestLane.clearQueued();
     // Remote wallet coin registrations are lost with the connection. Clear the
     // local cache even when a reconnect reuses the same registration scope key.
@@ -278,6 +304,10 @@ export class BlockchainPoller {
 
   private isConnected(): boolean {
     return this.connectionActive && this.adapter.isConnected();
+  }
+
+  private isConnectionEpochActive(connectionEpoch: number): boolean {
+    return connectionEpoch === this.connectionEpoch && this.isConnected();
   }
 
   /**
@@ -308,14 +338,17 @@ export class BlockchainPoller {
     }
   }
 
-  private async ensureRegistered(names: string[]) {
+  private async ensureRegistered(names: string[], connectionEpoch: number) {
+    if (!this.isConnectionEpochActive(connectionEpoch)) return;
     this.syncRegistrationScope();
     const newNames = names.filter((n) => !this.registeredNames.has(n));
     if (newNames.length === 0) return;
     try {
       await this.adapter.registerCoins(newNames);
+      if (!this.isConnectionEpochActive(connectionEpoch)) return;
       for (const n of newNames) this.registeredNames.add(n);
     } catch (e) {
+      if (!this.isConnectionEpochActive(connectionEpoch)) return;
       // Leave unregistered so the next tick retries.
       log(`[blockchain-poller] registerCoins failed, will retry: ${String(e)}`);
     }
@@ -334,13 +367,15 @@ export class BlockchainPoller {
   }
 
   private async runHeightPoll(): Promise<void> {
-    if (!this.isConnected()) return;
+    const connectionEpoch = this.connectionEpoch;
+    if (!this.isConnectionEpochActive(connectionEpoch)) return;
     try {
       // Report the latest height even when it decreases: a drop signals a reorg,
       // which the transaction manager detects via height < last_height. Clamping
       // this monotonically would hide reorgs from the manager.
       const previousPeak = this.peak;
       const height = await this.adapter.getHeightInfo();
+      if (!this.isConnectionEpochActive(connectionEpoch)) return;
       this.previousPeakForCoinReport = previousPeak;
       this.peak = height;
       // Advance every session as soon as a height is available, independently
@@ -357,7 +392,7 @@ export class BlockchainPoller {
       }
       this.consecutiveFailures = 0;
     } catch (e) {
-      if (!this.running) return;
+      if (!this.running || !this.isConnectionEpochActive(connectionEpoch)) return;
       this.consecutiveFailures++;
       diagStack('blockchain-poller height failed', e);
       log(`[blockchain-poller] height failed: ${String(e)}`);
@@ -365,7 +400,8 @@ export class BlockchainPoller {
   }
 
   private async runCoinPoll(): Promise<void> {
-    if (!this.isConnected()) return;
+    const connectionEpoch = this.connectionEpoch;
+    if (!this.isConnectionEpochActive(connectionEpoch)) return;
     try {
       const perSession = this.collectGameSessionCoins();
 
@@ -374,7 +410,8 @@ export class BlockchainPoller {
         for (const { coin_name } of coins) allNames.add(coin_name);
       }
       const names = [...allNames];
-      await this.ensureRegistered(names);
+      await this.ensureRegistered(names, connectionEpoch);
+      if (!this.isConnectionEpochActive(connectionEpoch)) return;
       // Only query coins we've successfully registered.  If a backend requires
       // registration, querying an unregistered name can throw and turn a transient
       // register failure into a polling failure loop; registration is retried each
@@ -382,13 +419,15 @@ export class BlockchainPoller {
       const namesToQuery = names.filter((n) => this.registeredNames.has(n));
 
       const records = namesToQuery.length > 0 ? await this.adapter.getCoinRecordsByNames(namesToQuery) : [];
-      const recordByName = await this.recordMap(records);
+      if (!this.isConnectionEpochActive(connectionEpoch)) return;
+      const recordByName = await this.recordMap(records, connectionEpoch);
+      if (!this.isConnectionEpochActive(connectionEpoch)) return;
       if (recordByName) {
         this.reportToCradles(perSession, recordByName, this.peak, this.previousPeakForCoinReport);
       }
       this.consecutiveFailures = 0;
     } catch (e) {
-      if (!this.running) return;
+      if (!this.running || !this.isConnectionEpochActive(connectionEpoch)) return;
       this.consecutiveFailures++;
       diagStack('blockchain-poller coin poll failed', e);
       log(`[blockchain-poller] coin poll failed: ${String(e)}`);
@@ -396,18 +435,23 @@ export class BlockchainPoller {
   }
 
   private async runBalancePoll(): Promise<void> {
-    if (!this.balanceCallbacks || !this.isConnected()) return;
+    const connectionEpoch = this.connectionEpoch;
+    if (!this.balanceCallbacks || !this.isConnectionEpochActive(connectionEpoch)) return;
     try {
       const balance = await this.adapter.getBalance();
-      if (this.balancePollingScheduler.isInterested()) {
+      if (this.isConnectionEpochActive(connectionEpoch) && this.balancePollingScheduler.isInterested()) {
         this.balanceCallbacks?.onBalance(balance);
       }
     } catch (e) {
+      if (!this.isConnectionEpochActive(connectionEpoch)) return;
       this.balanceCallbacks?.onError?.(e);
     }
   }
 
-  private async recordMap(records: CoinRecord[]): Promise<Map<string, CoinRecord> | null> {
+  private async recordMap(
+    records: CoinRecord[],
+    connectionEpoch: number,
+  ): Promise<Map<string, CoinRecord> | null> {
     const recordByName = new Map<string, CoinRecord>();
     let hasUnmappedRecord = false;
     for (const rec of records) {
@@ -418,6 +462,7 @@ export class BlockchainPoller {
         hasUnmappedRecord = true;
       }
     }
+    if (!this.isConnectionEpochActive(connectionEpoch)) return null;
     for (const name of recordByName.keys()) this.observedNames.add(name);
     return hasUnmappedRecord ? null : recordByName;
   }

--- a/front-end/src/lib/AsyncScheduler.ts
+++ b/front-end/src/lib/AsyncScheduler.ts
@@ -1,6 +1,7 @@
 export type AsyncQueueJob = {
   label: string;
   run: () => Promise<void>;
+  onDiscard?: () => void;
 };
 
 export type AsyncJobQueueOptions = {
@@ -35,6 +36,7 @@ export class AsyncJobQueue {
   }
 
   clearQueued(): void {
+    for (const job of [...this.frontQueue, ...this.queue]) job.onDiscard?.();
     this.frontQueue = [];
     this.queue = [];
   }

--- a/front-end/src/lib/AsyncScheduler.ts
+++ b/front-end/src/lib/AsyncScheduler.ts
@@ -178,7 +178,11 @@ export class AsyncPollingScheduler {
           this.target.onError?.(e);
         } finally {
           this.inFlight = false;
-          if (!this.interested || generation !== this.generation) return;
+          if (!this.interested) return;
+          if (generation !== this.generation) {
+            this.enqueueIfIdle();
+            return;
+          }
           if (this.target.getNextIntervalMs) {
             this.timer.intervalMs = this.target.getNextIntervalMs();
           }

--- a/front-end/src/lib/tests/blockchain_poller.test.ts
+++ b/front-end/src/lib/tests/blockchain_poller.test.ts
@@ -418,9 +418,40 @@ describe('BlockchainPoller', () => {
     onConnectionChange?.(true);
     await jest.advanceTimersByTimeAsync(0);
     expect(rpc.getHeightInfo).toHaveBeenCalledTimes(2);
-    expect(rpc.registerCoins).toHaveBeenCalledTimes(1);
+    expect(rpc.registerCoins).toHaveBeenCalledTimes(2);
     expect(rpc.getCoinRecordsByNames).toHaveBeenCalledTimes(2);
     expect(rpc.getBalance).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
+  it('rejects queued wallet RPCs when the wallet disconnects', async () => {
+    jest.useFakeTimers();
+    let connected = true;
+    let onConnectionChange: ((next: boolean) => void) | undefined;
+    const height = deferred<bigint>();
+    const selectCoins = jest.fn();
+    const rpc = {
+      getHeightInfo: () => height.promise,
+      selectCoins,
+      isConnected: () => connected,
+      onConnectionChange: (callback: (next: boolean) => void) => {
+        onConnectionChange = callback;
+        return () => { onConnectionChange = undefined; };
+      },
+    } as unknown as InternalBlockchainInterface;
+    const poller = new BlockchainPoller(rpc, 1000);
+    poller.start();
+
+    await advanceLane(0);
+    const walletRequest = poller.rpc.selectCoins('wallet', 1n);
+
+    connected = false;
+    onConnectionChange?.(false);
+    await expect(walletRequest).rejects.toThrow('RPC request discarded during disconnect: selectCoins');
+    expect(selectCoins).not.toHaveBeenCalled();
+
+    height.resolve(100n);
+    await advanceLane(0);
     jest.useRealTimers();
   });
 

--- a/front-end/src/lib/tests/blockchain_poller.test.ts
+++ b/front-end/src/lib/tests/blockchain_poller.test.ts
@@ -457,6 +457,47 @@ describe('BlockchainPoller', () => {
     jest.useRealTimers();
   });
 
+  it('discards a stale coin registration before reconnect polling resumes', async () => {
+    jest.useFakeTimers();
+    let connected = true;
+    let onConnectionChange: ((next: boolean) => void) | undefined;
+    const firstRegistration = deferred<void>();
+    const registerCoins = jest.fn()
+      .mockReturnValueOnce(firstRegistration.promise)
+      .mockResolvedValueOnce(undefined);
+    const rpc = {
+      getHeightInfo: jest.fn().mockResolvedValue(100n),
+      registerCoins,
+      getCoinRecordsByNames: jest.fn().mockResolvedValue([]),
+      isConnected: () => connected,
+      onConnectionChange: (callback: (next: boolean) => void) => {
+        onConnectionChange = callback;
+        return () => { onConnectionChange = undefined; };
+      },
+    } as unknown as InternalBlockchainInterface;
+    const cradle: PollingGameSession = {
+      snapshotWatchedCoins: () => [{ coin_name: 'aa', coin_string: 'coin-a' }],
+      reportCoinStates: () => {},
+      reportNewBlock: () => {},
+    };
+    const poller = new BlockchainPoller(rpc, 1000);
+    poller.attachGameSession(cradle);
+    poller.start();
+
+    await advanceLane(0);
+    expect(registerCoins).toHaveBeenCalledTimes(1);
+
+    connected = false;
+    onConnectionChange?.(false);
+    connected = true;
+    onConnectionChange?.(true);
+    firstRegistration.resolve();
+
+    await advanceLane(0);
+    expect(registerCoins).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
   it('does not resume coin polling while the wallet session is disconnected', async () => {
     jest.useFakeTimers();
     let onConnectionChange: ((next: boolean) => void) | undefined;
@@ -517,6 +558,8 @@ describe('BlockchainPoller', () => {
     connected = false;
     onConnectionChange?.(false);
     await expect(walletRequest).rejects.toThrow('RPC request discarded during disconnect: selectCoins');
+    await expect(poller.rpc.selectCoins('wallet', 1n))
+      .rejects.toThrow('RPC request discarded during disconnect: selectCoins');
     expect(selectCoins).not.toHaveBeenCalled();
 
     height.resolve(100n);

--- a/front-end/src/lib/tests/blockchain_poller.test.ts
+++ b/front-end/src/lib/tests/blockchain_poller.test.ts
@@ -424,6 +424,75 @@ describe('BlockchainPoller', () => {
     jest.useRealTimers();
   });
 
+  it('restarts a poll that was in flight during reconnect', async () => {
+    jest.useFakeTimers();
+    let connected = true;
+    let onConnectionChange: ((next: boolean) => void) | undefined;
+    const firstHeight = deferred<bigint>();
+    const getHeightInfo = jest.fn()
+      .mockReturnValueOnce(firstHeight.promise)
+      .mockResolvedValueOnce(101n);
+    const rpc = {
+      getHeightInfo,
+      isConnected: () => connected,
+      onConnectionChange: (callback: (next: boolean) => void) => {
+        onConnectionChange = callback;
+        return () => { onConnectionChange = undefined; };
+      },
+    } as unknown as InternalBlockchainInterface;
+    const poller = new BlockchainPoller(rpc, 1000);
+    poller.start();
+
+    await advanceLane(0);
+    expect(getHeightInfo).toHaveBeenCalledTimes(1);
+
+    connected = false;
+    onConnectionChange?.(false);
+    connected = true;
+    onConnectionChange?.(true);
+    firstHeight.resolve(100n);
+
+    await advanceLane(0);
+    expect(getHeightInfo).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
+  it('does not resume coin polling while the wallet session is disconnected', async () => {
+    jest.useFakeTimers();
+    let onConnectionChange: ((next: boolean) => void) | undefined;
+    const rpc = {
+      getHeightInfo: jest.fn().mockResolvedValue(100n),
+      registerCoins: jest.fn().mockResolvedValue(undefined),
+      getCoinRecordsByNames: jest.fn().mockResolvedValue([]),
+      isConnected: () => true,
+      onConnectionChange: (callback: (next: boolean) => void) => {
+        onConnectionChange = callback;
+        return () => { onConnectionChange = undefined; };
+      },
+    } as unknown as InternalBlockchainInterface;
+    const cradle: PollingGameSession = {
+      snapshotWatchedCoins: () => [{ coin_name: 'aa', coin_string: 'coin-a' }],
+      reportCoinStates: () => {},
+      reportNewBlock: () => {},
+    };
+    const poller = new BlockchainPoller(rpc, 1000);
+    poller.attachGameSession(cradle);
+    poller.start();
+
+    await advanceLane(0);
+    expect(rpc.registerCoins).toHaveBeenCalledTimes(1);
+
+    onConnectionChange?.(false);
+    poller.watchCoin(cradle, { coin_name: 'bb', coin_string: 'coin-b' });
+    await advanceLane(0);
+    expect(rpc.registerCoins).toHaveBeenCalledTimes(1);
+
+    onConnectionChange?.(true);
+    await advanceLane(0);
+    expect(rpc.registerCoins).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
   it('rejects queued wallet RPCs when the wallet disconnects', async () => {
     jest.useFakeTimers();
     let connected = true;

--- a/front-end/src/lib/tests/blockchain_poller.test.ts
+++ b/front-end/src/lib/tests/blockchain_poller.test.ts
@@ -375,6 +375,55 @@ describe('BlockchainPoller', () => {
     jest.useRealTimers();
   });
 
+  it('pauses routine wallet queries while disconnected and resumes on reconnect', async () => {
+    jest.useFakeTimers();
+    let connected = true;
+    let onConnectionChange: ((next: boolean) => void) | undefined;
+    const rpc = {
+      getHeightInfo: jest.fn().mockResolvedValue(100n),
+      registerCoins: jest.fn().mockResolvedValue(undefined),
+      getCoinRecordsByNames: jest.fn().mockResolvedValue([]),
+      getBalance: jest.fn().mockResolvedValue(10n),
+      isConnected: () => connected,
+      onConnectionChange: (callback: (next: boolean) => void) => {
+        onConnectionChange = callback;
+        return () => { onConnectionChange = undefined; };
+      },
+    } as unknown as InternalBlockchainInterface;
+    const cradle: PollingGameSession = {
+      snapshotWatchedCoins: () => [{ coin_name: 'aa', coin_string: 'coin-a' }],
+      reportCoinStates: () => {},
+      reportNewBlock: () => {},
+    };
+    const poller = new BlockchainPoller(rpc, 1000);
+    poller.attachGameSession(cradle);
+    poller.start();
+    poller.startBalanceInterest(1000, { onBalance: () => {} });
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(rpc.getHeightInfo).toHaveBeenCalledTimes(1);
+    expect(rpc.registerCoins).toHaveBeenCalledTimes(1);
+    expect(rpc.getCoinRecordsByNames).toHaveBeenCalledTimes(1);
+    expect(rpc.getBalance).toHaveBeenCalledTimes(1);
+
+    connected = false;
+    onConnectionChange?.(false);
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(rpc.getHeightInfo).toHaveBeenCalledTimes(1);
+    expect(rpc.registerCoins).toHaveBeenCalledTimes(1);
+    expect(rpc.getCoinRecordsByNames).toHaveBeenCalledTimes(1);
+    expect(rpc.getBalance).toHaveBeenCalledTimes(1);
+
+    connected = true;
+    onConnectionChange?.(true);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(rpc.getHeightInfo).toHaveBeenCalledTimes(2);
+    expect(rpc.registerCoins).toHaveBeenCalledTimes(1);
+    expect(rpc.getCoinRecordsByNames).toHaveBeenCalledTimes(2);
+    expect(rpc.getBalance).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
   it('clears registered coin cache when the adapter registration scope changes', async () => {
     let scope = '99';
     const registered: string[][] = [];

--- a/front-end/src/lib/tests/message_protocol.test.ts
+++ b/front-end/src/lib/tests/message_protocol.test.ts
@@ -1271,6 +1271,7 @@ describe('transaction submission', () => {
     const blockchain = new BlockchainPoller({
       ...mockRpc,
       spend,
+      isConnected: () => true,
       getHeightInfo: () => Promise.resolve(1n),
       registerCoins: () => Promise.resolve(),
       getCoinRecordsByNames: () => Promise.resolve([]),
@@ -1358,6 +1359,7 @@ describe('transaction submission', () => {
     const blockchain = new BlockchainPoller({
       ...mockRpc,
       spend,
+      isConnected: () => true,
     } as InternalBlockchainInterface, 60000);
     const sentMessages: Array<{ msgno: number; msg: Uint8Array }> = [];
     const sentAcks: number[] = [];
@@ -1422,6 +1424,7 @@ describe('transaction submission', () => {
     const blockchain = new BlockchainPoller({
       ...mockRpc,
       spend,
+      isConnected: () => true,
     } as InternalBlockchainInterface, 60000);
     const sentMessages: Array<{ msgno: number; msg: Uint8Array }> = [];
     const sentAcks: number[] = [];


### PR DESCRIPTION
## Summary
- pause routine height, coin, and balance polling when the wallet disconnects
- resume retained polling interests when the wallet reconnects
- guard queued poll work against disconnected-wallet RPC calls

## Test plan
- [x] ./ct.sh

Made with [Cursor](https://cursor.com)