### PR TITLE
Session-scope change address and remove legacy fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 *.hex
 *.sym
 .build-chialisp.state
+.build-chialisp.cache
+
+# Local compression benchmarks
+/group-sizes/
 
 # cargo / rust
 vendor/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,8 @@ export default defineConfig([
     '**/node_modules/**',
     '**/public/index.js',
     '**/serve/**',
+    'deploy_hub/**',
+    'deploy_player_app/**',
     'front-end/src/lib/pkg/**',
   ]),
   {

--- a/front-end/src/hooks/BlockchainPoller.ts
+++ b/front-end/src/hooks/BlockchainPoller.ts
@@ -117,8 +117,12 @@ export class BlockchainPoller {
     return {
       requestGapMs: adapter.requestGapMs,
       getRegistrationScopeKey: () => adapter.getRegistrationScopeKey?.(),
-      spend: (blob, spendBundle, source, fee) =>
-        this.enqueueRpc('spend', () => adapter.spend(blob, spendBundle, source, fee), true),
+      spend: (blob, spendBundle, changePuzzleHash, source, fee) =>
+        this.enqueueRpc(
+          'spend',
+          () => adapter.spend(blob, spendBundle, changePuzzleHash, source, fee),
+          true,
+        ),
       rememberLocalRemovals: adapter.rememberLocalRemovals
         ? (spendBundle) =>
             this.enqueueRpc(

--- a/front-end/src/hooks/FakeBlockchainInterface.ts
+++ b/front-end/src/hooks/FakeBlockchainInterface.ts
@@ -239,6 +239,7 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
   async spend(
     blob: string,
     _spendBundle: unknown,
+    _changePuzzleHash: string,
     _source?: string,
     _fee?: bigint,
   ): Promise<string> {

--- a/front-end/src/hooks/RealBlockchainInterface.ts
+++ b/front-end/src/hooks/RealBlockchainInterface.ts
@@ -291,12 +291,12 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
     spendBundle: WalletSpendBundle,
     fee: bigint,
     removals: CoinsetCoin[],
+    changePuzzleHash: string,
   ): Promise<TransactionRecord> {
-    const puzzleHash = this.blockchainAddressData.puzzleHash;
-    if (!puzzleHash) {
-      throw new Error('buildTransactionRecord: blockchain address puzzle hash is not set');
+    if (!changePuzzleHash) {
+      throw new Error('buildTransactionRecord: change puzzle hash is required');
     }
-    const toAddress = encodePuzzleHashToBech32m(puzzleHash);
+    const toAddress = encodePuzzleHashToBech32m(changePuzzleHash);
 
     const nameBytes = new TextEncoder().encode(jsonStringify(spendBundle));
     const hashBuf = await crypto.subtle.digest('SHA-256', nameBytes);
@@ -307,7 +307,7 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
     return {
       confirmed_at_height: 0n,
       created_at_time: BigInt(Math.floor(Date.now() / 1000)),
-      to_puzzle_hash: puzzleHash,
+      to_puzzle_hash: changePuzzleHash,
       amount: 0n,
       fee_amount: fee,
       confirmed: false,
@@ -329,6 +329,7 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
   async spend(
     _blob: string,
     spendBundle: unknown,
+    changePuzzleHash: string,
     _source?: string,
     fee?: bigint,
   ): Promise<string> {
@@ -361,6 +362,7 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
         spendBundle as WalletSpendBundle,
         feeValue,
         removals,
+        changePuzzleHash,
       );
       const result = await rpc.pushTransactions({
         transactions: [txRecord],
@@ -379,7 +381,9 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
       if (isRetryablePushError(errStr)) {
         return new Promise((resolve, reject) => {
           setTimeout(() => {
-            this.spend(_blob, spendBundle, `retry-of-#${seq}`, fee).then(resolve).catch(reject);
+            this.spend(_blob, spendBundle, changePuzzleHash, `retry-of-#${seq}`, fee)
+              .then(resolve)
+              .catch(reject);
           }, PUSH_RETRY_DELAY);
         });
       }

--- a/front-end/src/hooks/SessionController.ts
+++ b/front-end/src/hooks/SessionController.ts
@@ -11,7 +11,6 @@ import {
   WasmResult,
   SpendBundle,
   ProposeGameParams,
-  BlockchainInboundAddressResult,
   WasmEvent,
   NeedCoinSpendRequest,
 } from '../types/ChiaGaming';
@@ -39,6 +38,7 @@ export interface WasmFields {
   myContribution: string;
   theirContribution: string;
   perGameAmount: string;
+  rewardPuzzleHash: string | null;
   unackedMessages: Array<{ msgno: bigint; msg: Uint8Array }>;
   wasmNotificationHistory: string[];
   diagnosticLog: string[];
@@ -112,6 +112,7 @@ export class SessionController implements PollingGameSession {
   myContribution: bigint;
   theirContribution: bigint;
   perGameAmount: bigint;
+  rewardPuzzleHash: string | null;
   wc: WasmConnection | undefined;
   sendMessage: (msgno: bigint, msg: Uint8Array) => boolean;
   sendAck: (ackMsgno: bigint) => boolean;
@@ -222,6 +223,7 @@ export class SessionController implements PollingGameSession {
     this.myContribution = myContribution;
     this.theirContribution = theirContribution;
     this.perGameAmount = 0n;
+    this.rewardPuzzleHash = null;
     this.iStarted = false;
     this.channelReady = false;
     this.storedMessages = [];
@@ -588,8 +590,11 @@ export class SessionController implements PollingGameSession {
     }
   }
 
-  setBlockchainAddress(a: BlockchainInboundAddressResult) {
-    this.rxjsEmitter?.next({ type: 'address', data: a });
+  emitRewardAddress() {
+    if (!this.rewardPuzzleHash) {
+      throw new Error('emitRewardAddress: rewardPuzzleHash is not set');
+    }
+    this.rxjsEmitter?.next({ type: 'address', data: { puzzleHash: this.rewardPuzzleHash } });
   }
 
   kickSystem(flags: number) {
@@ -622,7 +627,16 @@ export class SessionController implements PollingGameSession {
       const spendBundle = this.wc?.convert_spend_to_coinset_org(blob);
       const fee = this.getFee();
       log(`[wasm] submitTransaction blobLen=${blob.length}`);
-      await blockchain.rpc.spend(blob, spendBundle, 'submitTransaction', fee || undefined);
+      if (!this.rewardPuzzleHash) {
+        throw new Error('submitTransactionNow: rewardPuzzleHash is not set');
+      }
+      await blockchain.rpc.spend(
+        blob,
+        spendBundle,
+        this.rewardPuzzleHash,
+        'submitTransaction',
+        fee || undefined,
+      );
     } catch (e) {
       const message = extractErrorMessage(e);
       if (isBenignTransactionSubmitError(message)) {
@@ -1357,6 +1371,7 @@ export class SessionController implements PollingGameSession {
       myContribution: this.myContribution.toString(),
       theirContribution: this.theirContribution.toString(),
       perGameAmount: this.perGameAmount.toString(),
+      rewardPuzzleHash: this.rewardPuzzleHash,
       unackedMessages: [...this.unackedMessages],
       wasmNotificationHistory: recentEntries(
         this.wasmNotificationHistory,

--- a/front-end/src/hooks/blobSingleton.ts
+++ b/front-end/src/hooks/blobSingleton.ts
@@ -101,7 +101,8 @@ export async function configSessionController(
   const seedHex = Array.from(entropy, (b) => b.toString(16).padStart(2, '0')).join('');
   const rngId = wasmConnection.create_rng(seedHex);
   const address = await blockchain.rpc.getAddress();
-  sc.setBlockchainAddress(address);
+  sc.rewardPuzzleHash = address.puzzleHash;
+  sc.emitRewardAddress();
   const theirContribution = sc.theirContribution;
   const { game: cradle } = wasmStateInit.createGame(
     rngId,
@@ -109,7 +110,7 @@ export async function configSessionController(
     iStarted,
     sc.myContribution,
     theirContribution,
-    address.puzzleHash,
+    sc.rewardPuzzleHash,
     channelTimeout,
     unrollTimeout,
   );
@@ -185,6 +186,10 @@ export async function restoreSession(
   sc.myAlias = save.myAlias;
   sc.opponentAlias = save.opponentAlias;
   sc.lastOutcomeWin = save.lastOutcomeWin;
+  if (!save.rewardPuzzleHash) {
+    throw new Error('restoreSession: missing rewardPuzzleHash in persisted session');
+  }
+  sc.rewardPuzzleHash = save.rewardPuzzleHash;
   sc.markRestored();
   sc.setGameSession(cradle);
 

--- a/front-end/src/hooks/save.ts
+++ b/front-end/src/hooks/save.ts
@@ -93,6 +93,8 @@ export interface SessionSave {
   /** Blocks; persisted so a deploy-stale reload can resume pre-cradle handshake. */
   channelTimeout?: string;
   unrollTimeout?: string;
+  /** Change/reward address the session was created with; immutable for the life of the session. Null when no session is active. */
+  rewardPuzzleHash: string | null;
   unackedMessages?: Array<{ msgno: bigint; msg: Uint8Array }>;
   humanHistory?: string[];
   wasmNotificationHistory?: string[];
@@ -623,6 +625,7 @@ function loadPreferences(): SessionSave {
         return {
           version: CURRENT_VERSION,
           ...preferences,
+          rewardPuzzleHash: null,
           defaultFee:
             preferences.defaultFee === undefined ? undefined : BigInt(preferences.defaultFee),
         };
@@ -631,7 +634,7 @@ function loadPreferences(): SessionSave {
   } catch (e) {
     console.error('[save] failed to load preferences:', e);
   }
-  return { version: CURRENT_VERSION, playerId: randomHex() };
+  return { version: CURRENT_VERSION, playerId: randomHex(), rewardPuzzleHash: null };
 }
 
 function isTerminalFinishedChannel(status: ChannelStatusPayload | null | undefined): boolean {
@@ -1121,6 +1124,7 @@ export function clearSession(): Promise<void> {
     walletAlert: prev.walletAlert,
     hubAlert: prev.hubAlert,
     blockchainType: prev.blockchainType,
+    rewardPuzzleHash: null,
   };
   savePreferences(cached);
   const deletePromise = (writeChain = writeChain

--- a/front-end/src/hooks/useGameSession.ts
+++ b/front-end/src/hooks/useGameSession.ts
@@ -1141,6 +1141,7 @@ export function useGameSession(
       myContribution: wasm.myContribution,
       theirContribution: wasm.theirContribution,
       perGameAmount: wasm.perGameAmount,
+      rewardPuzzleHash: wasm.rewardPuzzleHash,
       unackedMessages: wasm.unackedMessages,
       activeGameIds: presentationModel.game.activeIds,
       iProposedHand,

--- a/front-end/src/lib/tests/blockchain_poller.test.ts
+++ b/front-end/src/lib/tests/blockchain_poller.test.ts
@@ -266,7 +266,7 @@ describe('BlockchainPoller', () => {
     const p2 = poller.rpc.getBalance();
     const p3 = poller.rpc.createOfferForIds('u', {});
     const p4 = poller.rpc.selectCoins('u', 1n);
-    const p5 = poller.rpc.spend('blob', {});
+    const p5 = poller.rpc.spend('blob', {}, '11'.repeat(32), 'submitTransaction', 0n);
 
     first.resolve(7n);
     await advanceLane();

--- a/front-end/src/lib/tests/message_protocol.test.ts
+++ b/front-end/src/lib/tests/message_protocol.test.ts
@@ -249,6 +249,9 @@ function transactionSubmitQueue(blob: SessionController): Promise<void> {
 }
 
 function submitTransaction(blob: SessionController, tx: SpendBundle): void {
+  if (!blob.rewardPuzzleHash) {
+    blob.rewardPuzzleHash = '11'.repeat(32);
+  }
   (blob as unknown as { submitTransaction: (tx: SpendBundle) => void }).submitTransaction(tx);
 }
 
@@ -875,6 +878,7 @@ describe('restore ordering', () => {
           iStarted: true,
           pairingToken: 'tok',
           activeGameIds: [],
+          rewardPuzzleHash: '11'.repeat(32),
           unackedMessages: [{ msgno: 4n, msg: enc('outbound') }],
           wasmNotificationHistory: ['notification'],
           diagnosticLog: ['diagnostic'],
@@ -1780,6 +1784,7 @@ describe('transaction submission', () => {
       makePeerConn(sentMessages, sentAcks),
     );
     activeBlob = blob;
+    blob.rewardPuzzleHash = '11'.repeat(32);
     const cradle = {
       ...makeMockCradle(),
       snapshot_watched_coins: jest.fn(() => [{ coin_name: 'cc', coin_string: 'coin-c' }]),
@@ -1894,6 +1899,7 @@ describe('transaction submission', () => {
       makePeerConn(sentMessages, sentAcks),
     );
     activeBlob = blob;
+    blob.rewardPuzzleHash = '11'.repeat(32);
     const cradle = {
       ...makeMockCradle(),
       drain_submissions: jest.fn(() => [testSpendBundle('01'), testSpendBundle('02')]),
@@ -1929,6 +1935,7 @@ describe('transaction submission', () => {
       makePeerConn(sentMessages, sentAcks),
     );
     activeBlob = blob;
+    blob.rewardPuzzleHash = '11'.repeat(32);
     const cradle = {
       ...makeMockCradle(),
       drain_submissions: jest.fn(() => [testSpendBundle('06')]),
@@ -1988,6 +1995,7 @@ describe('transaction submission', () => {
       makePeerConn(sentMessages, sentAcks),
     );
     activeBlob = blob;
+    blob.rewardPuzzleHash = '11'.repeat(32);
     const errors: string[] = [];
     blob.getObservable().subscribe((evt) => {
       if (evt.type === 'error') errors.push(evt.error);

--- a/front-end/src/lib/tests/real_blockchain_interface.test.ts
+++ b/front-end/src/lib/tests/real_blockchain_interface.test.ts
@@ -425,7 +425,7 @@ describe('RealBlockchainInterface', () => {
       aggregated_signature: '0x00',
     };
     await expect(
-      blockchain.spend('80', submittedBundle, 'submitTransaction', 10n),
+      blockchain.spend('80', submittedBundle, puzzleHash, 'submitTransaction', 10n),
     ).resolves.toEqual({ success: true });
 
     expect(mockPushTransactions).toHaveBeenCalledWith(
@@ -440,6 +440,32 @@ describe('RealBlockchainInterface', () => {
                 amount,
               },
             ],
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('uses the provided change puzzle hash in the transaction record', async () => {
+    const blockchain = new RealBlockchainInterface();
+    blockchain.blockchainAddressData = { puzzleHash: '11'.repeat(32) };
+    const sessionPuzzleHash = '22'.repeat(32);
+    mockPushTransactions.mockResolvedValue({ success: true });
+
+    await blockchain.spend(
+      '80',
+      { coin_spends: [], aggregated_signature: '0x00' },
+      sessionPuzzleHash,
+      'submitTransaction',
+      0n,
+    );
+
+    expect(mockPushTransactions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transactions: [
+          expect.objectContaining({
+            to_puzzle_hash: sessionPuzzleHash,
+            to_address: encodePuzzleHashToBech32m(sessionPuzzleHash),
           }),
         ],
       }),

--- a/front-end/src/lib/tests/save.test.ts
+++ b/front-end/src/lib/tests/save.test.ts
@@ -89,6 +89,7 @@ const sampleSession: Partial<SessionSave> = {
   myContribution: '60',
   theirContribution: '40',
   perGameAmount: '10',
+  rewardPuzzleHash: '11'.repeat(32),
   unackedMessages: [{ msgno: 4n, msg: new Uint8Array([3, 4, 5]) }],
   humanHistory: ['human1'],
   wasmNotificationHistory: ['notification1'],

--- a/front-end/src/types/ChiaGaming.ts
+++ b/front-end/src/types/ChiaGaming.ts
@@ -603,7 +603,13 @@ export interface ConnectionSetup {
 export interface InternalBlockchainInterface {
   requestGapMs?: number;
   getRegistrationScopeKey?(): string | undefined;
-  spend(blob: string, spendBundle: unknown, source?: string, fee?: bigint): Promise<string>;
+  spend(
+    blob: string,
+    spendBundle: unknown,
+    changePuzzleHash: string,
+    source?: string,
+    fee?: bigint,
+  ): Promise<string>;
   rememberLocalRemovals?(spendBundle: unknown): void | Promise<void>;
   getAddress(): Promise<BlockchainInboundAddressResult>;
   getBalance(): Promise<bigint>;


### PR DESCRIPTION
## Summary

This change makes the session's reward/change address (`rewardPuzzleHash`) authoritative for the life of a session and removes the legacy fallbacks that could substitute a wallet-level or empty address.

- Adds `rewardPuzzleHash` to `SessionSave`, `SessionController`, and `WasmFields`.
- Captures the address when a new session is created and restores it from persisted state.
- Throws on restore if `rewardPuzzleHash` is missing, instead of falling back to an empty string.
- Threads `changePuzzleHash` through `InternalBlockchainInterface.spend` so transaction record metadata uses the session-level address.
- Removes the fallback to `this.blockchainAddressData.puzzleHash` in `RealBlockchainInterface.buildTransactionRecord`.
- Renames `setBlockchainAddress` to `emitRewardAddress` and removes the unused address parameter.
- Also ignores deploy artifacts in `eslint.config.mjs` and adds `.build-chialisp.cache` / `group-sizes/` to `.gitignore`.

## Test plan

- [x] `pnpm -w run lint:fix`
- [x] `pnpm -w run format`
- [x] `cargo clippy`
- [x] `cargo fmt`
- [x] `pnpm --dir front-end test` (343/343 passed)

Made with [Cursor](https://cursor.com)