### PR TITLE
Improve deploy

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "build": "pnpm exec tsc --project . && pnpm exec esbuild dist/js/index.js --bundle --sourcemap --outfile=dist/js/index-rollup.js && pnpm exec tailwindcss -i ./src/index.css -o ./dist/css/index.css",
-    "build:deploy": "pnpm exec tsc --project . && pnpm exec esbuild dist/js/index.js --bundle --format=esm --splitting --sourcemap --outdir=dist/app && pnpm exec tailwindcss -i ./src/index.css -o ./dist/app/index.css",
+    "build:deploy": "pnpm exec tsc --project . && pnpm exec esbuild dist/js/index.js --bundle --format=esm --splitting --outdir=dist/app && pnpm exec tailwindcss -i ./src/index.css -o ./dist/app/index.css",
     "bundle": "rm -rf dist/app && pnpm run build:deploy && node scripts/assemble-bundle.mjs",
     "test": "pnpm exec tsc -p tsconfig.json --noEmit && pnpm exec jest --silent=false --verbose --useStderr --ci"
   },

--- a/static-server.js
+++ b/static-server.js
@@ -58,15 +58,30 @@ function cacheControlForPath(pathname) {
   return 'public, max-age=86400';
 }
 
-function sendFile(res, filePath, pathname) {
-  const ext = path.extname(filePath);
+function acceptsGzip(req) {
+  const accept = req.headers['accept-encoding'] || '';
+  return accept.includes('gzip');
+}
+
+function gzipPath(filePath, req) {
+  if (!acceptsGzip(req)) return null;
+  const gz = filePath + '.gz';
+  if (fs.existsSync(gz)) return gz;
+  return null;
+}
+
+function sendFile(res, filePath, pathname, gzip = false) {
+  const ext = path.extname(pathname);
   const ct = MIME[ext] || 'application/octet-stream';
   const headers = {
     'Content-Type': ct,
     'Cache-Control': cacheControlForPath(pathname),
   };
+  if (gzip) {
+    headers['Content-Encoding'] = 'gzip';
+  }
   if (ext === '.wasm') {
-    headers['SourceMap'] = path.basename(filePath) + '.map';
+    headers['SourceMap'] = path.basename(pathname) + '.map';
   }
 
   const stream = fs.createReadStream(filePath);
@@ -103,7 +118,8 @@ const server = http.createServer((req, res) => {
 
   fs.stat(filePath, (err, st) => {
     if (!err && st.isFile()) {
-      return sendFile(res, filePath, pathname);
+      const gz = gzipPath(filePath, req);
+      return sendFile(res, gz || filePath, pathname, !!gz);
     }
 
     // SPA fallback: serve index.html for missing extensionless paths
@@ -114,7 +130,8 @@ const server = http.createServer((req, res) => {
           res.writeHead(404);
           return res.end('Not found');
         }
-        return sendFile(res, indexPath, '/index.html');
+        const gz = gzipPath(indexPath, req);
+        return sendFile(res, gz || indexPath, '/index.html', !!gz);
       });
     }
 

--- a/static-server.js
+++ b/static-server.js
@@ -79,6 +79,7 @@ function sendFile(res, filePath, pathname, gzip = false) {
   };
   if (gzip) {
     headers['Content-Encoding'] = 'gzip';
+    headers['Vary'] = 'Accept-Encoding';
   }
   if (ext === '.wasm') {
     headers['SourceMap'] = path.basename(pathname) + '.map';

--- a/tools/build-deploy.sh
+++ b/tools/build-deploy.sh
@@ -65,6 +65,19 @@ GAME_ZIP="chia-gaming-${TAG}.zip"
 HUB_TARBALL="chia-gaming-hub-${TAG}.tgz"
 HUB_ZIP="chia-gaming-hub-${TAG}.zip"
 
+# Create zip archive if the `zip` command is available; otherwise warn and skip.
+# The tarball is always created and is sufficient for deployment.
+function maybe_zip() {
+    local src_dir=$1
+    local out_zip=$2
+    if command -v zip >/dev/null 2>&1; then
+        rm -f "$out_zip"
+        (cd "$src_dir" && zip -rq "$out_zip" .)
+    else
+        echo "Warning: 'zip' command not found, skipping $out_zip"
+    fi
+}
+
 # macOS wasm32 clang workaround
 if [ -x /opt/homebrew/opt/llvm/bin/clang ]; then
     export CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang
@@ -128,8 +141,7 @@ node "$ROOT_DIR/tools/verify-stage.mjs" "$GAME_STAGE"
 echo "=== Creating $GAME_TARBALL and $GAME_ZIP ==="
 mkdir -p "$ROOT_DIR/deploy_player_app"
 tar -czf "$ROOT_DIR/deploy_player_app/$GAME_TARBALL" -C "$GAME_STAGE" .
-rm -f "$ROOT_DIR/deploy_player_app/$GAME_ZIP"
-(cd "$GAME_STAGE" && zip -rq "$ROOT_DIR/deploy_player_app/$GAME_ZIP" .)
+maybe_zip "$GAME_STAGE" "$ROOT_DIR/deploy_player_app/$GAME_ZIP"
 rm -rf "$GAME_STAGE"
 
 # ── Assemble hub staging tree ──────────────────────────────────────
@@ -153,8 +165,7 @@ node "$ROOT_DIR/tools/verify-stage.mjs" "$HUB_STAGE"
 echo "=== Creating $HUB_TARBALL and $HUB_ZIP ==="
 mkdir -p "$ROOT_DIR/deploy_hub"
 tar -czf "$ROOT_DIR/deploy_hub/$HUB_TARBALL" -C "$HUB_STAGE" .
-rm -f "$ROOT_DIR/deploy_hub/$HUB_ZIP"
-(cd "$HUB_STAGE" && zip -rq "$ROOT_DIR/deploy_hub/$HUB_ZIP" .)
+maybe_zip "$HUB_STAGE" "$ROOT_DIR/deploy_hub/$HUB_ZIP"
 rm -rf "$HUB_STAGE"
 
 # ── Done ─────────────────────────────────────────────────────────────
@@ -163,9 +174,9 @@ echo ""
 echo "════════════════════════════════════════════════════════"
 echo "  Artifacts:"
 echo "    $ROOT_DIR/deploy_player_app/$GAME_TARBALL"
-echo "    $ROOT_DIR/deploy_player_app/$GAME_ZIP"
+[ -f "$ROOT_DIR/deploy_player_app/$GAME_ZIP" ] && echo "    $ROOT_DIR/deploy_player_app/$GAME_ZIP"
 echo "    $ROOT_DIR/deploy_hub/$HUB_TARBALL"
-echo "    $ROOT_DIR/deploy_hub/$HUB_ZIP"
+[ -f "$ROOT_DIR/deploy_hub/$HUB_ZIP" ] && echo "    $ROOT_DIR/deploy_hub/$HUB_ZIP"
 echo "════════════════════════════════════════════════════════"
 
 ABORTED=0

--- a/tools/run-production.sh
+++ b/tools/run-production.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Run the staged production player app and hub services.
+#
+# Must be run after ./tools/stage-production.sh. Press Ctrl-C to stop both.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GAME_PORT="${GAME_PORT:-3002}"
+HUB_PORT="${HUB_PORT:-3003}"
+HOST="${HOST:-127.0.0.1}"
+
+PLAYER_STAGE="${PLAYER_STAGE:-$ROOT_DIR/.stage-player}"
+HUB_STAGE="${HUB_STAGE:-$ROOT_DIR/.stage-hub}"
+
+if [ ! -d "$PLAYER_STAGE" ] || [ ! -d "$HUB_STAGE" ]; then
+    echo "Staging directories missing. Run ./tools/stage-production.sh first."
+    exit 1
+fi
+
+if [ ! -f "$PLAYER_STAGE/static-server.js" ]; then
+    echo "ERROR: player stage is missing static-server.js"
+    exit 1
+fi
+
+if [ ! -f "$HUB_STAGE/service.js" ]; then
+    echo "ERROR: hub stage is missing service.js"
+    exit 1
+fi
+
+PIDS=()
+CLEANED_UP=0
+
+cleanup() {
+    [ "$CLEANED_UP" -eq 0 ] || return
+    CLEANED_UP=1
+    echo ""
+    echo "=== Stopping services ==="
+    for pid in "${PIDS[@]}"; do
+        kill -TERM "$pid" 2>/dev/null || true
+    done
+
+    for _ in $(seq 1 50); do
+        local running=0
+        for pid in "${PIDS[@]}"; do
+            if kill -0 "$pid" 2>/dev/null; then
+                running=1
+                break
+            fi
+        done
+        [ "$running" -eq 0 ] && break
+        sleep 0.1
+    done
+
+    local forced=0
+    for pid in "${PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -KILL "$pid" 2>/dev/null || true
+            forced=1
+        fi
+    done
+    [ "$forced" -eq 0 ] || echo "Forced remaining services to stop."
+
+    for pid in "${PIDS[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT INT TERM
+
+echo "=== Starting player app on http://$HOST:$GAME_PORT ==="
+node "$PLAYER_STAGE/static-server.js" "$PLAYER_STAGE" "$GAME_PORT" "$HOST" &
+PIDS+=($!)
+
+echo "=== Starting hub on http://$HOST:$HUB_PORT ==="
+PORT="$HUB_PORT" node "$HUB_STAGE/service.js" \
+    --self "http://$HOST:$HUB_PORT" \
+    --dir "$HUB_STAGE" &
+PIDS+=($!)
+
+echo ""
+echo "════════════════════════════════════════════════════════"
+echo "  Player app: http://$HOST:$GAME_PORT"
+echo "  Hub:        http://$HOST:$HUB_PORT"
+echo ""
+echo "  Press Ctrl-C to stop both services."
+echo "════════════════════════════════════════════════════════"
+
+wait

--- a/tools/stage-production.sh
+++ b/tools/stage-production.sh
@@ -40,11 +40,14 @@ tar -xzf "$HUB_TGZ" -C "$HUB_STAGE"
 echo "=== Compressing player app static assets ==="
 # Pre-compress assets so static-server.js can serve .gz files to clients that
 # accept gzip. The original files are kept for clients that do not.
-find "$PLAYER_STAGE" -type f \
-  \( -name '*.html' -o -name '*.js' -o -name '*.mjs' -o -name '*.css' \
-     -o -name '*.json' -o -name '*.wasm' -o -name '*.hex' -o -name '*.dat' \
-     -o -name '*.svg' \) \
-  -exec gzip -k -f {} \;
+# Use gzip -c (stdout) rather than -k/--keep because BSD gzip on macOS does
+# not support -k. -n omits the filename/timestamp header for reproducibility.
+while IFS= read -r -d '' f; do
+    gzip -c -n -f "$f" > "$f.gz" || exit 1
+  done < <(find "$PLAYER_STAGE" -type f \
+    \( -name '*.html' -o -name '*.js' -o -name '*.mjs' -o -name '*.css' \
+       -o -name '*.json' -o -name '*.wasm' -o -name '*.hex' -o -name '*.dat' \
+       -o -name '*.svg' \) -print0)
 
 echo "=== Sanity-checking Krunk files ==="
 for f in \

--- a/tools/stage-production.sh
+++ b/tools/stage-production.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Build production deploy artifacts and stage them for local production testing.
+#
+# This is the production counterpart to run-local-demo.sh: it uses the release
+# build path (tools/build-deploy.sh) rather than the dev path, and it does not
+# start the simulator. After staging, run tools/run-production.sh to start the
+# player app and hub services.
+#
+# Outputs:
+#   deploy_player_app/chia-gaming-*.tgz/.zip
+#   deploy_hub/chia-gaming-hub-*.tgz/.zip
+#   .stage-player/  — extracted player app, with gzipped static assets
+#   .stage-hub/     — extracted hub frontend + service
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PLAYER_STAGE="${PLAYER_STAGE:-$ROOT_DIR/.stage-player}"
+HUB_STAGE="${HUB_STAGE:-$ROOT_DIR/.stage-hub}"
+
+echo "=== Wiping old deploy artifacts and stages ==="
+rm -rf "$ROOT_DIR/deploy_player_app" "$ROOT_DIR/deploy_hub" "$PLAYER_STAGE" "$HUB_STAGE"
+
+echo "=== Running production build ==="
+cd "$ROOT_DIR"
+./tools/build-deploy.sh
+
+echo "=== Extracting player app ==="
+mkdir -p "$PLAYER_STAGE"
+PLAYER_TGZ=$(ls -t "$ROOT_DIR/deploy_player_app"/chia-gaming-*.tgz | head -1)
+tar -xzf "$PLAYER_TGZ" -C "$PLAYER_STAGE"
+
+echo "=== Extracting hub ==="
+mkdir -p "$HUB_STAGE"
+HUB_TGZ=$(ls -t "$ROOT_DIR/deploy_hub"/chia-gaming-hub-*.tgz | head -1)
+tar -xzf "$HUB_TGZ" -C "$HUB_STAGE"
+
+echo "=== Compressing player app static assets ==="
+# Pre-compress assets so static-server.js can serve .gz files to clients that
+# accept gzip. The original files are kept for clients that do not.
+find "$PLAYER_STAGE" -type f \
+  \( -name '*.html' -o -name '*.js' -o -name '*.mjs' -o -name '*.css' \
+     -o -name '*.json' -o -name '*.wasm' -o -name '*.hex' -o -name '*.dat' \
+     -o -name '*.svg' \) \
+  -exec gzip -k -f {} \;
+
+echo "=== Sanity-checking Krunk files ==="
+for f in \
+    "clsp/games/krunk/krunk_include_krunk_factory.hex" \
+    "clsp/games/krunk/krunk_signed_dict_tree.dat"
+do
+    if [ ! -f "$PLAYER_STAGE/$f" ]; then
+        echo "ERROR: missing $f in player staging"
+        exit 1
+    fi
+    echo "  ok: $f"
+done
+
+echo ""
+echo "════════════════════════════════════════════════════════"
+echo "  Staged for production run:"
+echo "    Player app: $PLAYER_STAGE"
+echo "    Hub:        $HUB_STAGE"
+echo ""
+echo "  Run ./tools/run-production.sh to start the services."
+echo "════════════════════════════════════════════════════════"


### PR DESCRIPTION
Added production-path build and run scripts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to build/deploy tooling and static file serving; no auth, payments, or core game logic.
> 
> **Overview**
> Adds a **production local workflow**: `stage-production.sh` runs `build-deploy.sh`, extracts player and hub tarballs into `.stage-player` / `.stage-hub`, pre-gzips static assets for the player stage, and checks Krunk game files; `run-production.sh` starts the player static server and hub service with graceful shutdown.
> 
> **`static-server.js`** now serves companion `.gz` files when the client accepts gzip (`Content-Encoding`, `Vary`), and derives MIME/extension from the URL pathname so compressed responses keep correct types (including WASM source maps).
> 
> **`build-deploy.sh`** wraps zip creation in `maybe_zip` so environments without `zip` still get tarballs only; artifact listings print zip paths only when those files exist.
> 
> **`front-end` `build:deploy`** drops per-chunk `--sourcemap` from esbuild (deploy bundles still split to `dist/app`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36eab653d8a2b1f70da3bac4a5abb9004362127c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->