### PR TITLE
Add Rust pre-commit quality checks

### DIFF
--- a/.cursor/rules/use-git-for-file-ops.mdc
+++ b/.cursor/rules/use-git-for-file-ops.mdc
@@ -12,3 +12,10 @@ When adding, removing, or moving files in this repo, always use git commands:
 - **Add new files:** create the file, then `git add <path>`
 
 This keeps the index in sync and avoids forgetting to stage changes.
+
+## Committing changes
+
+When the user asks to commit, use `git commit -a` for tracked modifications
+and deletions. New files must already have been explicitly staged when created,
+per the rules above. Review `git status` and `git diff` before committing;
+do not use `git add -A` unless the user explicitly requests it.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+before_diff="$(mktemp)"
+after_diff="$(mktemp)"
+trap 'rm -f "$before_diff" "$after_diff"' EXIT
+
+git diff --binary >"$before_diff"
+
+cargo clippy --fix --allow-dirty --allow-staged
+cargo fmt
+cargo clippy -- -D warnings
+
+git diff --binary >"$after_diff"
+if ! cmp -s "$before_diff" "$after_diff"; then
+  echo "Clippy or cargo fmt updated files; review and stage the changes before committing." >&2
+  exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,9 +7,9 @@ trap 'rm -f "$before_diff" "$after_diff"' EXIT
 
 git diff --binary >"$before_diff"
 
-cargo clippy --fix --allow-dirty --allow-staged
+cargo clippy --all --features=sim-tests,sim-server --fix --allow-dirty --allow-staged
 cargo fmt
-cargo clippy -- -D warnings
+cargo clippy --all --features=sim-tests,sim-server -- -D warnings
 
 git diff --binary >"$after_diff"
 if ! cmp -s "$before_diff" "$after_diff"; then

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "chia-gaming-hooks",
+  "private": true,
+  "packageManager": "pnpm@10.33.0",
+  "devDependencies": {
+    "husky": "^9.1.7"
+  },
+  "scripts": {
+    "prepare": "husky"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+
+packages:
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  husky@9.1.7: {}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # See also .github/worlflows/build-test.yml for toolchain version (dtolnay/rust-toolchain@1.88.0)
 channel = "stable"
-components = [ "rustfmt", "rustc-dev" ]
+components = [ "clippy", "rustfmt", "rustc-dev" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Summary
- add Husky at the repository root for shared Git hooks
- auto-fix Clippy suggestions and format Rust sources before commits
- reject commits when strict Clippy still reports warnings or auto-fixes require staging

## Test plan
- [x] `sh .husky/pre-commit`
- [x] committed with the hook enabled

Made with [Cursor](https://cursor.com)