### PR TITLE
Add Git hooks for pre-commit checks and update documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,6 +71,16 @@ fail with clang errors.
 ./tools/local-wasm-tests.sh
 ```
 
+## Git Hooks
+
+To install the repo's versioned pre-commit hook in your local checkout:
+
+```bash
+tools/install-git-hooks.sh
+```
+
+The hook builds Chialisp and runs `./ct.sh` before allowing a commit.
+
 
 # Running from tarball or zipfile
 

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== Pre-commit: building chialisp ==="
+./tools/build-chialisp.sh
+
+echo "=== Pre-commit: running ct.sh ==="
+./ct.sh

--- a/tools/install-git-hooks.sh
+++ b/tools/install-git-hooks.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK_SOURCE="$REPO_ROOT/tools/git-hooks/pre-commit"
+HOOK_TARGET="$REPO_ROOT/.git/hooks/pre-commit"
+
+cd "$REPO_ROOT"
+
+if [ ! -d ".git" ]; then
+    echo "Error: .git directory not found; run this from a git checkout" >&2
+    exit 1
+fi
+
+if [ ! -f "$HOOK_SOURCE" ]; then
+    echo "Error: missing hook source: $HOOK_SOURCE" >&2
+    exit 1
+fi
+
+mkdir -p "$REPO_ROOT/.git/hooks"
+cp "$HOOK_SOURCE" "$HOOK_TARGET"
+chmod +x "$HOOK_TARGET"
+
+echo "Installed pre-commit hook at $HOOK_TARGET"


### PR DESCRIPTION
- Introduced a pre-commit hook that builds Chialisp and runs `ct.sh` before commits.
- Added a script to install the pre-commit hook in the local repository.
- Updated DEVELOPMENT.md to include instructions for using the Git hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hook and docs only affect developer workflow; risk rises if build-state or local scratch files are merged unintentionally.
> 
> **Overview**
> Adds **local commit gating** via a repo-managed pre-commit hook that runs `./tools/build-chialisp.sh` and `./ct.sh` before a commit is allowed, plus `tools/install-git-hooks.sh` to copy it into `.git/hooks`.
> 
> **DEVELOPMENT.md** gains a short **Git Hooks** section pointing developers at the installer and describing what the hook runs.
> 
> The same diff also adds several **non-product** paths (e.g. `.build-chialisp.state`, `TODO.txt`, patch/diff scratch files, `dep-tree.txt`, and built lobby serve assets) that look like accidental local artifacts rather than part of the hook feature—worth dropping before merge unless intentional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9bebccbc1d3c2ad1cb352007c0cc8e23cceb335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->