### PR TITLE
Add first Rue puzzle rewrite

### DIFF
--- a/rue/test/mock_validator.rue
+++ b/rue/test/mock_validator.rue
@@ -1,0 +1,19 @@
+// Mock validator for referee tests.
+// Mirrors clsp/test/mock_validator.clsp while puzzles migrate to Rue.
+//
+// The referee passes:
+// (mod_hash, curried_args, previous_state, ...rest)
+//
+// Returning `previous_state` lets each test control the validator result.
+fn main(
+    _mod_hash: Bytes32,
+    _curried_args: Any,
+    previous_state: Any,
+    ..._rest: Any,
+) -> Any {
+    if unchecked_cast::<Bool>(previous_state) {
+        previous_state
+    } else {
+        previous_state
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- mirror the smallest Chialisp puzzle under `rue/test/`
- rewrite the test mock validator in Rue with the same argument layout and identity behavior
- preserve a pair-shaped compiled program required by the referee slash dispatcher

## Validation
- compiled successfully with Rue 0.8.4
- verified pair, nil, and atom `previous_state` values are returned unchanged
- `./cb.sh` passed
- `./ct.sh` passed: 260 Rust/simulator tests and 254 JS/WASM tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9715-4245-7a1a-a9d9-23fac87a2cbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9715-4245-7a1a-a9d9-23fac87a2cbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

