### PR TITLE
Replace full-shell session transition overlay

### DIFF
--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -170,7 +170,7 @@ while WASM protocol frames remain raw bytes with the existing reliability tags.
 | Event              | Payload                                                                               | Purpose                                                                                                                                                                                                                                                   |
 | ------------------ | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `registered`       | `{ player_id }`                                                                       | Confirmation of identity. Sent in response to `identify`.                                                                                                                                                                                                 |
-| `advisory_start`   | `{ peer_id, peer_alias, my_amount, their_amount, channel_timeout?, unroll_timeout? }` | The hub suggests starting a session with this peer (triggered by challenge acceptance in the hub). One-sided: only sent to the challenge accepter, who may become the channel initiator after local consent. Amounts are from the accepter's perspective. |
+| `advisory_start`   | `{ peer_id, peer_alias, my_amount, their_amount, channel_timeout?, unroll_timeout? }` | The hub suggests starting a session with this peer (triggered by challenge acceptance in the hub). One-sided: only sent to the challenge accepter, who may become the channel initiator after local consent. Amounts are from the accepter's perspective. The client ignores advisories with invalid amounts or out-of-range timeouts (no consent UI; advisory is hub-originated, so no `session_reject`). |
 | binary frame       | `[4-byte from_id_len BE][from_id UTF-8][4-byte alias_len BE][alias UTF-8][payload]`   | A peer payload from another peer, relayed through the hub pipe with the sender's public id and alias.                                                                                                                                                     |
 | `delivery_failure` | `{ to }`                                                                              | The target peer is not connected; the message could not be delivered.                                                                                                                                                                                     |
 | `hub_attention`    | `{}`                                                                                  | Signals that something happened in the hub that the user should look at.                                                                                                                                                                                  |
@@ -196,15 +196,21 @@ while WASM protocol frames remain raw bytes with the existing reliability tags.
    frames through the same addressed pipe. Starting persists session state
    asynchronously; a later `session_reject` (or local cancel) must abort that
    in-flight start so it cannot resurrect an orphan handshake.
-7. The peer receives the `session_proposal`, checks local availability, stores
-   the `game_session_id` in its PeerSession, reserves that peer id so early
-   handshake bytes can buffer, and shows its own consent prompt. If unavailable
+7. The peer receives the `session_proposal`, checks local availability and
+   validates amounts/timeouts at the trust boundary, stores the
+   `game_session_id` in its PeerSession, reserves that peer id so early
+   handshake bytes can buffer, and shows its own consent prompt. Invalid
+   amounts or out-of-range timeouts are rejected with `session_reject` only —
+   they must not clear a finished freeze or IndexedDB checkpoint. If unavailable
    or declined, it sends `session_reject` and discards any buffered handshake
    bytes. Receiving `session_reject` during pre-active matchmaking cancels the
    attempt (including any in-flight async start) and surfaces cancelled/error —
    it must not leave an orphan handshake. If accepted, the peer marks itself
    busy, starts the WASM session as receiver, and drains the buffered handshake
-   bytes.
+   bytes. A start failure before the live checkpoint replaces any terminal
+   save ends the peer attempt only (reject + clear provisional relay) and may
+   surface a session error warning; full attempt teardown is reserved for
+   failures after that persist succeeds.
 8. Both players exchange binary game frames through the addressed hub pipe.
    The reliability layer (msgno/ack/keepalive) is encoded inside the binary
    payload, peer-to-peer — the hub never interprets it.

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -1051,11 +1051,12 @@ For accepted session setup, the transition is keyed atomically with the same
 `pairingToken` that identifies the new controller instance. Completion for a
 different instance is ignored.
 
-`GameSession` remains mounted underneath a session-pane transition. This lets
-the WASM/controller setup continue and keeps its existing notification overlays
-available above the presentation surface. `GameSession` reports its normal
-`SessionModel` to Shell; it has no transition-specific rendering mode or
-readiness flag.
+`GameSession` remains mounted underneath a session-pane transition. The
+presentation surface is rendered inside `GameSession` (below its notification
+z-index) so WASM/controller setup can continue while existing notification
+overlays stay available and clickable above the surface. `GameSession` reports
+its normal `SessionModel` to Shell; it has no transition-specific readiness
+flag beyond the optional surface cover.
 
 Shell releases the transition when the canonical dashboard selector moves past
 the setup **Cancel** action. Because that selector reads the projected

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -203,14 +203,23 @@ while WASM protocol frames remain raw bytes with the existing reliability tags.
    amounts or out-of-range timeouts are rejected with `session_reject` only —
    they must not clear a finished freeze or IndexedDB checkpoint. If unavailable
    or declined, it sends `session_reject` and discards any buffered handshake
-   bytes. Receiving `session_reject` during pre-active matchmaking cancels the
-   attempt (including any in-flight async start) and surfaces cancelled/error —
-   it must not leave an orphan handshake. If accepted, the peer marks itself
+   bytes. Receiving `session_reject` or `delivery_failure` during an Accept
+   transition aborts that attempt with the same freeze-safe disposition as
+   dashboard Cancel (peer-only abandon before the checkpoint write lands; full
+   teardown after). Outside Accept, `session_reject` during pre-active
+   matchmaking cancels the attempt (including any in-flight async start) and
+   surfaces cancelled/error — it must not leave an orphan handshake; resolved
+   finished sessions without an Accept in flight keep their freeze. If accepted,
+   the peer marks itself
    busy, starts the WASM session as receiver, and drains the buffered handshake
-   bytes. A start failure before the live checkpoint replaces any terminal
-   save ends the peer attempt only (reject + clear provisional relay) and may
-   surface a session error warning; full attempt teardown is reserved for
-   failures after that persist succeeds.
+   bytes. A start failure or dashboard Cancel before the live checkpoint
+   write lands ends the peer attempt only (reject + clear provisional relay)
+   and must preserve any finished freeze / terminal IndexedDB save; full attempt
+   teardown is reserved for failures or Cancel after that persist succeeds. A
+   start failure past the intake wall may also surface a session error warning.
+   While an aborted Accept may still be draining its persist callback, the client
+   stays unavailable for new session prompts so a second Accept cannot race
+   checkpoint restore/cleanup.
 8. Both players exchange binary game frames through the addressed hub pipe.
    The reliability layer (msgno/ack/keepalive) is encoded inside the binary
    payload, peer-to-peer — the hub never interprets it.
@@ -1067,8 +1076,12 @@ flag beyond the optional surface cover.
 Shell releases the transition when the canonical dashboard selector moves past
 the setup **Cancel** action. Because that selector reads the projected
 `ChannelStatus`, the core remains authoritative for the commitment boundary.
-Cancellation uses the same `cancelDashboardSession` path as the visible
-dashboard button and explicitly releases any pending transition.
+Cancellation of an Accept attempt before the live checkpoint write lands uses
+`abandonFailedStartAttempt` (reject peer + clear provisional relay/transition)
+so a finished freeze and terminal IndexedDB save stay intact. After that write
+succeeds, Accept Cancel still goes through `abortAcceptAttemptIfActive`, which
+tears down via `cancelAttemptedSession` (full attempt cleanup) and releases the
+pending transition.
 
 ### Blockchain Connection Flow
 

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -426,7 +426,7 @@ are grouped under those phase-owned payloads:
 | `blockchainType`                | `'simulator' \| 'walletconnect'?`                                                                          | Which wallet backend is active or should be reconnected.                                                                                                                                                                                                                                                        |
 | `serializedGameSession`         | `Uint8Array?`                                                                                              | Raw binary WASM game-session state via `serialize()`.                                                                                                                                                                                                                                                           |
 | `gameSessionSchemaVersion`      | `bigint?`                                                                                                  | Rust-owned schema ID for `serializedGameSession`; currently `4`. Missing or mismatched IDs are unsupported and cleared before deserialization.                                                                                                                                                                  |
-| `pairingToken`                  | `string?`                                                                                                  | Hub pairing token, for reconciliation on reconnect.                                                                                                                                                                                                                                                             |
+| `pairingToken`                  | `string?`                                                                                                  | Locally generated identity for the current peer-session/controller instance. It is persisted so pre-cradle setup or a full session resumes into the same instance, and it correlates Shell transition completion with that instance; it is not protocol authority.                                              |
 | `sessionPeerId`                 | `string?`                                                                                                  | Public hub peer id of the current opponent, used to rebind `PeerSession` on restore.                                                                                                                                                                                                                            |
 | `myHubPlayerId`                 | `string?`                                                                                                  | Last public player id assigned by the hub, used only to detect remapping during resume.                                                                                                                                                                                                                         |
 | `gameSessionId`                 | `string?`                                                                                                  | Per-pairing game session id exchanged in `session_proposal`.                                                                                                                                                                                                                                                    |
@@ -646,6 +646,15 @@ projects channel / lifecycle labels and the primary action button
 (clean shutdown, go on-chain, abandon, etc.). `selectStatusBarBalances`
 projects the balance segments under those labels. Both read from the shared
 `SessionModel`; they are not a separate React-owned copy of channel state.
+
+During the short interval after the user accepts a session but before
+`GameSession` has reported its first model, Shell passes an explicit
+`setupPending` input to the same dashboard selector. This makes the existing
+primary action show **Cancel** immediately without introducing a second setup
+button or a parallel cancellation path. Once a model exists, the action is
+entirely core-derived: handshake and wallet-signing statuses remain
+**Cancel**, while `OfferSent` / `TransactionPending` cross the commitment
+boundary and project **Waiting** (or the later timer-gated **Abandon** action).
 
 The dashboard never derives whether a shutdown has value remaining from its
 displayed balances or game state. Rust provides `channelStatus.zero_payout`
@@ -1008,6 +1017,8 @@ The Shell is the top-level React component. It owns:
   (`useThemeSyncToIframe`)
 - **Tab navigation** — five tabs: Wallet, Hub, Game, History, Log
 - **Unique ID and session ID** — persisted in localStorage, stable across reloads
+- **Session lifecycle and transition presentation** — reducer-backed lifecycle
+  state plus scoped transition surfaces around asynchronous session operations
 
 The Shell does not know about game protocol details. When the hub challenge
 flow completes, Shell creates `GameSessionParams` with the total channel amount
@@ -1021,6 +1032,33 @@ and clearing session refs) are driven by Shell's
 after Rust's final `ChannelStatus` snapshot has been projected into React, so
 Shell preserves the final dashboard snapshot before tearing down the live
 controller.
+
+#### Session transition ownership
+
+Shell owns session transitions through `useShellSessionTransition` and the
+reducer in `front-end/src/lib/session/shellSessionState.ts`. A transition has a
+reason and a presentation scope:
+
+- `shell` replaces the whole shell for operations that intentionally make the
+  app unavailable.
+- `session-pane` preserves the tabs and `GameDashboard` while covering only the
+  game-content pane with `SessionTransitionSurface`.
+
+For accepted session setup, the transition is keyed atomically with the same
+`pairingToken` that identifies the new controller instance. Completion for a
+different instance is ignored.
+
+`GameSession` remains mounted underneath a session-pane transition. This lets
+the WASM/controller setup continue and keeps its existing notification overlays
+available above the presentation surface. `GameSession` reports its normal
+`SessionModel` to Shell; it has no transition-specific rendering mode or
+readiness flag.
+
+Shell releases the transition when the canonical dashboard selector moves past
+the setup **Cancel** action. Because that selector reads the projected
+`ChannelStatus`, the core remains authoritative for the commitment boundary.
+Cancellation uses the same `cancelDashboardSession` path as the visible
+dashboard button and explicitly releases any pending transition.
 
 ### Blockchain Connection Flow
 

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -648,16 +648,16 @@ projects the balance segments under those labels. Both read from the shared
 `SessionModel`; they are not a separate React-owned copy of channel state.
 
 During the short interval after the user accepts a session — before
-`GameSession` has reported its first model, and also while a prior finished
+`GameSession` has reported its first live model, and also while a prior finished
 freeze model is still mounted until `retireTerminalDisplay` runs after async
 `replaceSession` — Shell passes an explicit `setupPending` input to the same
 dashboard selector. This makes the existing primary action show **Cancel**
 immediately without introducing a second setup button or a parallel
-cancellation path. Once setup is no longer pending and a live model exists,
-the action is entirely core-derived: handshake and wallet-signing statuses
-remain **Cancel**, while `OfferSent` / `TransactionPending` cross the
-commitment boundary and project **Waiting** (or the later timer-gated
-**Abandon** action).
+cancellation path. Once a live (non-resolved) model exists, labels and actions
+are entirely core-derived even if the session-pane transition is still pending:
+handshake and wallet-signing statuses remain **Cancel**, while `OfferSent` /
+`TransactionPending` cross the commitment boundary and project **Waiting** (or
+the later timer-gated **Abandon** action).
 
 The dashboard never derives whether a shutdown has value remaining from its
 displayed balances or game state. Rust provides `channelStatus.zero_payout`

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -647,14 +647,17 @@ projects channel / lifecycle labels and the primary action button
 projects the balance segments under those labels. Both read from the shared
 `SessionModel`; they are not a separate React-owned copy of channel state.
 
-During the short interval after the user accepts a session but before
-`GameSession` has reported its first model, Shell passes an explicit
-`setupPending` input to the same dashboard selector. This makes the existing
-primary action show **Cancel** immediately without introducing a second setup
-button or a parallel cancellation path. Once a model exists, the action is
-entirely core-derived: handshake and wallet-signing statuses remain
-**Cancel**, while `OfferSent` / `TransactionPending` cross the commitment
-boundary and project **Waiting** (or the later timer-gated **Abandon** action).
+During the short interval after the user accepts a session — before
+`GameSession` has reported its first model, and also while a prior finished
+freeze model is still mounted until `retireTerminalDisplay` runs after async
+`replaceSession` — Shell passes an explicit `setupPending` input to the same
+dashboard selector. This makes the existing primary action show **Cancel**
+immediately without introducing a second setup button or a parallel
+cancellation path. Once setup is no longer pending and a live model exists,
+the action is entirely core-derived: handshake and wallet-signing statuses
+remain **Cancel**, while `OfferSent` / `TransactionPending` cross the
+commitment boundary and project **Waiting** (or the later timer-gated
+**Abandon** action).
 
 The dashboard never derives whether a shutdown has value remaining from its
 displayed balances or game state. Rust provides `channelStatus.zero_payout`

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -1035,8 +1035,9 @@ The Shell is the top-level React component. It owns:
   (`useThemeSyncToIframe`)
 - **Tab navigation** — five tabs: Wallet, Hub, Game, History, Log
 - **Unique ID and session ID** — persisted in localStorage, stable across reloads
-- **Session lifecycle and transition presentation** — reducer-backed lifecycle
-  state plus scoped transition surfaces around asynchronous session operations
+- **Session lifecycle and Accept presentation** — `useShellSessionState` fields
+  plus `useAcceptLifecycle` / `acceptLifecycle` for Accept abort, persist, and
+  session-pane setup covers
 
 The Shell does not know about game protocol details. When the hub challenge
 flow completes, Shell creates `GameSessionParams` with the total channel amount
@@ -1053,35 +1054,36 @@ controller.
 
 #### Session transition ownership
 
-Shell owns session transitions through `useShellSessionTransition` and the
-reducer in `front-end/src/lib/session/shellSessionState.ts`. A transition has a
-reason and a presentation scope:
+Accept ownership lives in `front-end/src/lib/session/acceptLifecycle.ts` and
+`useAcceptLifecycle`, composed by Shell. Session fields and the Accept
+session-pane transition bookkeeping live in `useShellSessionState` /
+`shellSessionState.ts`.
 
-- `shell` replaces the whole shell for operations that intentionally make the
-  app unavailable.
-- `session-pane` preserves the tabs and `GameDashboard` while covering only the
-  game-content pane with `SessionTransitionSurface`.
+Accept session setup is always `session-pane` scope: tabs and `GameDashboard`
+stay mounted while `SessionTransitionSurface` covers only the game-content
+pane. Shell renders that cover only before `GameSession` is kept; once
+mounted, `GameSession` hosts the same surface under its notification z-index
+so overlays remain clickable.
 
-For accepted session setup, the transition is keyed atomically with the same
-`pairingToken` that identifies the new controller instance. Completion for a
-different instance is ignored.
+`beginAccept` clears consent prompts atomically with entering the pending
+transition, keyed by the same `pairingToken` that identifies the new
+controller instance. Completion for a different instance is ignored.
 
-`GameSession` remains mounted underneath a session-pane transition. The
-presentation surface is rendered inside `GameSession` (below its notification
-z-index) so WASM/controller setup can continue while existing notification
-overlays stay available and clickable above the surface. `GameSession` reports
-its normal `SessionModel` to Shell; it has no transition-specific readiness
-flag beyond the optional surface cover.
+Shell releases the transition via `shouldCompleteAcceptTransition`: true once
+the projected `ChannelStatus` leaves Cancel-only setup states. The core remains
+authoritative for that commitment boundary.
 
-Shell releases the transition when the canonical dashboard selector moves past
-the setup **Cancel** action. Because that selector reads the projected
-`ChannelStatus`, the core remains authoritative for the commitment boundary.
-Cancellation of an Accept attempt before the live checkpoint write lands uses
-`abandonFailedStartAttempt` (reject peer + clear provisional relay/transition)
-so a finished freeze and terminal IndexedDB save stay intact. After that write
-succeeds, Accept Cancel still goes through `abortAcceptAttemptIfActive`, which
-tears down via `cancelAttemptedSession` (full attempt cleanup) and releases the
-pending transition.
+`abortAccept` is the single Accept abort API (Cancel, `session_reject`,
+`delivery_failure`, remap, disconnect-during-Accept). It owns `session_reject`
+when a peer id is supplied and chooses freeze-safe disposition:
+pre-`replaceSession` → peer-only abandon via atomic `acceptAborted` (finished
+freeze + terminal IndexedDB stay); after the write lands → full attempt
+teardown via `cancelAttemptedSession`. `persistFreshStartCheckpoint` marks the
+write committed as soon as `replaceSession` succeeds, so a Cancel-race restore
+failure still takes full teardown rather than leaving an orphan live cradle.
+While Accept is pending or its persist callback is still draining,
+`getPresence` / wallet-reconnect busy and local prompt availability all stay
+blocked so hub re-identify cannot advertise available mid-Accept.
 
 ### Blockchain Connection Flow
 

--- a/front-end/src/components/GameSession.tsx
+++ b/front-end/src/components/GameSession.tsx
@@ -28,6 +28,7 @@ import {
   peerProposalIdNeedsGameTabAttention,
 } from '../lib/gameTabAttention';
 import { shouldReportSessionPhase } from '../lib/restoreLifecycle';
+import { SessionTransitionSurface } from './SessionTransitionSurface';
 import {
   PRE_ACTIVE_CHANNEL_STATES,
   selectInertGameInterfaceForBetweenHandDialog,
@@ -564,6 +565,8 @@ export interface GameSessionProps {
   suppressPhaseReporting?: boolean;
   blockchain: BlockchainPoller | null;
   terminalPresentation?: TerminalSessionPresentation | null;
+  /** Cover game content during session-pane setup; stays under notification z-index. */
+  showTransitionSurface?: boolean;
 }
 
 const MountedGameSession: React.FC<GameSessionProps & { sessionController: SessionController }> = ({
@@ -580,6 +583,7 @@ const MountedGameSession: React.FC<GameSessionProps & { sessionController: Sessi
   blockchain,
   sessionController,
   terminalPresentation,
+  showTransitionSurface = false,
 }) => {
   const session = useGameSession(
     params,
@@ -844,6 +848,17 @@ const MountedGameSession: React.FC<GameSessionProps & { sessionController: Sessi
             </>
           )}
       </div>
+
+      {/*
+        Cover content during session-pane setup inside GameSession's stacking
+        context so notification overlays (z-40 / z-50) stay clickable above it.
+        A Shell sibling at z-30 would paint over those overlays.
+      */}
+      {showTransitionSurface && (
+        <div className="absolute inset-0 z-20" aria-hidden>
+          <SessionTransitionSurface />
+        </div>
+      )}
 
       {showBetweenHandOverlay && (
         <BetweenHandOverlay restoreFocus={restoreGameAreaFocus}>

--- a/front-end/src/components/GameSession.tsx
+++ b/front-end/src/components/GameSession.tsx
@@ -29,6 +29,7 @@ import {
 } from '../lib/gameTabAttention';
 import { shouldReportSessionPhase } from '../lib/restoreLifecycle';
 import { SessionTransitionSurface } from './SessionTransitionSurface';
+import { ACCEPT_SETTING_UP_COPY } from '../lib/session/acceptLifecycle';
 import {
   PRE_ACTIVE_CHANNEL_STATES,
   selectInertGameInterfaceForBetweenHandDialog,
@@ -801,11 +802,6 @@ const MountedGameSession: React.FC<GameSessionProps & { sessionController: Sessi
             </GameAreaErrorBoundary>
           )}
 
-          {(!handEverStarted || PRE_ACTIVE_CHANNEL_STATES.has(session.channelStatus.state)) && (
-            <div className="flex items-center justify-center py-20">
-              <p className="text-canvas-text">Setting up channel…</p>
-            </div>
-          )}
           {handEverStarted &&
             !PRE_ACTIVE_CHANNEL_STATES.has(session.channelStatus.state) &&
             !gameSpecificView.displayGameId &&
@@ -850,14 +846,21 @@ const MountedGameSession: React.FC<GameSessionProps & { sessionController: Sessi
       </div>
 
       {/*
-        Cover content during session-pane setup inside GameSession's stacking
-        context so notification overlays (z-40 / z-50) stay clickable above it.
-        A Shell sibling at z-30 would paint over those overlays.
+        Full-pane centered setup copy. SessionTransitionSurface covers Accept
+        cancel states; once that cover drops (OfferSent / TransactionPending)
+        keep the same absolute centering so the text does not jump to the top.
+        z-20 stays under notification overlays (z-40 / z-50).
       */}
-      {showTransitionSurface && (
+      {showTransitionSurface ? (
         <div className="absolute inset-0 z-20" aria-hidden>
           <SessionTransitionSurface />
         </div>
+      ) : (
+        (!handEverStarted || PRE_ACTIVE_CHANNEL_STATES.has(session.channelStatus.state)) && (
+          <div className="absolute inset-0 z-20 flex items-center justify-center pointer-events-none">
+            <p className="text-canvas-text">{ACCEPT_SETTING_UP_COPY}</p>
+          </div>
+        )
       )}
 
       {showBetweenHandOverlay && (

--- a/front-end/src/components/GameSession.tsx
+++ b/front-end/src/components/GameSession.tsx
@@ -894,7 +894,11 @@ const GameSession: React.FC<GameSessionProps> = (props) => {
     props.blockchain,
     props.terminalPresentation != null,
   );
-  if (!sessionController) return null;
+  if (!sessionController) {
+    // keepSession mounts us before the post-commit controller exists; keep the
+    // session-pane cover visible so accept does not flash a blank pane.
+    return props.showTransitionSurface ? <SessionTransitionSurface /> : null;
+  }
   return <MountedGameSession {...props} sessionController={sessionController} />;
 };
 

--- a/front-end/src/components/SessionTransitionSurface.tsx
+++ b/front-end/src/components/SessionTransitionSurface.tsx
@@ -1,0 +1,13 @@
+export function SessionTransitionSurface() {
+  return (
+    <div className="relative w-full h-full min-h-0 flex flex-col bg-canvas-bg-subtle text-canvas-text pt-6">
+      <div className="flex flex-col gap-2 px-4 pb-2 sm:px-6 md:px-8">
+        <div className="relative overflow-hidden z-0">
+          <div className="flex items-center justify-center py-20">
+            <p className="text-canvas-text">Setting up channel…</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/components/SessionTransitionSurface.tsx
+++ b/front-end/src/components/SessionTransitionSurface.tsx
@@ -1,13 +1,9 @@
+import { ACCEPT_SETTING_UP_COPY } from '../lib/session/acceptLifecycle';
+
 export function SessionTransitionSurface() {
   return (
-    <div className="relative w-full h-full min-h-0 flex flex-col bg-canvas-bg-subtle text-canvas-text pt-6">
-      <div className="flex flex-col gap-2 px-4 pb-2 sm:px-6 md:px-8">
-        <div className="relative overflow-hidden z-0">
-          <div className="flex items-center justify-center py-20">
-            <p className="text-canvas-text">Setting up channel…</p>
-          </div>
-        </div>
-      </div>
+    <div className="w-full h-full min-h-0 flex items-center justify-center bg-canvas-bg-subtle text-canvas-text">
+      <p className="text-canvas-text">{ACCEPT_SETTING_UP_COPY}</p>
     </div>
   );
 }

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 
+import { useShellSessionTransition } from '../hooks/useShellSessionTransition';
+import {
+  PendingSessionProposal,
+  ShellSessionTransitionReason,
+} from '../lib/session/shellSessionState';
 import GameSession from './GameSession';
 import { GameSessionErrorBoundary, UncaughtClientErrorReporter } from './GameSession';
+import { SessionTransitionSurface } from './SessionTransitionSurface';
 import FinishedSessionGameView from './FinishedSessionGameView';
 import { SimulatorSetupModal } from './SimulatorSetupModal';
 import QRCode from 'qrcode';
@@ -199,16 +205,6 @@ function sessionSaveForReactProps(save: SessionSave | null): SessionSave | undef
   }
   return propSafeSave;
 }
-
-type PendingSessionProposal = {
-  from_id: string;
-  from_alias: string;
-  proposer_amount: string;
-  responder_amount: string;
-  channel_timeout?: string;
-  unroll_timeout?: string;
-  game_session_id?: string;
-};
 
 type SessionStartRequest = {
   peerId: string;
@@ -631,6 +627,24 @@ function LogPanel({ lines }: { lines: string[] }) {
   );
 }
 
+function SessionTransitionOverlay({ reason }: { reason: ShellSessionTransitionReason }) {
+  const labels: Record<ShellSessionTransitionReason, string> = {
+    'accept-advisory': 'Starting session…',
+    'accept-proposal': 'Starting session…',
+    resume: 'Resuming…',
+    'start-over': 'Starting over…',
+    disconnect: 'Disconnecting…',
+    finish: 'Finishing session…',
+  };
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-canvas-bg-subtle text-canvas-text">
+      <div className="flex flex-col items-center gap-2">
+        <p className="text-lg font-semibold">{labels[reason]}</p>
+      </div>
+    </div>
+  );
+}
+
 const Shell = () => {
   const uniqueId = getPlayerId();
   // Do not mint hub sessionId here — boot must hydrate IndexedDB first
@@ -647,12 +661,24 @@ const Shell = () => {
     setActiveTabRaw(tab);
     saveActiveTab(tab);
   }, []);
-  const [sessionConfig, setSessionConfig] = useState<GameSessionParams | null>(null);
+  // Shell-level session lifecycle state and transition guard.
+  const {
+    state: shellState,
+    dispatch: shellDispatch,
+    runTransition,
+    completeTransition,
+    cancelTransition,
+  } = useShellSessionTransition();
+  const shellDispatchRef = useRef(shellDispatch);
+  shellDispatchRef.current = shellDispatch;
+  const sessionConfig = shellState.sessionConfig;
   const sessionConfigRef = useRef<GameSessionParams | null>(null);
   sessionConfigRef.current = sessionConfig;
   const [transactionPublishNerfed, setTransactionPublishNerfed] = useState(false);
-  const [peerConn, setPeerConn] = useState<PeerConnectionResult | null>(null);
-  const [dashboardSessionModel, setDashboardSessionModel] = useState<SessionModel | null>(null);
+  const peerConn = shellState.peerConn;
+  const dashboardSessionModel = shellState.dashboardSessionModel;
+  const dashboardSessionModelRef = useRef<SessionModel | null>(null);
+  dashboardSessionModelRef.current = dashboardSessionModel;
   const [terminalPresentation, setTerminalPresentation] =
     useState<TerminalSessionPresentation | null>(null);
   const [finishedSessionIdentity, setFinishedSessionIdentity] = useState<{
@@ -672,17 +698,19 @@ const Shell = () => {
   const waitingStateRef = useRef<SessionModel['channel']['status']['state'] | null>(null);
 
   // Consent prompt state for the new hub protocol
-  const [pendingAdvisory, setPendingAdvisory] = useState<AdvisoryStartParams | null>(null);
+  const pendingAdvisory = shellState.pendingAdvisory;
   const pendingAdvisoryRef = useRef<AdvisoryStartParams | null>(null);
+  pendingAdvisoryRef.current = pendingAdvisory;
   const setPendingAdvisoryState = useCallback((next: AdvisoryStartParams | null) => {
     pendingAdvisoryRef.current = next;
-    setPendingAdvisory(next);
+    shellDispatchRef.current({ type: 'setPendingAdvisory', value: next });
   }, []);
-  const [pendingProposal, setPendingProposal] = useState<PendingSessionProposal | null>(null);
+  const pendingProposal = shellState.pendingProposal;
   const pendingProposalRef = useRef<PendingSessionProposal | null>(null);
+  pendingProposalRef.current = pendingProposal;
   const setPendingProposalState = useCallback((next: PendingSessionProposal | null) => {
     pendingProposalRef.current = next;
-    setPendingProposal(next);
+    shellDispatchRef.current({ type: 'setPendingProposal', value: next });
   }, []);
   const peerSessionRef = useRef<PeerSession | null>(null);
   const peerMessageHandlerRef = useRef<import('../services/PeerSession').MessageHandler | null>(
@@ -711,6 +739,54 @@ const Shell = () => {
   }, []);
   const getCoins = useCallback(() => coinsGetterRef.current?.() ?? frozenCoins, [frozenCoins]);
 
+  const setSessionConfig = useCallback((value: GameSessionParams | null) => {
+    sessionConfigRef.current = value;
+    shellDispatchRef.current({ type: 'setSessionConfig', value });
+  }, []);
+
+  const setPeerConn = useCallback((value: PeerConnectionResult | null) => {
+    shellDispatchRef.current({ type: 'setPeerConn', value });
+  }, []);
+
+  const setDashboardSessionModel = useCallback(
+    (value: SessionModel | null | ((prev: SessionModel | null) => SessionModel | null)) => {
+      const next = typeof value === 'function' ? value(dashboardSessionModelRef.current) : value;
+      dashboardSessionModelRef.current = next;
+      shellDispatchRef.current({ type: 'setDashboardSessionModel', value: next });
+    },
+    [],
+  );
+
+  const setSessionPhase = useCallback((value: SessionPhase) => {
+    shellDispatchRef.current({ type: 'setSessionPhase', value });
+  }, []);
+
+  const sessionPhase = shellState.sessionPhase;
+
+  const setSessionError = useCallback((value: boolean) => {
+    shellDispatchRef.current({ type: 'setSessionError', value });
+  }, []);
+
+  const sessionError = shellState.sessionError;
+
+  const setRestoreStatus = useCallback((value: RestoreStatus) => {
+    shellDispatchRef.current({ type: 'setRestoreStatus', value });
+  }, []);
+
+  const restoreStatus = shellState.restoreStatus;
+
+  const setRestoreError = useCallback((value: string | null) => {
+    shellDispatchRef.current({ type: 'setRestoreError', value });
+  }, []);
+
+  const restoreError = shellState.restoreError;
+
+  const setRestoreHubReconciled = useCallback((value: boolean) => {
+    shellDispatchRef.current({ type: 'setRestoreHubReconciled', value });
+  }, []);
+
+  const restoreHubReconciled = shellState.restoreHubReconciled;
+
   const stablePeerConn: PeerConnectionResult = useMemo(
     () => ({
       sendMessage: (n, m) => (peerSessionRef.current ?? IDLE_PEER_CONNECTION).sendMessage(n, m),
@@ -725,11 +801,6 @@ const Shell = () => {
   const [walletConnected, setWalletConnected] = useState(false);
   const [hubLiveness, setHubLiveness] = useState<HubLiveness | null>(null);
   const [peerLiveness, setPeerLiveness] = useState<PeerLiveness>(null);
-  const [sessionPhase, setSessionPhase] = useState<SessionPhase>('none');
-  const [sessionError, setSessionError] = useState(false);
-  const [restoreStatus, setRestoreStatus] = useState<RestoreStatus>('idle');
-  const [restoreError, setRestoreError] = useState<string | null>(null);
-  const [restoreHubReconciled, setRestoreHubReconciled] = useState(false);
   const [confirmDialog, setConfirmDialog] = useState<{
     title: string;
     body: string;
@@ -1093,7 +1164,7 @@ const Shell = () => {
   const sessionStartedRef = useRef(false);
   const sessionFinishedCleanupRef = useRef(false);
   const sessionPhaseRef = useRef<SessionPhase>('none');
-  const dashboardSessionModelRef = useRef<SessionModel | null>(null);
+  sessionPhaseRef.current = sessionPhase;
   /** Bumped on cancel so in-flight startFreshSessionWithPeer aborts after awaits. */
   const sessionStartEpochRef = useRef(0);
 
@@ -1227,185 +1298,220 @@ const Shell = () => {
       setRestoreStatus('idle');
       setRestoreError(null);
       setRestoreHubReconciled(false);
+      cancelTransition();
       hubConnRef.current?.setBusy(shouldReportHubBusy('none', walletConnectedRef.current));
     },
     [
+      cancelTransition,
       clearSessionPreservingHistory,
       resetPeerRelayState,
       setPendingAdvisoryState,
       setPendingProposalState,
+      setDashboardSessionModel,
+      setPeerConn,
+      setRestoreError,
+      setRestoreHubReconciled,
+      setRestoreStatus,
+      setSessionConfig,
+      setSessionError,
+      setSessionPhase,
     ],
   );
 
   const startFreshSessionWithPeer = useCallback(
-    async (request: SessionStartRequest & { gameSessionId?: string }) => {
-      const conn = hubConnRef.current;
-      if (!conn) return;
-      const epoch = sessionStartEpochRef.current;
-
-      let myContribution: bigint;
-      let theirContribution: bigint;
+    async (
+      request: SessionStartRequest & {
+        gameSessionId?: string;
+        pairingToken: string;
+      },
+    ) => {
       try {
-        myContribution = parseSessionAmount(request.myAmount);
-        theirContribution = parseSessionAmount(request.theirAmount);
-      } catch (e) {
-        console.error('[Shell] rejecting session start with invalid amounts', e);
-        setSessionError(true);
-        return;
-      }
-      const minContribution =
-        myContribution < theirContribution ? myContribution : theirContribution;
-      const perGame = minContribution / 10n || 1n;
-      const sessionId = request.gameSessionId ?? generateSessionId();
-      const token = `peer_${request.peerId}_${Date.now()}`;
-      const hubSessionId = getSessionId();
+        const conn = hubConnRef.current;
+        if (!conn) throw new Error('hub connection unavailable during session start');
+        const epoch = sessionStartEpochRef.current;
+        const myContribution = parseSessionAmount(request.myAmount);
+        const theirContribution = parseSessionAmount(request.theirAmount);
+        const minContribution =
+          myContribution < theirContribution ? myContribution : theirContribution;
+        const perGame = minContribution / 10n || 1n;
+        const sessionId = request.gameSessionId ?? generateSessionId();
+        const token = request.pairingToken;
+        const hubSessionId = getSessionId();
 
-      const existing = peerSessionRef.current;
-      if (
-        existing &&
-        !existing.isDestroyed() &&
-        existing.peerId === request.peerId &&
-        existing.sessionId === sessionId
-      ) {
-        // Reuse provisional PeerSession created when the proposal arrived (preserves buffered messages).
-      } else {
-        existing?.destroy();
-        peerSessionRef.current = new PeerSession(request.peerId, sessionId, conn);
-        bindPeerMessageHandler(peerSessionRef.current);
-      }
-      const channelTimeout = parseOptionalBigInt(request.channel_timeout);
-      const unrollTimeout = parseOptionalBigInt(request.unroll_timeout);
-      const diagnosticLog = loadState().history.diagnosticLog;
-      const wasmNotificationHistory = loadState().history.wasmNotificationHistory;
+        const existing = peerSessionRef.current;
+        if (
+          existing &&
+          !existing.isDestroyed() &&
+          existing.peerId === request.peerId &&
+          existing.sessionId === sessionId
+        ) {
+          // Reuse provisional PeerSession created when the proposal arrived (preserves buffered messages).
+        } else {
+          existing?.destroy();
+          peerSessionRef.current = new PeerSession(request.peerId, sessionId, conn);
+          bindPeerMessageHandler(peerSessionRef.current);
+        }
+        const channelTimeout = parseOptionalBigInt(request.channel_timeout);
+        const unrollTimeout = parseOptionalBigInt(request.unroll_timeout);
+        const diagnosticLog = loadState().history.diagnosticLog;
+        const wasmNotificationHistory = loadState().history.wasmNotificationHistory;
 
-      await transitionToFreshSession({
-        reportBusy: () => conn.setBusy(true),
-        retireTerminalDisplay: () => {
-          sessionStartedRef.current = false;
-          sessionFinishedCleanupRef.current = false;
-          sessionPhaseRef.current = 'none';
-          if (cleanShutdownGraceTimerRef.current !== null) {
-            clearTimeout(cleanShutdownGraceTimerRef.current);
-            cleanShutdownGraceTimerRef.current = null;
-          }
-          if (abandonTimerRef.current !== null) {
-            clearTimeout(abandonTimerRef.current);
-            abandonTimerRef.current = null;
-          }
-          waitingEnteredAtRef.current = null;
-          waitingStateRef.current = null;
-          setAbandonEnabled(false);
-          setCleanShutdownGraceActive(false);
-          setSessionPhase('none');
-          setSessionError(false);
-          setRestoreStatus('idle');
-          setRestoreError(null);
-          setRestoreHubReconciled(true);
-          dashboardSessionModelRef.current = null;
-          setDashboardSessionModel(null);
-          setTerminalPresentation(null);
-          setSessionConfig(null);
-          setPeerConn(null);
-          destroySessionController();
-        },
-        persistLiveCheckpoint: async () => {
-          // Atomically replace the terminal envelope with the full pre-cradle
-          // handshake before GameSession mounts and fetches hex assets. A
-          // stale-deploy reload mid-fetch must Resume with the same
-          // pairing/amounts/peer ids and hub session_id.
-          await replaceSession({
-            pairing: {
-              token,
-              peerId: request.peerId,
-              gameSessionId: sessionId,
+        await transitionToFreshSession({
+          reportBusy: () => conn.setBusy(true),
+          retireTerminalDisplay: () => {
+            sessionStartedRef.current = false;
+            sessionFinishedCleanupRef.current = false;
+            sessionPhaseRef.current = 'none';
+            if (cleanShutdownGraceTimerRef.current !== null) {
+              clearTimeout(cleanShutdownGraceTimerRef.current);
+              cleanShutdownGraceTimerRef.current = null;
+            }
+            if (abandonTimerRef.current !== null) {
+              clearTimeout(abandonTimerRef.current);
+              abandonTimerRef.current = null;
+            }
+            waitingEnteredAtRef.current = null;
+            waitingStateRef.current = null;
+            setAbandonEnabled(false);
+            setCleanShutdownGraceActive(false);
+            setSessionPhase('none');
+            setSessionError(false);
+            setRestoreStatus('idle');
+            setRestoreError(null);
+            setRestoreHubReconciled(true);
+            dashboardSessionModelRef.current = null;
+            setDashboardSessionModel(null);
+            setTerminalPresentation(null);
+            setSessionConfig(null);
+            setPeerConn(null);
+            destroySessionController();
+          },
+          persistLiveCheckpoint: async () => {
+            // Atomically replace the terminal envelope with the full pre-cradle
+            // handshake before GameSession mounts and fetches hex assets. A
+            // stale-deploy reload mid-fetch must Resume with the same
+            // pairing/amounts/peer ids and hub session_id.
+            await replaceSession({
+              pairing: {
+                token,
+                peerId: request.peerId,
+                gameSessionId: sessionId,
+                iStarted: request.iStarted,
+                myContribution: myContribution.toString(),
+                theirContribution: theirContribution.toString(),
+                perGameAmount: perGame.toString(),
+                opponentAlias: request.opponentAlias,
+                ...(channelTimeout !== undefined
+                  ? { channelTimeout: channelTimeout.toString() }
+                  : {}),
+                ...(unrollTimeout !== undefined
+                  ? { unrollTimeout: unrollTimeout.toString() }
+                  : {}),
+              },
+              identity: {
+                sessionId: hubSessionId,
+                ...(conn.getPlayerId() ? { myHubPlayerId: conn.getPlayerId()! } : {}),
+              },
+              history: {
+                ...(historyRef.current.length > 0 ? { humanHistory: historyRef.current } : {}),
+                ...(diagnosticLog && diagnosticLog.length > 0 ? { diagnosticLog } : {}),
+                ...(wasmNotificationHistory && wasmNotificationHistory.length > 0
+                  ? { wasmNotificationHistory }
+                  : {}),
+              },
+            });
+          },
+          mountLiveSession: () => {
+            if (epoch !== sessionStartEpochRef.current) {
+              log(
+                `[Shell] startFreshSessionWithPeer aborted: cancelled during persist peer=${request.peerId}`,
+              );
+              return;
+            }
+            try {
+              getActiveBlockchain().start();
+            } catch {
+              /* not connected */
+            }
+            setSessionConfig({
               iStarted: request.iStarted,
-              myContribution: myContribution.toString(),
-              theirContribution: theirContribution.toString(),
-              perGameAmount: perGame.toString(),
+              myContribution,
+              theirContribution,
+              perGameAmount: perGame,
+              restoring: false,
+              pairingToken: token,
+              myAlias: undefined,
               opponentAlias: request.opponentAlias,
-              ...(channelTimeout !== undefined
-                ? { channelTimeout: channelTimeout.toString() }
-                : {}),
-              ...(unrollTimeout !== undefined ? { unrollTimeout: unrollTimeout.toString() } : {}),
-            },
-            identity: {
-              sessionId: hubSessionId,
-              ...(conn.getPlayerId() ? { myHubPlayerId: conn.getPlayerId()! } : {}),
-            },
-            history: {
-              ...(historyRef.current.length > 0 ? { humanHistory: historyRef.current } : {}),
-              ...(diagnosticLog && diagnosticLog.length > 0 ? { diagnosticLog } : {}),
-              ...(wasmNotificationHistory && wasmNotificationHistory.length > 0
-                ? { wasmNotificationHistory }
-                : {}),
-            },
-          });
-        },
-        mountLiveSession: () => {
-          if (epoch !== sessionStartEpochRef.current) {
-            log(
-              `[Shell] startFreshSessionWithPeer aborted: cancelled during persist peer=${request.peerId}`,
-            );
-            return;
-          }
-          try {
-            getActiveBlockchain().start();
-          } catch {
-            /* not connected */
-          }
-          setSessionConfig({
-            iStarted: request.iStarted,
-            myContribution,
-            theirContribution,
-            perGameAmount: perGame,
-            restoring: false,
-            pairingToken: token,
-            myAlias: undefined,
-            opponentAlias: request.opponentAlias,
-            channelTimeout,
-            unrollTimeout,
-          });
-          setPeerConn(stablePeerConn);
-          setPeerLiveness(null);
-        },
-      });
+              channelTimeout,
+              unrollTimeout,
+            });
+            setPeerConn(stablePeerConn);
+            setPeerLiveness(null);
+          },
+        });
+      } catch (error) {
+        console.error('[Shell] session start failed', error);
+        sendSessionReject(request.peerId);
+        cancelAttemptedSession({ error: true });
+      }
     },
-    [stablePeerConn, bindPeerMessageHandler],
+    [
+      stablePeerConn,
+      bindPeerMessageHandler,
+      cancelAttemptedSession,
+      sendSessionReject,
+      setDashboardSessionModel,
+      setPeerConn,
+      setRestoreError,
+      setRestoreHubReconciled,
+      setRestoreStatus,
+      setSessionConfig,
+      setSessionError,
+      setSessionPhase,
+    ],
   );
 
   const acceptPendingAdvisory = useCallback(
     (advisory: AdvisoryStartParams) => {
       const conn = hubConnRef.current;
-      if (!conn) return;
-      setPendingAdvisoryState(null);
-      const gameSessionId = generateSessionId();
-      // Reserve the peer relay before sending so a delivery_failure for this
-      // proposal can cancel the attempt (PeerSession must already exist).
-      peerSessionRef.current?.destroy();
-      peerSessionRef.current = new PeerSession(advisory.peer_id, gameSessionId, conn);
-      bindPeerMessageHandler(peerSessionRef.current);
-      conn.sendPeerAppMessage(advisory.peer_id, {
-        type: 'session_proposal',
-        proposer_amount: advisory.my_amount,
-        responder_amount: advisory.their_amount,
-        // Hub-synced alias only — never getAlias(), which invents Player_*.
-        from_alias: peekAlias(),
-        channel_timeout: advisory.channel_timeout,
-        unroll_timeout: advisory.unroll_timeout,
-        game_session_id: gameSessionId,
-      });
-      startFreshSessionWithPeer({
-        peerId: advisory.peer_id,
-        opponentAlias: advisory.peer_alias,
-        myAmount: advisory.my_amount,
-        theirAmount: advisory.their_amount,
-        channel_timeout: advisory.channel_timeout,
-        unroll_timeout: advisory.unroll_timeout,
-        iStarted: true,
-        gameSessionId,
-      });
+      if (!conn || pendingAdvisoryRef.current !== advisory) return;
+      const pairingToken = `peer_${advisory.peer_id}_${Date.now()}`;
+      void runTransition(
+        'accept-advisory',
+        async () => {
+          setPendingAdvisoryState(null);
+          const gameSessionId = generateSessionId();
+          // Reserve the peer relay before sending so a delivery_failure for this
+          // proposal can cancel the attempt (PeerSession must already exist).
+          peerSessionRef.current?.destroy();
+          peerSessionRef.current = new PeerSession(advisory.peer_id, gameSessionId, conn);
+          bindPeerMessageHandler(peerSessionRef.current);
+          conn.sendPeerAppMessage(advisory.peer_id, {
+            type: 'session_proposal',
+            proposer_amount: advisory.my_amount,
+            responder_amount: advisory.their_amount,
+            // Hub-synced alias only — never getAlias(), which invents Player_*.
+            from_alias: peekAlias(),
+            channel_timeout: advisory.channel_timeout,
+            unroll_timeout: advisory.unroll_timeout,
+            game_session_id: gameSessionId,
+          });
+          await startFreshSessionWithPeer({
+            peerId: advisory.peer_id,
+            opponentAlias: advisory.peer_alias,
+            myAmount: advisory.my_amount,
+            theirAmount: advisory.their_amount,
+            channel_timeout: advisory.channel_timeout,
+            unroll_timeout: advisory.unroll_timeout,
+            iStarted: true,
+            gameSessionId,
+            pairingToken,
+          });
+        },
+        { scope: 'session-pane', waitForReady: true, readyKey: pairingToken },
+      );
     },
-    [setPendingAdvisoryState, startFreshSessionWithPeer, bindPeerMessageHandler],
+    [runTransition, setPendingAdvisoryState, startFreshSessionWithPeer, bindPeerMessageHandler],
   );
 
   const declinePendingAdvisory = useCallback(
@@ -1418,19 +1524,28 @@ const Shell = () => {
 
   const acceptPendingProposal = useCallback(
     (proposal: PendingSessionProposal) => {
-      setPendingProposalState(null);
-      startFreshSessionWithPeer({
-        peerId: proposal.from_id,
-        opponentAlias: proposal.from_alias,
-        myAmount: proposal.responder_amount,
-        theirAmount: proposal.proposer_amount,
-        channel_timeout: proposal.channel_timeout,
-        unroll_timeout: proposal.unroll_timeout,
-        iStarted: false,
-        gameSessionId: proposal.game_session_id,
-      });
+      if (pendingProposalRef.current !== proposal) return;
+      const pairingToken = `peer_${proposal.from_id}_${Date.now()}`;
+      void runTransition(
+        'accept-proposal',
+        async () => {
+          setPendingProposalState(null);
+          await startFreshSessionWithPeer({
+            peerId: proposal.from_id,
+            opponentAlias: proposal.from_alias,
+            myAmount: proposal.responder_amount,
+            theirAmount: proposal.proposer_amount,
+            channel_timeout: proposal.channel_timeout,
+            unroll_timeout: proposal.unroll_timeout,
+            iStarted: false,
+            gameSessionId: proposal.game_session_id,
+            pairingToken,
+          });
+        },
+        { scope: 'session-pane', waitForReady: true, readyKey: pairingToken },
+      );
     },
-    [setPendingProposalState, startFreshSessionWithPeer],
+    [runTransition, setPendingProposalState, startFreshSessionWithPeer],
   );
 
   const declinePendingProposal = useCallback(
@@ -2091,15 +2206,25 @@ const Shell = () => {
       setRestoreHubReconciled(false);
       setPendingAdvisoryState(null);
       setPendingProposalState(null);
+      cancelTransition();
       hubConnRef.current?.setBusy(shouldReportHubBusy('none', walletConnectedRef.current), alias);
     },
     [
+      cancelTransition,
       clearSessionPreservingHistory,
       clearSessionTimers,
       resetPeerRelayState,
       sendSessionReject,
       setPendingAdvisoryState,
       setPendingProposalState,
+      setDashboardSessionModel,
+      setPeerConn,
+      setRestoreError,
+      setRestoreHubReconciled,
+      setRestoreStatus,
+      setSessionConfig,
+      setSessionError,
+      setSessionPhase,
     ],
   );
 
@@ -2217,22 +2342,32 @@ const Shell = () => {
     [finishResolvedSessionDisplay, setActiveTab, startBalancePolling],
   );
 
-  const handleRestoreStatusChange = useCallback((status: RestoreStatus, error: string | null) => {
-    setRestoreStatus(status);
-    setRestoreError(error);
-    setDashboardSessionModel((prev) =>
-      prev ? { ...prev, restore: { ...prev.restore, status, error } } : prev,
-    );
-    if (status === 'failed') {
-      markSavedSession();
-      setSessionError(true);
-    }
-  }, []);
+  const handleRestoreStatusChange = useCallback(
+    (status: RestoreStatus, error: string | null) => {
+      setRestoreStatus(status);
+      setRestoreError(error);
+      setDashboardSessionModel((prev) =>
+        prev ? { ...prev, restore: { ...prev.restore, status, error } } : prev,
+      );
+      if (status === 'failed') {
+        markSavedSession();
+        setSessionError(true);
+      }
+    },
+    [setDashboardSessionModel, setRestoreError, setRestoreStatus, setSessionError],
+  );
 
-  const handleSessionModelChange = useCallback((model: SessionModel) => {
-    dashboardSessionModelRef.current = model;
-    setDashboardSessionModel(model);
-  }, []);
+  const handleSessionModelChange = useCallback(
+    (model: SessionModel) => {
+      dashboardSessionModelRef.current = model;
+      setDashboardSessionModel(model);
+      const pairingToken = sessionConfigRef.current?.pairingToken;
+      if (pairingToken && selectGameDashboardView(model).actionKind !== 'cancel') {
+        completeTransition(pairingToken);
+      }
+    },
+    [completeTransition, setDashboardSessionModel],
+  );
 
   const restoreBlocked = isRestoreBlocked(
     !!sessionConfig?.restoring,
@@ -3052,6 +3187,9 @@ const Shell = () => {
     );
   }
 
+  const sessionPaneTransition =
+    shellState.transition.kind === 'pending' && shellState.transition.scope === 'session-pane';
+
   const sessionCanMount = sessionConfig !== null && peerConn !== null;
   const { startSession: sessionReadyToStart, keepSession } = shouldMountGameSession(
     sessionCanMount,
@@ -3063,6 +3201,7 @@ const Shell = () => {
 
   const dashboardView: GameDashboardViewModel = selectGameDashboardView(dashboardSessionModel, {
     hasSession: dashboardSessionModel !== null,
+    setupPending: sessionPaneTransition,
     cleanShutdownGraceActive,
     abandonEnabled,
   });
@@ -3126,6 +3265,10 @@ const Shell = () => {
       </div>
     </div>
   ) : null;
+
+  if (shellState.transition.kind === 'pending' && shellState.transition.scope === 'shell') {
+    return <SessionTransitionOverlay reason={shellState.transition.reason} />;
+  }
 
   // --- Main tabbed app ---
   // autoResuming with session hydrated: mount the real tree invisibly so
@@ -3605,7 +3748,9 @@ const Shell = () => {
               getCoins={getCoins}
             />
             <div style={{ flex: '1 1 0%', minHeight: 0, overflow: 'auto' }}>
-              {keepSession && restoreStatus === 'failed' ? (
+              {sessionPaneTransition && !keepSession && !sessionCanMount ? (
+                <SessionTransitionSurface />
+              ) : keepSession && restoreStatus === 'failed' ? (
                 <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-canvas-text p-8">
                   <h2 className="text-lg font-semibold text-alert-text">Restore failed</h2>
                   <p className="max-w-lg text-sm text-center select-text cursor-text">
@@ -3640,6 +3785,11 @@ const Shell = () => {
                       terminalPresentation={terminalPresentation}
                     />
                   </GameSessionErrorBoundary>
+                  {sessionPaneTransition && (
+                    <div className="absolute inset-0 z-30">
+                      <SessionTransitionSurface />
+                    </div>
+                  )}
                   {sessionConsentOverlay}
                 </div>
               ) : sessionCanMount ? (

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -97,6 +97,7 @@ import {
   shouldReportHubBusyPresence,
   shouldSuppressPhaseReporting,
   shouldSwitchToHubOnResolved,
+  shouldSynthesizeSetupPending,
   transitionToFreshSession,
 } from '../lib/restoreLifecycle';
 import {
@@ -3252,6 +3253,9 @@ const Shell = () => {
 
   const sessionPaneTransition =
     shellState.transition.kind === 'pending' && shellState.transition.scope === 'session-pane';
+  // Finished freeze (resolved) is not a live setup model — keep Cancel synthesized
+  // until the first non-resolved SessionModel arrives from GameSession.
+  const hasLiveSessionModel = dashboardSessionModel !== null && sessionPhase !== 'resolved';
 
   const sessionCanMount = sessionConfig !== null && peerConn !== null;
   const { startSession: sessionReadyToStart, keepSession } = shouldMountGameSession(
@@ -3264,7 +3268,7 @@ const Shell = () => {
 
   const dashboardView: GameDashboardViewModel = selectGameDashboardView(dashboardSessionModel, {
     hasSession: dashboardSessionModel !== null,
-    setupPending: sessionPaneTransition,
+    setupPending: shouldSynthesizeSetupPending(sessionPaneTransition, hasLiveSessionModel),
     cleanShutdownGraceActive,
     abandonEnabled,
   });
@@ -3811,7 +3815,7 @@ const Shell = () => {
               getCoins={getCoins}
             />
             <div style={{ flex: '1 1 0%', minHeight: 0, overflow: 'auto' }}>
-              {sessionPaneTransition && !keepSession && !sessionCanMount ? (
+              {sessionPaneTransition && !keepSession ? (
                 <SessionTransitionSurface />
               ) : keepSession && restoreStatus === 'failed' ? (
                 <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-canvas-text p-8">

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -1358,8 +1358,9 @@ const Shell = () => {
         const diagnosticLog = loadState().history.diagnosticLog;
         const wasmNotificationHistory = loadState().history.wasmNotificationHistory;
 
-        await transitionToFreshSession({
+        const outcome = await transitionToFreshSession({
           reportBusy: () => conn.setBusy(true),
+          shouldAbort: () => epoch !== sessionStartEpochRef.current,
           retireTerminalDisplay: () => {
             sessionStartedRef.current = false;
             sessionFinishedCleanupRef.current = false;
@@ -1420,6 +1421,11 @@ const Shell = () => {
                   : {}),
               },
             });
+            // Cancel can interleave after replaceSession's awaits and still leave
+            // a durable pre-handshake checkpoint on the write chain. Drop it.
+            if (epoch !== sessionStartEpochRef.current) {
+              clearSessionPreservingHistory();
+            }
           },
           mountLiveSession: () => {
             if (epoch !== sessionStartEpochRef.current) {
@@ -1449,6 +1455,12 @@ const Shell = () => {
             setPeerLiveness(null);
           },
         });
+        if (outcome === 'aborted') {
+          log(
+            `[Shell] startFreshSessionWithPeer aborted: cancelled after persist peer=${request.peerId}`,
+          );
+          return;
+        }
       } catch (error) {
         console.error('[Shell] session start failed', error);
         sendSessionReject(request.peerId);
@@ -1459,6 +1471,7 @@ const Shell = () => {
       stablePeerConn,
       bindPeerMessageHandler,
       cancelAttemptedSession,
+      clearSessionPreservingHistory,
       sendSessionReject,
       setDashboardSessionModel,
       setPeerConn,
@@ -3836,13 +3849,9 @@ const Shell = () => {
                         terminalPresentation != null,
                       )}
                       terminalPresentation={terminalPresentation}
+                      showTransitionSurface={sessionPaneTransition}
                     />
                   </GameSessionErrorBoundary>
-                  {sessionPaneTransition && (
-                    <div className="absolute inset-0 z-30">
-                      <SessionTransitionSurface />
-                    </div>
-                  )}
                   {sessionConsentOverlay}
                 </div>
               ) : sessionPhase === 'resolved' && dashboardSessionModel ? (

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -4,6 +4,7 @@ import { useShellSessionTransition } from '../hooks/useShellSessionTransition';
 import {
   PendingSessionProposal,
   ShellSessionTransitionReason,
+  isAcceptSessionTransition,
 } from '../lib/session/shellSessionState';
 import GameSession from './GameSession';
 import { GameSessionErrorBoundary, UncaughtClientErrorReporter } from './GameSession';
@@ -47,6 +48,7 @@ import {
   peekAutoResumeOnce,
   clearAutoResumeOnce,
   loadState,
+  saveTerminalSession,
   LiveSessionSave,
   SessionSave,
   getDefaultFee,
@@ -650,6 +652,8 @@ const Shell = () => {
   } = useShellSessionTransition();
   const shellDispatchRef = useRef(shellDispatch);
   shellDispatchRef.current = shellDispatch;
+  const shellTransitionRef = useRef(shellState.transition);
+  shellTransitionRef.current = shellState.transition;
   const sessionConfig = shellState.sessionConfig;
   const sessionConfigRef = useRef<GameSessionParams | null>(null);
   sessionConfigRef.current = sessionConfig;
@@ -1146,6 +1150,10 @@ const Shell = () => {
   sessionPhaseRef.current = sessionPhase;
   /** Bumped on cancel so in-flight startFreshSessionWithPeer aborts after awaits. */
   const sessionStartEpochRef = useRef(0);
+  /** True once Accept's replaceSession write has landed. */
+  const freshStartPersistCommittedRef = useRef(false);
+  /** True while startFreshSessionWithPeer may still be inside persist/transition. */
+  const freshStartPersistInFlightRef = useRef(false);
 
   const deferStateUpdate = useCallback((fn: () => void) => {
     if (typeof queueMicrotask === 'function') {
@@ -1214,6 +1222,7 @@ const Shell = () => {
       pendingAdvisoryRef.current === null &&
       pendingProposalRef.current === null &&
       peerSessionRef.current === null &&
+      !freshStartPersistInFlightRef.current &&
       !(
         (sessionSaveRef.current?.phase === 'live' ||
           sessionSaveRef.current?.phase === 'pre-handshake') &&
@@ -1239,6 +1248,7 @@ const Shell = () => {
   const cancelAttemptedSession = useCallback(
     (options?: { error?: boolean }) => {
       sessionStartEpochRef.current += 1;
+      freshStartPersistCommittedRef.current = false;
       abandonPendingRef.current = false;
       setPendingAdvisoryState(null);
       setPendingProposalState(null);
@@ -1298,22 +1308,26 @@ const Shell = () => {
   );
 
   /**
-   * End a failed Accept without touching a finished freeze / terminal
+   * End an Accept attempt without touching a finished freeze / terminal
    * checkpoint that `transitionToFreshSession` never retired. Peer attempt
-   * only: reject already sent by caller; clear provisional relay + transition;
-   * surface sessionError as a should-never-happen belt-and-suspenders warning.
+   * only: clear provisional relay + transition; optional sessionError when
+   * used as a should-never-happen belt-and-suspenders warning.
    */
   const abandonFailedStartAttempt = useCallback(
     (options?: { error?: boolean }) => {
       sessionStartEpochRef.current += 1;
+      freshStartPersistCommittedRef.current = false;
       abandonPendingRef.current = false;
       setPendingAdvisoryState(null);
       setPendingProposalState(null);
       resetPeerRelayState();
       cancelTransition();
       setSessionError(!!options?.error);
+      // Stay busy while the aborted start may still be inside replaceSession /
+      // restore — otherwise a new Accept can race checkpoint cleanup.
       hubConnRef.current?.setBusy(
-        shouldReportHubBusy(sessionPhaseRef.current, walletConnectedRef.current),
+        freshStartPersistInFlightRef.current ||
+          shouldReportHubBusy(sessionPhaseRef.current, walletConnectedRef.current),
         sessionConfigRef.current?.myAlias ?? savedMyAlias(sessionSaveRef.current) ?? peekAlias(),
       );
     },
@@ -1326,6 +1340,23 @@ const Shell = () => {
     ],
   );
 
+  /**
+   * Abort an in-flight Accept with the freeze-safe disposition, or return false
+   * so the caller can fall through to ordinary matchmaking cancel rules.
+   */
+  const abortAcceptAttemptIfActive = useCallback(
+    (options?: { error?: boolean }): boolean => {
+      if (!isAcceptSessionTransition(shellTransitionRef.current)) return false;
+      if (startFailureDisposition(freshStartPersistCommittedRef.current) === 'abandon-peer-only') {
+        abandonFailedStartAttempt(options);
+      } else {
+        cancelAttemptedSession(options);
+      }
+      return true;
+    },
+    [abandonFailedStartAttempt, cancelAttemptedSession],
+  );
+
   const startFreshSessionWithPeer = useCallback(
     async (
       request: SessionStartRequest & {
@@ -1333,11 +1364,13 @@ const Shell = () => {
         pairingToken: string;
       },
     ) => {
-      let checkpointPersisted = false;
+      freshStartPersistCommittedRef.current = false;
+      freshStartPersistInFlightRef.current = true;
+      let epoch = sessionStartEpochRef.current;
       try {
         const conn = hubConnRef.current;
         if (!conn) throw new Error('hub connection unavailable during session start');
-        const epoch = sessionStartEpochRef.current;
+        epoch = sessionStartEpochRef.current;
         const myContribution = parseSessionAmount(request.myAmount);
         const theirContribution = parseSessionAmount(request.theirAmount);
         const minContribution =
@@ -1397,6 +1430,18 @@ const Shell = () => {
             destroySessionController();
           },
           persistLiveCheckpoint: async () => {
+            // Cancel / epoch bump before the write lands: keep the finished freeze.
+            if (epoch !== sessionStartEpochRef.current) return;
+            // Prefer durable cache over sessionSaveRef — finishResolvedSessionDisplay
+            // nulls the ref while loadState() still holds the terminal envelope.
+            const prior = loadState();
+            const terminalBackup =
+              prior.phase === 'terminal'
+                ? {
+                    terminal: structuredClone(prior.terminal),
+                    presentation: structuredClone(prior.presentation),
+                  }
+                : null;
             // Atomically replace the terminal envelope with the full pre-cradle
             // handshake before GameSession mounts and fetches hex assets. A
             // stale-deploy reload mid-fetch must Resume with the same
@@ -1428,12 +1473,19 @@ const Shell = () => {
                   : {}),
               },
             });
-            checkpointPersisted = true;
-            // Cancel can interleave after replaceSession's awaits and still leave
-            // a durable pre-handshake checkpoint on the write chain. Drop it.
+            // Cancel raced the write: restore the finished freeze rather than
+            // leaving preferences-only IndexedDB under a still-visible results UI.
             if (epoch !== sessionStartEpochRef.current) {
-              clearSessionPreservingHistory();
+              if (terminalBackup) {
+                await saveTerminalSession(terminalBackup);
+                sessionSaveRef.current = loadState();
+              } else {
+                clearSessionPreservingHistory();
+              }
+              return;
             }
+            // Only after the write: Cancel/failure must fully tear down the attempt.
+            freshStartPersistCommittedRef.current = true;
           },
           mountLiveSession: () => {
             if (epoch !== sessionStartEpochRef.current) {
@@ -1472,13 +1524,24 @@ const Shell = () => {
       } catch (error) {
         console.error('[Shell] session start failed', error);
         sendSessionReject(request.peerId);
-        if (startFailureDisposition(checkpointPersisted) === 'cancel-attempt') {
+        if (startFailureDisposition(freshStartPersistCommittedRef.current) === 'cancel-attempt') {
           cancelAttemptedSession({ error: true });
         } else {
-          // Persist never succeeded: finished freeze + terminal checkpoint remain.
+          // Persist never committed: finished freeze + terminal checkpoint remain.
           // End the peer attempt only and warn — parse/start failures past the
           // intake wall should never happen.
           abandonFailedStartAttempt({ error: true });
+        }
+      } finally {
+        freshStartPersistInFlightRef.current = false;
+        // Abandon kept the hub busy while this callback drained; release now.
+        if (epoch !== sessionStartEpochRef.current) {
+          hubConnRef.current?.setBusy(
+            shouldReportHubBusy(sessionPhaseRef.current, walletConnectedRef.current),
+            sessionConfigRef.current?.myAlias ??
+              savedMyAlias(sessionSaveRef.current) ??
+              peekAlias(),
+          );
         }
       }
     },
@@ -1508,39 +1571,54 @@ const Shell = () => {
       void runTransition(
         'accept-advisory',
         async () => {
-          setPendingAdvisoryState(null);
-          const gameSessionId = generateSessionId();
-          // Reserve the peer relay before sending so a delivery_failure for this
-          // proposal can cancel the attempt (PeerSession must already exist).
-          peerSessionRef.current?.destroy();
-          peerSessionRef.current = new PeerSession(advisory.peer_id, gameSessionId, conn);
-          bindPeerMessageHandler(peerSessionRef.current);
-          conn.sendPeerAppMessage(advisory.peer_id, {
-            type: 'session_proposal',
-            proposer_amount: advisory.my_amount,
-            responder_amount: advisory.their_amount,
-            // Hub-synced alias only — never getAlias(), which invents Player_*.
-            from_alias: peekAlias(),
-            channel_timeout: advisory.channel_timeout,
-            unroll_timeout: advisory.unroll_timeout,
-            game_session_id: gameSessionId,
-          });
-          await startFreshSessionWithPeer({
-            peerId: advisory.peer_id,
-            opponentAlias: advisory.peer_alias,
-            myAmount: advisory.my_amount,
-            theirAmount: advisory.their_amount,
-            channel_timeout: advisory.channel_timeout,
-            unroll_timeout: advisory.unroll_timeout,
-            iStarted: true,
-            gameSessionId,
-            pairingToken,
-          });
+          try {
+            setPendingAdvisoryState(null);
+            const gameSessionId = generateSessionId();
+            // Reserve the peer relay before sending so a delivery_failure for this
+            // proposal can cancel the attempt (PeerSession must already exist).
+            peerSessionRef.current?.destroy();
+            peerSessionRef.current = new PeerSession(advisory.peer_id, gameSessionId, conn);
+            bindPeerMessageHandler(peerSessionRef.current);
+            conn.sendPeerAppMessage(advisory.peer_id, {
+              type: 'session_proposal',
+              proposer_amount: advisory.my_amount,
+              responder_amount: advisory.their_amount,
+              // Hub-synced alias only — never getAlias(), which invents Player_*.
+              from_alias: peekAlias(),
+              channel_timeout: advisory.channel_timeout,
+              unroll_timeout: advisory.unroll_timeout,
+              game_session_id: gameSessionId,
+            });
+            await startFreshSessionWithPeer({
+              peerId: advisory.peer_id,
+              opponentAlias: advisory.peer_alias,
+              myAmount: advisory.my_amount,
+              theirAmount: advisory.their_amount,
+              channel_timeout: advisory.channel_timeout,
+              unroll_timeout: advisory.unroll_timeout,
+              iStarted: true,
+              gameSessionId,
+              pairingToken,
+            });
+          } catch (error) {
+            // Setup threw before startFreshSessionWithPeer could clean up (e.g.
+            // after PeerSession was reserved). Do not leave the lobby stuck.
+            console.error('[Shell] accept-advisory failed', error);
+            sendSessionReject(advisory.peer_id);
+            abandonFailedStartAttempt({ error: true });
+          }
         },
         { scope: 'session-pane', waitForReady: true, readyKey: pairingToken },
       );
     },
-    [runTransition, setPendingAdvisoryState, startFreshSessionWithPeer, bindPeerMessageHandler],
+    [
+      abandonFailedStartAttempt,
+      bindPeerMessageHandler,
+      runTransition,
+      sendSessionReject,
+      setPendingAdvisoryState,
+      startFreshSessionWithPeer,
+    ],
   );
 
   const declinePendingAdvisory = useCallback(
@@ -1558,23 +1636,35 @@ const Shell = () => {
       void runTransition(
         'accept-proposal',
         async () => {
-          setPendingProposalState(null);
-          await startFreshSessionWithPeer({
-            peerId: proposal.from_id,
-            opponentAlias: proposal.from_alias,
-            myAmount: proposal.responder_amount,
-            theirAmount: proposal.proposer_amount,
-            channel_timeout: proposal.channel_timeout,
-            unroll_timeout: proposal.unroll_timeout,
-            iStarted: false,
-            gameSessionId: proposal.game_session_id,
-            pairingToken,
-          });
+          try {
+            setPendingProposalState(null);
+            await startFreshSessionWithPeer({
+              peerId: proposal.from_id,
+              opponentAlias: proposal.from_alias,
+              myAmount: proposal.responder_amount,
+              theirAmount: proposal.proposer_amount,
+              channel_timeout: proposal.channel_timeout,
+              unroll_timeout: proposal.unroll_timeout,
+              iStarted: false,
+              gameSessionId: proposal.game_session_id,
+              pairingToken,
+            });
+          } catch (error) {
+            console.error('[Shell] accept-proposal failed', error);
+            sendSessionReject(proposal.from_id);
+            abandonFailedStartAttempt({ error: true });
+          }
         },
         { scope: 'session-pane', waitForReady: true, readyKey: pairingToken },
       );
     },
-    [runTransition, setPendingProposalState, startFreshSessionWithPeer],
+    [
+      abandonFailedStartAttempt,
+      runTransition,
+      sendSessionReject,
+      setPendingProposalState,
+      startFreshSessionWithPeer,
+    ],
   );
 
   const declinePendingProposal = useCallback(
@@ -1819,6 +1909,7 @@ const Shell = () => {
               if (ps?.peerId === fromId) {
                 log(`[Shell] session_reject from=${fromId}: cancelling attempted session`);
                 markPeerDead();
+                if (abortAcceptAttemptIfActive({ error: true })) return;
                 const channelState = dashboardSessionModelRef.current?.channel.status.state;
                 if (
                   shouldCancelOnPeerUnreachable(
@@ -1836,6 +1927,10 @@ const Shell = () => {
             console.warn('[Shell] delivery_failure to=%s', to);
             const ps = peerSessionRef.current;
             if (!ps || to !== ps.peerId) return;
+            if (abortAcceptAttemptIfActive()) {
+              markPeerDead();
+              return;
+            }
             const channelState = dashboardSessionModelRef.current?.channel.status.state;
             if (
               shouldCancelOnPeerUnreachable(
@@ -1866,28 +1961,41 @@ const Shell = () => {
             // Pre-cradle routing is by peer player_id. If *we* remapped (hub
             // restart or session_id churn), abort rather than handshaking at a
             // stale sessionPeerId. First-ever register (no prior id) is fine.
-            if (
-              prevMine &&
-              prevMine !== playerId &&
-              (pairing?.token || sessionConfigRef.current?.pairingToken) &&
-              save?.phase !== 'live' &&
-              shouldCancelOnPeerUnreachable(
-                sessionPhaseRef.current,
-                dashboardSessionModelRef.current?.channel.status.state,
-                abandonPendingRef.current,
-              )
-            ) {
-              console.warn(
-                '[Shell] hub player_id remapped during pre-cradle handshake (%s → %s); rematch required',
-                prevMine,
-                playerId,
-              );
-              log(
-                `[hub] player_id remapped during pre-cradle handshake (${prevMine} → ${playerId}); rematch required`,
-              );
-              saveSession({ scope: 'common', identity: { myHubPlayerId: playerId } });
-              cancelAttemptedSession();
-              return;
+            // Cold Accept may not have pairing/sessionConfig tokens yet — still
+            // abort an in-flight Accept transition (same as session_reject).
+            if (prevMine && prevMine !== playerId && save?.phase !== 'live') {
+              if (abortAcceptAttemptIfActive()) {
+                console.warn(
+                  '[Shell] hub player_id remapped during pre-cradle handshake (%s → %s); rematch required',
+                  prevMine,
+                  playerId,
+                );
+                log(
+                  `[hub] player_id remapped during pre-cradle handshake (${prevMine} → ${playerId}); rematch required`,
+                );
+                saveSession({ scope: 'common', identity: { myHubPlayerId: playerId } });
+                return;
+              }
+              if (
+                (pairing?.token || sessionConfigRef.current?.pairingToken) &&
+                shouldCancelOnPeerUnreachable(
+                  sessionPhaseRef.current,
+                  dashboardSessionModelRef.current?.channel.status.state,
+                  abandonPendingRef.current,
+                )
+              ) {
+                console.warn(
+                  '[Shell] hub player_id remapped during pre-cradle handshake (%s → %s); rematch required',
+                  prevMine,
+                  playerId,
+                );
+                log(
+                  `[hub] player_id remapped during pre-cradle handshake (${prevMine} → ${playerId}); rematch required`,
+                );
+                saveSession({ scope: 'common', identity: { myHubPlayerId: playerId } });
+                cancelAttemptedSession();
+                return;
+              }
             }
             saveSession({ scope: 'common', identity: { myHubPlayerId: playerId } });
             if (save) save.identity.myHubPlayerId = playerId;
@@ -1980,6 +2088,7 @@ const Shell = () => {
       markPeerInactive,
       markPeerDead,
       cancelAttemptedSession,
+      abortAcceptAttemptIfActive,
       isAvailableForNewSessionPrompt,
       sendSessionReject,
       setPendingAdvisoryState,
@@ -2217,6 +2326,7 @@ const Shell = () => {
   const cancelDashboardSession = useCallback(
     (options?: { retainFinishedGuard?: boolean }) => {
       sessionStartEpochRef.current += 1;
+      freshStartPersistCommittedRef.current = false;
       abandonPendingRef.current = false;
       const alias =
         sessionConfigRef.current?.myAlias ?? savedMyAlias(sessionSaveRef.current) ?? peekAlias();
@@ -2880,13 +2990,14 @@ const Shell = () => {
         !!sessionConfigRef.current?.pairingToken ||
         sessionSaveRef.current?.phase === 'live' ||
         sessionSaveRef.current?.phase === 'pre-handshake';
+      const accepting = isAcceptSessionTransition(shellTransitionRef.current);
       const shouldCancel = shouldCancelAttemptOnDisconnect(
         hasAttempt,
         sessionPhaseRef.current,
         channelState,
         abandonPendingRef.current,
       );
-      if (hasPendingPrompt || shouldCancel) {
+      if (hasPendingPrompt || shouldCancel || accepting) {
         const peerId =
           peerSessionRef.current?.peerId ??
           pendingProposalRef.current?.from_id ??
@@ -2897,7 +3008,10 @@ const Shell = () => {
             : undefined);
         if (peerId) sendSessionReject(peerId);
       }
-      if (shouldCancel) {
+      if (accepting) {
+        if (!preserveHub) saveHubUrl(undefined);
+        abortAcceptAttemptIfActive();
+      } else if (shouldCancel) {
         if (!preserveHub) saveHubUrl(undefined);
         cancelAttemptedSession();
       } else {
@@ -2912,6 +3026,7 @@ const Shell = () => {
       }
     },
     [
+      abortAcceptAttemptIfActive,
       cancelAttemptedSession,
       resetPeerRelayState,
       sendSessionReject,
@@ -3068,9 +3183,22 @@ const Shell = () => {
   const handleDashboardAction = useCallback(
     (kind: GameDashboardActionKind) => {
       switch (kind) {
-        case 'cancel':
+        case 'cancel': {
+          // During Accept, Cancel before the checkpoint write lands must not wipe
+          // a finished freeze — same disposition as a pre-persist start failure.
+          if (isAcceptSessionTransition(shellState.transition)) {
+            const saved = sessionSaveRef.current;
+            const peerId =
+              peerSessionRef.current?.peerId ??
+              (saved?.phase === 'live' || saved?.phase === 'pre-handshake'
+                ? saved.pairing.peerId
+                : undefined);
+            if (peerId) sendSessionReject(peerId);
+            if (abortAcceptAttemptIfActive()) break;
+          }
           cancelDashboardSession();
           break;
+        }
         case 'clean-shutdown':
           requestDashboardCleanShutdown();
           break;
@@ -3102,9 +3230,12 @@ const Shell = () => {
     },
     [
       abandonActiveChannel,
+      abortAcceptAttemptIfActive,
       cancelDashboardSession,
       requestDashboardCleanShutdown,
       requestDashboardGoOnChain,
+      sendSessionReject,
+      shellState.transition,
     ],
   );
 

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -1,11 +1,18 @@
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 
-import { useShellSessionTransition } from '../hooks/useShellSessionTransition';
+import { useAcceptLifecycle } from '../hooks/useAcceptLifecycle';
+import { useShellSessionState } from '../hooks/useShellSessionState';
 import {
   PendingSessionProposal,
-  ShellSessionTransitionReason,
   isAcceptSessionTransition,
 } from '../lib/session/shellSessionState';
+import {
+  persistFreshStartCheckpoint,
+  shouldCompleteAcceptTransition,
+  shouldSynthesizeSetupPending,
+  startFailureDisposition,
+} from '../lib/session/acceptLifecycle';
+import { selectGamePaneKind } from '../lib/session/gamePane';
 import GameSession from './GameSession';
 import { GameSessionErrorBoundary, UncaughtClientErrorReporter } from './GameSession';
 import { SessionTransitionSurface } from './SessionTransitionSurface';
@@ -99,7 +106,6 @@ import {
   shouldReportHubBusyPresence,
   shouldSuppressPhaseReporting,
   shouldSwitchToHubOnResolved,
-  shouldSynthesizeSetupPending,
   transitionToFreshSession,
 } from '../lib/restoreLifecycle';
 import {
@@ -125,7 +131,6 @@ import {
   isValidTimeoutString,
   parseOptionalBigInt,
   parseSessionAmount,
-  startFailureDisposition,
 } from '../lib/session/peerSessionParams';
 import { sessionModelForReactProps } from '../lib/session/finishedSessionDisplay';
 import { finalizeTerminalSession } from '../lib/session/terminalFinalization';
@@ -324,18 +329,23 @@ function savedOpponentAlias(save: SessionSave | null | undefined): string | unde
   return undefined;
 }
 
-/** Hub busy from phase, wallet, and any in-progress non-terminal restore cradle. */
+/** Hub busy from phase, wallet, restore cradle, and in-flight Accept work. */
 function hubBusyFromSessionState(
   phase: SessionPhase,
   walletConnected: boolean,
   restoring: boolean,
   save: SessionSave | null | undefined,
+  acceptBusy?: { pending?: boolean; persistInFlight?: boolean },
 ): boolean {
-  return shouldReportHubBusyPresence(phase, walletConnected, {
-    restoring,
-    terminalSave: !!save && isTerminalSavedChannel(save),
-    hasCradle: save?.phase === 'live' || save?.phase === 'pre-handshake',
-  });
+  return (
+    !!acceptBusy?.pending ||
+    !!acceptBusy?.persistInFlight ||
+    shouldReportHubBusyPresence(phase, walletConnected, {
+      restoring,
+      terminalSave: !!save && isTerminalSavedChannel(save),
+      hasCradle: save?.phase === 'live' || save?.phase === 'pre-handshake',
+    })
+  );
 }
 
 /** Tab to show before any resume hydrate — session restores always open on Game. */
@@ -608,24 +618,6 @@ function LogPanel({ lines }: { lines: string[] }) {
   );
 }
 
-function SessionTransitionOverlay({ reason }: { reason: ShellSessionTransitionReason }) {
-  const labels: Record<ShellSessionTransitionReason, string> = {
-    'accept-advisory': 'Starting session…',
-    'accept-proposal': 'Starting session…',
-    resume: 'Resuming…',
-    'start-over': 'Starting over…',
-    disconnect: 'Disconnecting…',
-    finish: 'Finishing session…',
-  };
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-canvas-bg-subtle text-canvas-text">
-      <div className="flex flex-col items-center gap-2">
-        <p className="text-lg font-semibold">{labels[reason]}</p>
-      </div>
-    </div>
-  );
-}
-
 const Shell = () => {
   const uniqueId = getPlayerId();
   // Do not mint hub sessionId here — boot must hydrate IndexedDB first
@@ -642,14 +634,24 @@ const Shell = () => {
     setActiveTabRaw(tab);
     saveActiveTab(tab);
   }, []);
-  // Shell-level session lifecycle state and transition guard.
+  // Shell session fields + Accept session-pane transition bookkeeping.
   const {
     state: shellState,
     dispatch: shellDispatch,
-    runTransition,
+    beginAcceptTransition,
     completeTransition,
     cancelTransition,
-  } = useShellSessionTransition();
+  } = useShellSessionState();
+  const {
+    sessionStartEpochRef,
+    freshStartPersistCommittedRef,
+    freshStartPersistInFlightRef,
+    bumpStartEpoch,
+    beginPersistFlight,
+    endPersistFlight,
+    markPersistCommitted,
+    abortAccept,
+  } = useAcceptLifecycle();
   const shellDispatchRef = useRef(shellDispatch);
   shellDispatchRef.current = shellDispatch;
   const shellTransitionRef = useRef(shellState.transition);
@@ -1148,12 +1150,6 @@ const Shell = () => {
   const sessionFinishedCleanupRef = useRef(false);
   const sessionPhaseRef = useRef<SessionPhase>('none');
   sessionPhaseRef.current = sessionPhase;
-  /** Bumped on cancel so in-flight startFreshSessionWithPeer aborts after awaits. */
-  const sessionStartEpochRef = useRef(0);
-  /** True once Accept's replaceSession write has landed. */
-  const freshStartPersistCommittedRef = useRef(false);
-  /** True while startFreshSessionWithPeer may still be inside persist/transition. */
-  const freshStartPersistInFlightRef = useRef(false);
 
   const deferStateUpdate = useCallback((fn: () => void) => {
     if (typeof queueMicrotask === 'function') {
@@ -1222,6 +1218,7 @@ const Shell = () => {
       pendingAdvisoryRef.current === null &&
       pendingProposalRef.current === null &&
       peerSessionRef.current === null &&
+      !isAcceptSessionTransition(shellTransitionRef.current) &&
       !freshStartPersistInFlightRef.current &&
       !(
         (sessionSaveRef.current?.phase === 'live' ||
@@ -1229,7 +1226,7 @@ const Shell = () => {
         sessionSaveRef.current.pairing.peerId
       )
     );
-  }, []);
+  }, [freshStartPersistInFlightRef]);
 
   const sendSessionReject = useCallback((peerId: string) => {
     hubConnRef.current?.sendPeerAppMessage(peerId, { type: 'session_reject' });
@@ -1247,11 +1244,10 @@ const Shell = () => {
 
   const cancelAttemptedSession = useCallback(
     (options?: { error?: boolean }) => {
-      sessionStartEpochRef.current += 1;
-      freshStartPersistCommittedRef.current = false;
+      bumpStartEpoch();
       abandonPendingRef.current = false;
-      setPendingAdvisoryState(null);
-      setPendingProposalState(null);
+      pendingAdvisoryRef.current = null;
+      pendingProposalRef.current = null;
       resetPeerRelayState();
       destroySessionController();
       clearSessionPreservingHistory();
@@ -1278,7 +1274,6 @@ const Shell = () => {
       setAbandonEnabled(false);
       setCleanShutdownGraceActive(false);
       setSessionPhase('none');
-      setSessionError(!!options?.error);
       setSessionConfig(null);
       setPeerConn(null);
       dashboardSessionModelRef.current = null;
@@ -1287,22 +1282,19 @@ const Shell = () => {
       setRestoreStatus('idle');
       setRestoreError(null);
       setRestoreHubReconciled(false);
-      cancelTransition();
+      shellDispatchRef.current({ type: 'acceptAborted', error: !!options?.error });
       hubConnRef.current?.setBusy(shouldReportHubBusy('none', walletConnectedRef.current));
     },
     [
-      cancelTransition,
+      bumpStartEpoch,
       clearSessionPreservingHistory,
       resetPeerRelayState,
-      setPendingAdvisoryState,
-      setPendingProposalState,
       setDashboardSessionModel,
       setPeerConn,
       setRestoreError,
       setRestoreHubReconciled,
       setRestoreStatus,
       setSessionConfig,
-      setSessionError,
       setSessionPhase,
     ],
   );
@@ -1310,19 +1302,17 @@ const Shell = () => {
   /**
    * End an Accept attempt without touching a finished freeze / terminal
    * checkpoint that `transitionToFreshSession` never retired. Peer attempt
-   * only: clear provisional relay + transition; optional sessionError when
-   * used as a should-never-happen belt-and-suspenders warning.
+   * only: clear provisional relay + transition; optional sessionError for
+   * real Accept setup failures.
    */
   const abandonFailedStartAttempt = useCallback(
     (options?: { error?: boolean }) => {
-      sessionStartEpochRef.current += 1;
-      freshStartPersistCommittedRef.current = false;
+      bumpStartEpoch();
       abandonPendingRef.current = false;
-      setPendingAdvisoryState(null);
-      setPendingProposalState(null);
+      pendingAdvisoryRef.current = null;
+      pendingProposalRef.current = null;
       resetPeerRelayState();
-      cancelTransition();
-      setSessionError(!!options?.error);
+      shellDispatchRef.current({ type: 'acceptAborted', error: !!options?.error });
       // Stay busy while the aborted start may still be inside replaceSession /
       // restore — otherwise a new Accept can race checkpoint cleanup.
       hubConnRef.current?.setBusy(
@@ -1331,30 +1321,29 @@ const Shell = () => {
         sessionConfigRef.current?.myAlias ?? savedMyAlias(sessionSaveRef.current) ?? peekAlias(),
       );
     },
-    [
-      cancelTransition,
-      resetPeerRelayState,
-      setPendingAdvisoryState,
-      setPendingProposalState,
-      setSessionError,
-    ],
+    [bumpStartEpoch, freshStartPersistInFlightRef, resetPeerRelayState],
+  );
+
+  const acceptAbortHandlers = useMemo(
+    () => ({
+      getTransition: () => shellTransitionRef.current,
+      abandonPeerOnly: abandonFailedStartAttempt,
+      cancelAttempt: cancelAttemptedSession,
+      sendSessionReject,
+    }),
+    [abandonFailedStartAttempt, cancelAttemptedSession, sendSessionReject],
   );
 
   /**
    * Abort an in-flight Accept with the freeze-safe disposition, or return false
    * so the caller can fall through to ordinary matchmaking cancel rules.
+   * Owns session_reject when peerId is provided.
    */
-  const abortAcceptAttemptIfActive = useCallback(
-    (options?: { error?: boolean }): boolean => {
-      if (!isAcceptSessionTransition(shellTransitionRef.current)) return false;
-      if (startFailureDisposition(freshStartPersistCommittedRef.current) === 'abandon-peer-only') {
-        abandonFailedStartAttempt(options);
-      } else {
-        cancelAttemptedSession(options);
-      }
-      return true;
+  const abortAcceptIfActive = useCallback(
+    (options?: { error?: boolean; peerId?: string }): boolean => {
+      return abortAccept(acceptAbortHandlers, options);
     },
-    [abandonFailedStartAttempt, cancelAttemptedSession],
+    [abortAccept, acceptAbortHandlers],
   );
 
   const startFreshSessionWithPeer = useCallback(
@@ -1364,8 +1353,7 @@ const Shell = () => {
         pairingToken: string;
       },
     ) => {
-      freshStartPersistCommittedRef.current = false;
-      freshStartPersistInFlightRef.current = true;
+      beginPersistFlight();
       let epoch = sessionStartEpochRef.current;
       try {
         const conn = hubConnRef.current;
@@ -1430,88 +1418,70 @@ const Shell = () => {
             destroySessionController();
           },
           persistLiveCheckpoint: async () => {
-            // Cancel / epoch bump before the write lands: keep the finished freeze.
-            if (epoch !== sessionStartEpochRef.current) return;
-            // Prefer durable cache over sessionSaveRef — finishResolvedSessionDisplay
-            // nulls the ref while loadState() still holds the terminal envelope.
-            const prior = loadState();
-            const terminalBackup =
-              prior.phase === 'terminal'
-                ? {
-                    terminal: structuredClone(prior.terminal),
-                    presentation: structuredClone(prior.presentation),
-                  }
-                : null;
-            // Atomically replace the terminal envelope with the full pre-cradle
-            // handshake before GameSession mounts and fetches hex assets. A
-            // stale-deploy reload mid-fetch must Resume with the same
-            // pairing/amounts/peer ids and hub session_id.
-            await replaceSession({
-              pairing: {
-                token,
-                peerId: request.peerId,
-                gameSessionId: sessionId,
-                iStarted: request.iStarted,
-                myContribution: myContribution.toString(),
-                theirContribution: theirContribution.toString(),
-                perGameAmount: perGame.toString(),
-                opponentAlias: request.opponentAlias,
-                ...(channelTimeout !== undefined
-                  ? { channelTimeout: channelTimeout.toString() }
-                  : {}),
-                ...(unrollTimeout !== undefined ? { unrollTimeout: unrollTimeout.toString() } : {}),
-              },
-              identity: {
-                sessionId: hubSessionId,
-                ...(conn.getPlayerId() ? { myHubPlayerId: conn.getPlayerId()! } : {}),
-              },
-              history: {
-                ...(historyRef.current.length > 0 ? { humanHistory: historyRef.current } : {}),
-                ...(diagnosticLog && diagnosticLog.length > 0 ? { diagnosticLog } : {}),
-                ...(wasmNotificationHistory && wasmNotificationHistory.length > 0
-                  ? { wasmNotificationHistory }
-                  : {}),
-              },
-            });
-            // Cancel raced the write: restore the finished freeze rather than
-            // leaving preferences-only IndexedDB under a still-visible results UI.
-            if (epoch !== sessionStartEpochRef.current) {
-              if (terminalBackup) {
-                await saveTerminalSession(terminalBackup);
+            await persistFreshStartCheckpoint({
+              epoch,
+              getCurrentEpoch: () => sessionStartEpochRef.current,
+              loadState,
+              replaceSession,
+              saveTerminalSession: async (fields) => {
+                await saveTerminalSession(fields);
                 sessionSaveRef.current = loadState();
-              } else {
-                clearSessionPreservingHistory();
-              }
-              return;
-            }
-            // Only after the write: Cancel/failure must fully tear down the attempt.
-            freshStartPersistCommittedRef.current = true;
+              },
+              clearSessionPreservingHistory,
+              checkpoint: {
+                pairing: {
+                  token,
+                  peerId: request.peerId,
+                  gameSessionId: sessionId,
+                  iStarted: request.iStarted,
+                  myContribution: myContribution.toString(),
+                  theirContribution: theirContribution.toString(),
+                  perGameAmount: perGame.toString(),
+                  opponentAlias: request.opponentAlias,
+                  ...(channelTimeout !== undefined
+                    ? { channelTimeout: channelTimeout.toString() }
+                    : {}),
+                  ...(unrollTimeout !== undefined
+                    ? { unrollTimeout: unrollTimeout.toString() }
+                    : {}),
+                },
+                identity: {
+                  sessionId: hubSessionId,
+                  ...(conn.getPlayerId() ? { myHubPlayerId: conn.getPlayerId()! } : {}),
+                },
+                history: {
+                  ...(historyRef.current.length > 0 ? { humanHistory: historyRef.current } : {}),
+                  ...(diagnosticLog && diagnosticLog.length > 0 ? { diagnosticLog } : {}),
+                  ...(wasmNotificationHistory && wasmNotificationHistory.length > 0
+                    ? { wasmNotificationHistory }
+                    : {}),
+                },
+              },
+              onCommitted: markPersistCommitted,
+            });
           },
           mountLiveSession: () => {
-            if (epoch !== sessionStartEpochRef.current) {
-              log(
-                `[Shell] startFreshSessionWithPeer aborted: cancelled during persist peer=${request.peerId}`,
-              );
-              return;
-            }
             try {
               getActiveBlockchain().start();
             } catch {
               /* not connected */
             }
-            setSessionConfig({
-              iStarted: request.iStarted,
-              myContribution,
-              theirContribution,
-              perGameAmount: perGame,
-              restoring: false,
-              pairingToken: token,
-              myAlias: undefined,
-              opponentAlias: request.opponentAlias,
-              channelTimeout,
-              unrollTimeout,
+            shellDispatchRef.current({
+              type: 'liveMounted',
+              sessionConfig: {
+                iStarted: request.iStarted,
+                myContribution,
+                theirContribution,
+                perGameAmount: perGame,
+                restoring: false,
+                pairingToken: token,
+                myAlias: undefined,
+                opponentAlias: request.opponentAlias,
+                channelTimeout,
+                unrollTimeout,
+              },
+              peerConn: stablePeerConn,
             });
-            setPeerConn(stablePeerConn);
             setPeerLiveness(null);
           },
         });
@@ -1528,12 +1498,10 @@ const Shell = () => {
           cancelAttemptedSession({ error: true });
         } else {
           // Persist never committed: finished freeze + terminal checkpoint remain.
-          // End the peer attempt only and warn — parse/start failures past the
-          // intake wall should never happen.
           abandonFailedStartAttempt({ error: true });
         }
       } finally {
-        freshStartPersistInFlightRef.current = false;
+        endPersistFlight();
         // Abandon kept the hub busy while this callback drained; release now.
         if (epoch !== sessionStartEpochRef.current) {
           hubConnRef.current?.setBusy(
@@ -1548,10 +1516,15 @@ const Shell = () => {
     [
       stablePeerConn,
       abandonFailedStartAttempt,
+      beginPersistFlight,
       bindPeerMessageHandler,
       cancelAttemptedSession,
       clearSessionPreservingHistory,
+      endPersistFlight,
+      freshStartPersistCommittedRef,
+      markPersistCommitted,
       sendSessionReject,
+      sessionStartEpochRef,
       setDashboardSessionModel,
       setPeerConn,
       setRestoreError,
@@ -1568,55 +1541,49 @@ const Shell = () => {
       const conn = hubConnRef.current;
       if (!conn || pendingAdvisoryRef.current !== advisory) return;
       const pairingToken = `peer_${advisory.peer_id}_${Date.now()}`;
-      void runTransition(
-        'accept-advisory',
-        async () => {
-          try {
-            setPendingAdvisoryState(null);
-            const gameSessionId = generateSessionId();
-            // Reserve the peer relay before sending so a delivery_failure for this
-            // proposal can cancel the attempt (PeerSession must already exist).
-            peerSessionRef.current?.destroy();
-            peerSessionRef.current = new PeerSession(advisory.peer_id, gameSessionId, conn);
-            bindPeerMessageHandler(peerSessionRef.current);
-            conn.sendPeerAppMessage(advisory.peer_id, {
-              type: 'session_proposal',
-              proposer_amount: advisory.my_amount,
-              responder_amount: advisory.their_amount,
-              // Hub-synced alias only — never getAlias(), which invents Player_*.
-              from_alias: peekAlias(),
-              channel_timeout: advisory.channel_timeout,
-              unroll_timeout: advisory.unroll_timeout,
-              game_session_id: gameSessionId,
-            });
-            await startFreshSessionWithPeer({
-              peerId: advisory.peer_id,
-              opponentAlias: advisory.peer_alias,
-              myAmount: advisory.my_amount,
-              theirAmount: advisory.their_amount,
-              channel_timeout: advisory.channel_timeout,
-              unroll_timeout: advisory.unroll_timeout,
-              iStarted: true,
-              gameSessionId,
-              pairingToken,
-            });
-          } catch (error) {
-            // Setup threw before startFreshSessionWithPeer could clean up (e.g.
-            // after PeerSession was reserved). Do not leave the lobby stuck.
-            console.error('[Shell] accept-advisory failed', error);
-            sendSessionReject(advisory.peer_id);
-            abandonFailedStartAttempt({ error: true });
-          }
-        },
-        { scope: 'session-pane', waitForReady: true, readyKey: pairingToken },
-      );
+      void beginAcceptTransition('accept-advisory', pairingToken, async () => {
+        try {
+          const gameSessionId = generateSessionId();
+          // Reserve the peer relay before sending so a delivery_failure for this
+          // proposal can cancel the attempt (PeerSession must already exist).
+          peerSessionRef.current?.destroy();
+          peerSessionRef.current = new PeerSession(advisory.peer_id, gameSessionId, conn);
+          bindPeerMessageHandler(peerSessionRef.current);
+          conn.sendPeerAppMessage(advisory.peer_id, {
+            type: 'session_proposal',
+            proposer_amount: advisory.my_amount,
+            responder_amount: advisory.their_amount,
+            // Hub-synced alias only — never getAlias(), which invents Player_*.
+            from_alias: peekAlias(),
+            channel_timeout: advisory.channel_timeout,
+            unroll_timeout: advisory.unroll_timeout,
+            game_session_id: gameSessionId,
+          });
+          await startFreshSessionWithPeer({
+            peerId: advisory.peer_id,
+            opponentAlias: advisory.peer_alias,
+            myAmount: advisory.my_amount,
+            theirAmount: advisory.their_amount,
+            channel_timeout: advisory.channel_timeout,
+            unroll_timeout: advisory.unroll_timeout,
+            iStarted: true,
+            gameSessionId,
+            pairingToken,
+          });
+        } catch (error) {
+          // Setup threw before startFreshSessionWithPeer could clean up (e.g.
+          // after PeerSession was reserved). Do not leave the lobby stuck.
+          console.error('[Shell] accept-advisory failed', error);
+          sendSessionReject(advisory.peer_id);
+          abandonFailedStartAttempt({ error: true });
+        }
+      });
     },
     [
       abandonFailedStartAttempt,
+      beginAcceptTransition,
       bindPeerMessageHandler,
-      runTransition,
       sendSessionReject,
-      setPendingAdvisoryState,
       startFreshSessionWithPeer,
     ],
   );
@@ -1633,36 +1600,30 @@ const Shell = () => {
     (proposal: PendingSessionProposal) => {
       if (pendingProposalRef.current !== proposal) return;
       const pairingToken = `peer_${proposal.from_id}_${Date.now()}`;
-      void runTransition(
-        'accept-proposal',
-        async () => {
-          try {
-            setPendingProposalState(null);
-            await startFreshSessionWithPeer({
-              peerId: proposal.from_id,
-              opponentAlias: proposal.from_alias,
-              myAmount: proposal.responder_amount,
-              theirAmount: proposal.proposer_amount,
-              channel_timeout: proposal.channel_timeout,
-              unroll_timeout: proposal.unroll_timeout,
-              iStarted: false,
-              gameSessionId: proposal.game_session_id,
-              pairingToken,
-            });
-          } catch (error) {
-            console.error('[Shell] accept-proposal failed', error);
-            sendSessionReject(proposal.from_id);
-            abandonFailedStartAttempt({ error: true });
-          }
-        },
-        { scope: 'session-pane', waitForReady: true, readyKey: pairingToken },
-      );
+      void beginAcceptTransition('accept-proposal', pairingToken, async () => {
+        try {
+          await startFreshSessionWithPeer({
+            peerId: proposal.from_id,
+            opponentAlias: proposal.from_alias,
+            myAmount: proposal.responder_amount,
+            theirAmount: proposal.proposer_amount,
+            channel_timeout: proposal.channel_timeout,
+            unroll_timeout: proposal.unroll_timeout,
+            iStarted: false,
+            gameSessionId: proposal.game_session_id,
+            pairingToken,
+          });
+        } catch (error) {
+          console.error('[Shell] accept-proposal failed', error);
+          sendSessionReject(proposal.from_id);
+          abandonFailedStartAttempt({ error: true });
+        }
+      });
     },
     [
       abandonFailedStartAttempt,
-      runTransition,
+      beginAcceptTransition,
       sendSessionReject,
-      setPendingProposalState,
       startFreshSessionWithPeer,
     ],
   );
@@ -1779,6 +1740,10 @@ const Shell = () => {
             true,
             !!sessionConfigRef.current?.restoring,
             sessionSaveRef.current,
+            {
+              pending: isAcceptSessionTransition(shellTransitionRef.current),
+              persistInFlight: freshStartPersistInFlightRef.current,
+            },
           ),
           sessionConfigRef.current?.myAlias ?? savedMyAlias(sessionSaveRef.current) ?? peekAlias(),
         );
@@ -1800,7 +1765,13 @@ const Shell = () => {
         );
       }
     });
-  }, [activeBlockchainPoller, blockchainType, setWalletAlert, startBalancePolling]);
+  }, [
+    activeBlockchainPoller,
+    blockchainType,
+    freshStartPersistInFlightRef,
+    setWalletAlert,
+    startBalancePolling,
+  ]);
 
   const [hubOrigin, setHubOrigin] = useState<string | null>(null);
   const [hubConnectionError, setHubConnectionError] = useState<string | null>(null);
@@ -1909,7 +1880,7 @@ const Shell = () => {
               if (ps?.peerId === fromId) {
                 log(`[Shell] session_reject from=${fromId}: cancelling attempted session`);
                 markPeerDead();
-                if (abortAcceptAttemptIfActive({ error: true })) return;
+                if (abortAcceptIfActive({ error: true })) return;
                 const channelState = dashboardSessionModelRef.current?.channel.status.state;
                 if (
                   shouldCancelOnPeerUnreachable(
@@ -1927,7 +1898,7 @@ const Shell = () => {
             console.warn('[Shell] delivery_failure to=%s', to);
             const ps = peerSessionRef.current;
             if (!ps || to !== ps.peerId) return;
-            if (abortAcceptAttemptIfActive()) {
+            if (abortAcceptIfActive()) {
               markPeerDead();
               return;
             }
@@ -1964,7 +1935,7 @@ const Shell = () => {
             // Cold Accept may not have pairing/sessionConfig tokens yet — still
             // abort an in-flight Accept transition (same as session_reject).
             if (prevMine && prevMine !== playerId && save?.phase !== 'live') {
-              if (abortAcceptAttemptIfActive()) {
+              if (abortAcceptIfActive()) {
                 console.warn(
                   '[Shell] hub player_id remapped during pre-cradle handshake (%s → %s); rematch required',
                   prevMine,
@@ -2056,12 +2027,18 @@ const Shell = () => {
             const save = sessionSaveRef.current;
             // A leftover cradle must not keep us busy after the session resolved
             // (wallet/handshake failures often leave Failed + persisted cradle).
+            // Accept-pending + persist-drain must also stay busy: identify/reconnect
+            // re-applies getPresence and would otherwise undo explicit setBusy.
             return {
               busy: hubBusyFromSessionState(
                 sessionPhaseRef.current,
                 walletConnectedRef.current,
                 !!sessionConfigRef.current?.restoring,
                 save,
+                {
+                  pending: isAcceptSessionTransition(shellTransitionRef.current),
+                  persistInFlight: freshStartPersistInFlightRef.current,
+                },
               ),
               // Prefer session aliases, then the hub-synced prefs alias. Never call
               // getAlias() here — inventing Player_* would pollute identify/set_busy.
@@ -2088,7 +2065,8 @@ const Shell = () => {
       markPeerInactive,
       markPeerDead,
       cancelAttemptedSession,
-      abortAcceptAttemptIfActive,
+      abortAcceptIfActive,
+      freshStartPersistInFlightRef,
       isAvailableForNewSessionPrompt,
       sendSessionReject,
       setPendingAdvisoryState,
@@ -2181,13 +2159,17 @@ const Shell = () => {
           true,
           !!sessionConfigRef.current?.restoring,
           sessionSaveRef.current,
+          {
+            pending: isAcceptSessionTransition(shellTransitionRef.current),
+            persistInFlight: freshStartPersistInFlightRef.current,
+          },
         ),
         sessionConfigRef.current?.myAlias ?? savedMyAlias(sessionSaveRef.current) ?? peekAlias(),
       );
       startBalancePolling(bcType);
       log(`${bcType} wallet connected`);
     },
-    [startBalancePolling, setConnecting, setActiveTab],
+    [freshStartPersistInFlightRef, startBalancePolling, setConnecting, setActiveTab],
   );
 
   // --- Unified connection flow ---
@@ -2325,8 +2307,7 @@ const Shell = () => {
 
   const cancelDashboardSession = useCallback(
     (options?: { retainFinishedGuard?: boolean }) => {
-      sessionStartEpochRef.current += 1;
-      freshStartPersistCommittedRef.current = false;
+      bumpStartEpoch();
       abandonPendingRef.current = false;
       const alias =
         sessionConfigRef.current?.myAlias ?? savedMyAlias(sessionSaveRef.current) ?? peekAlias();
@@ -2365,6 +2346,7 @@ const Shell = () => {
       hubConnRef.current?.setBusy(shouldReportHubBusy('none', walletConnectedRef.current), alias);
     },
     [
+      bumpStartEpoch,
       cancelTransition,
       clearSessionPreservingHistory,
       clearSessionTimers,
@@ -2543,7 +2525,7 @@ const Shell = () => {
       dashboardSessionModelRef.current = model;
       setDashboardSessionModel(model);
       const pairingToken = sessionConfigRef.current?.pairingToken;
-      if (pairingToken && selectGameDashboardView(model).actionKind !== 'cancel') {
+      if (pairingToken && shouldCompleteAcceptTransition(model)) {
         completeTransition(pairingToken);
       }
     },
@@ -3006,27 +2988,32 @@ const Shell = () => {
           sessionSaveRef.current?.phase === 'pre-handshake'
             ? sessionSaveRef.current.pairing.peerId
             : undefined);
-        if (peerId) sendSessionReject(peerId);
-      }
-      if (accepting) {
-        if (!preserveHub) saveHubUrl(undefined);
-        abortAcceptAttemptIfActive();
-      } else if (shouldCancel) {
-        if (!preserveHub) saveHubUrl(undefined);
-        cancelAttemptedSession();
-      } else {
-        if (hasPendingPrompt) {
-          setPendingAdvisoryState(null);
-          setPendingProposalState(null);
-          // Proposal path creates PeerSession before accept; drop it without
-          // clearSessionPreservingHistory (keeps terminal snapshot / freeze).
-          resetPeerRelayState();
+        if (accepting) {
+          if (!preserveHub) saveHubUrl(undefined);
+          // abortAccept owns reject for Accept branches.
+          abortAcceptIfActive(peerId ? { peerId } : undefined);
+        } else {
+          if (peerId) sendSessionReject(peerId);
+          if (shouldCancel) {
+            if (!preserveHub) saveHubUrl(undefined);
+            cancelAttemptedSession();
+          } else {
+            if (hasPendingPrompt) {
+              setPendingAdvisoryState(null);
+              setPendingProposalState(null);
+              // Proposal path creates PeerSession before accept; drop it without
+              // clearSessionPreservingHistory (keeps terminal snapshot / freeze).
+              resetPeerRelayState();
+            }
+            if (!preserveHub) saveHubUrl(undefined);
+          }
         }
-        if (!preserveHub) saveHubUrl(undefined);
+      } else if (!preserveHub) {
+        saveHubUrl(undefined);
       }
     },
     [
-      abortAcceptAttemptIfActive,
+      abortAcceptIfActive,
       cancelAttemptedSession,
       resetPeerRelayState,
       sendSessionReject,
@@ -3193,8 +3180,8 @@ const Shell = () => {
               (saved?.phase === 'live' || saved?.phase === 'pre-handshake'
                 ? saved.pairing.peerId
                 : undefined);
-            if (peerId) sendSessionReject(peerId);
-            if (abortAcceptAttemptIfActive()) break;
+            // abortAccept owns reject for Accept Cancel.
+            if (abortAcceptIfActive(peerId ? { peerId } : undefined)) break;
           }
           cancelDashboardSession();
           break;
@@ -3230,11 +3217,10 @@ const Shell = () => {
     },
     [
       abandonActiveChannel,
-      abortAcceptAttemptIfActive,
+      abortAcceptIfActive,
       cancelDashboardSession,
       requestDashboardCleanShutdown,
       requestDashboardGoOnChain,
-      sendSessionReject,
       shellState.transition,
     ],
   );
@@ -3493,10 +3479,6 @@ const Shell = () => {
       </div>
     </div>
   ) : null;
-
-  if (shellState.transition.kind === 'pending' && shellState.transition.scope === 'shell') {
-    return <SessionTransitionOverlay reason={shellState.transition.reason} />;
-  }
 
   // --- Main tabbed app ---
   // autoResuming with session hydrated: mount the real tree invisibly so
@@ -3976,74 +3958,93 @@ const Shell = () => {
               getCoins={getCoins}
             />
             <div style={{ flex: '1 1 0%', minHeight: 0, overflow: 'auto' }}>
-              {sessionPaneTransition && !keepSession ? (
-                <SessionTransitionSurface />
-              ) : keepSession && restoreStatus === 'failed' ? (
-                <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-canvas-text p-8">
-                  <h2 className="text-lg font-semibold text-alert-text">Restore failed</h2>
-                  <p className="max-w-lg text-sm text-center select-text cursor-text">
-                    {restoreError ?? 'The saved session could not be restored.'}
-                  </p>
-                  <button
-                    onClick={handleStartOver}
-                    disabled={startingOver}
-                    className="px-4 py-2 rounded-md font-medium text-sm border border-canvas-border text-canvas-text hover:bg-canvas-bg-hover transition-colors disabled:opacity-50"
-                  >
-                    {startingOver ? 'Starting over\u2026' : 'Start over'}
-                  </button>
-                </div>
-              ) : keepSession ? (
-                <div className="relative w-full h-full">
-                  <GameSessionErrorBoundary>
-                    <GameSession
-                      key={sessionConfig!.pairingToken}
-                      params={sessionConfig!}
-                      peerConn={peerConn!}
-                      registerMessageHandler={registerMessageHandler}
-                      appendGameLog={appendHistory}
-                      sessionSave={sessionSavePropRef.current}
-                      blockchain={activeBlockchainPoller}
-                      onGameActivity={onGameActivity}
-                      onSessionPhaseChange={handleSessionPhaseChange}
-                      onRestoreStatusChange={handleRestoreStatusChange}
-                      onSessionModelChange={handleSessionModelChange}
-                      onProtocolStateProviderChange={handleProtocolStateProviderChange}
-                      onCoinsProviderChange={handleCoinsProviderChange}
-                      suppressPhaseReporting={shouldSuppressPhaseReporting(
-                        restoreBlocked,
-                        terminalPresentation != null,
-                      )}
-                      terminalPresentation={terminalPresentation}
-                      showTransitionSurface={sessionPaneTransition}
-                    />
-                  </GameSessionErrorBoundary>
-                  {sessionConsentOverlay}
-                </div>
-              ) : sessionPhase === 'resolved' && dashboardSessionModel ? (
-                // Prefer the finished freeze over sessionCanMount+"Restoring session...".
-                // After live terminal finalization, sessionConfig/peerConn often remain
-                // (warm GameSession path); if keepSession drops, we must not claim restore.
-                <div className="relative w-full h-full">
-                  <FinishedSessionGameView
-                    model={sessionModelForReactProps(dashboardSessionModel)}
-                    myName={finishedSessionIdentity?.myName ?? peekAlias()}
-                    opponentName={finishedSessionIdentity?.opponentName}
-                    iStarted={finishedSessionIdentity?.iStarted ?? false}
-                  />
-                  {sessionConsentOverlay}
-                </div>
-              ) : sessionCanMount ? (
-                <div className="w-full h-full flex items-center justify-center text-canvas-solid">
-                  Restoring session...
-                </div>
-              ) : (
-                <div className="relative w-full h-full">
-                  <div className="w-full h-full flex items-center justify-center text-canvas-solid">
-                    No active game session
-                  </div>
-                  {sessionConsentOverlay}
-                </div>
-              )}
+              {(() => {
+                const pane = selectGamePaneKind({
+                  sessionPaneTransition,
+                  keepSession,
+                  restoreStatus,
+                  restoreError,
+                  sessionPhase,
+                  hasDashboardModel: dashboardSessionModel !== null,
+                  sessionCanMount,
+                });
+                switch (pane.kind) {
+                  case 'transitionCover':
+                    return <SessionTransitionSurface />;
+                  case 'restoreFailed':
+                    return (
+                      <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-canvas-text p-8">
+                        <h2 className="text-lg font-semibold text-alert-text">Restore failed</h2>
+                        <p className="max-w-lg text-sm text-center select-text cursor-text">
+                          {pane.error ?? 'The saved session could not be restored.'}
+                        </p>
+                        <button
+                          onClick={handleStartOver}
+                          disabled={startingOver}
+                          className="px-4 py-2 rounded-md font-medium text-sm border border-canvas-border text-canvas-text hover:bg-canvas-bg-hover transition-colors disabled:opacity-50"
+                        >
+                          {startingOver ? 'Starting over\u2026' : 'Start over'}
+                        </button>
+                      </div>
+                    );
+                  case 'gameSession':
+                    return (
+                      <div className="relative w-full h-full">
+                        <GameSessionErrorBoundary>
+                          <GameSession
+                            key={sessionConfig!.pairingToken}
+                            params={sessionConfig!}
+                            peerConn={peerConn!}
+                            registerMessageHandler={registerMessageHandler}
+                            appendGameLog={appendHistory}
+                            sessionSave={sessionSavePropRef.current}
+                            blockchain={activeBlockchainPoller}
+                            onGameActivity={onGameActivity}
+                            onSessionPhaseChange={handleSessionPhaseChange}
+                            onRestoreStatusChange={handleRestoreStatusChange}
+                            onSessionModelChange={handleSessionModelChange}
+                            onProtocolStateProviderChange={handleProtocolStateProviderChange}
+                            onCoinsProviderChange={handleCoinsProviderChange}
+                            suppressPhaseReporting={shouldSuppressPhaseReporting(
+                              restoreBlocked,
+                              terminalPresentation != null,
+                            )}
+                            terminalPresentation={terminalPresentation}
+                            showTransitionSurface={pane.showTransitionSurface}
+                          />
+                        </GameSessionErrorBoundary>
+                        {sessionConsentOverlay}
+                      </div>
+                    );
+                  case 'finishedFreeze':
+                    return (
+                      <div className="relative w-full h-full">
+                        <FinishedSessionGameView
+                          model={sessionModelForReactProps(dashboardSessionModel!)}
+                          myName={finishedSessionIdentity?.myName ?? peekAlias()}
+                          opponentName={finishedSessionIdentity?.opponentName}
+                          iStarted={finishedSessionIdentity?.iStarted ?? false}
+                        />
+                        {sessionConsentOverlay}
+                      </div>
+                    );
+                  case 'restoringPlaceholder':
+                    return (
+                      <div className="w-full h-full flex items-center justify-center text-canvas-solid">
+                        Restoring session...
+                      </div>
+                    );
+                  case 'empty':
+                    return (
+                      <div className="relative w-full h-full">
+                        <div className="w-full h-full flex items-center justify-center text-canvas-solid">
+                          No active game session
+                        </div>
+                        {sessionConsentOverlay}
+                      </div>
+                    );
+                }
+              })()}
             </div>
           </div>
 

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -118,6 +118,13 @@ import {
   type SessionModel,
   type StatusBarBalanceSegment,
 } from '../lib/session/model';
+import {
+  isValidSessionAmountString,
+  isValidTimeoutString,
+  parseOptionalBigInt,
+  parseSessionAmount,
+  startFailureDisposition,
+} from '../lib/session/peerSessionParams';
 import { sessionModelForReactProps } from '../lib/session/finishedSessionDisplay';
 import { finalizeTerminalSession } from '../lib/session/terminalFinalization';
 import type { TerminalSessionPresentation } from '../lib/session/sessionResult';
@@ -219,19 +226,6 @@ type SessionStartRequest = {
   iStarted: boolean;
 };
 
-function parseSessionAmount(raw: string): bigint {
-  try {
-    const amount = BigInt(raw);
-    if (amount <= 0n) {
-      throw new Error(`session amount must be positive, got ${raw}`);
-    }
-    return amount;
-  } catch (e) {
-    if (e instanceof Error && e.message.startsWith('session amount')) throw e;
-    throw new Error(`invalid session amount: ${raw}`, { cause: e });
-  }
-}
-
 function SessionBuyIn({
   myAmount,
   theirAmount,
@@ -274,15 +268,6 @@ function SessionBuyIn({
   );
 }
 
-function parseOptionalBigInt(raw: string | undefined): bigint | undefined {
-  if (!raw) return undefined;
-  try {
-    return BigInt(raw);
-  } catch {
-    return undefined;
-  }
-}
-
 const IDLE_PEER_CONNECTION: PeerConnectionResult = {
   sendMessage: () => false,
   sendAck: () => false,
@@ -301,9 +286,6 @@ const TAB_DEFS: { id: TabId; label: string }[] = [
 
 const ABANDON_DELAY_MS = 120_000n;
 const GRACE_DELAY_MS = 10_000n;
-
-const MIN_TIMEOUT_BLOCKS = 3;
-const MAX_TIMEOUT_BLOCKS = 30;
 
 function isAbandonWaitingState(
   state: SessionModel['channel']['status']['state'] | null | undefined,
@@ -358,12 +340,6 @@ function hubBusyFromSessionState(
 function tabForResumedSave(save: SessionSave): TabId | null {
   if (save.phase !== 'preferences') return 'game';
   return null;
-}
-
-function isValidTimeoutString(v: string | undefined): boolean {
-  if (v === undefined) return true;
-  const n = parseOptionalBigInt(v);
-  return n !== undefined && n >= BigInt(MIN_TIMEOUT_BLOCKS) && n <= BigInt(MAX_TIMEOUT_BLOCKS);
 }
 
 const TRACKER_LIVENESS_LABELS: Record<HubLiveness, string> = {
@@ -1321,6 +1297,35 @@ const Shell = () => {
     ],
   );
 
+  /**
+   * End a failed Accept without touching a finished freeze / terminal
+   * checkpoint that `transitionToFreshSession` never retired. Peer attempt
+   * only: reject already sent by caller; clear provisional relay + transition;
+   * surface sessionError as a should-never-happen belt-and-suspenders warning.
+   */
+  const abandonFailedStartAttempt = useCallback(
+    (options?: { error?: boolean }) => {
+      sessionStartEpochRef.current += 1;
+      abandonPendingRef.current = false;
+      setPendingAdvisoryState(null);
+      setPendingProposalState(null);
+      resetPeerRelayState();
+      cancelTransition();
+      setSessionError(!!options?.error);
+      hubConnRef.current?.setBusy(
+        shouldReportHubBusy(sessionPhaseRef.current, walletConnectedRef.current),
+        sessionConfigRef.current?.myAlias ?? savedMyAlias(sessionSaveRef.current) ?? peekAlias(),
+      );
+    },
+    [
+      cancelTransition,
+      resetPeerRelayState,
+      setPendingAdvisoryState,
+      setPendingProposalState,
+      setSessionError,
+    ],
+  );
+
   const startFreshSessionWithPeer = useCallback(
     async (
       request: SessionStartRequest & {
@@ -1328,6 +1333,7 @@ const Shell = () => {
         pairingToken: string;
       },
     ) => {
+      let checkpointPersisted = false;
       try {
         const conn = hubConnRef.current;
         if (!conn) throw new Error('hub connection unavailable during session start');
@@ -1422,6 +1428,7 @@ const Shell = () => {
                   : {}),
               },
             });
+            checkpointPersisted = true;
             // Cancel can interleave after replaceSession's awaits and still leave
             // a durable pre-handshake checkpoint on the write chain. Drop it.
             if (epoch !== sessionStartEpochRef.current) {
@@ -1465,11 +1472,19 @@ const Shell = () => {
       } catch (error) {
         console.error('[Shell] session start failed', error);
         sendSessionReject(request.peerId);
-        cancelAttemptedSession({ error: true });
+        if (startFailureDisposition(checkpointPersisted) === 'cancel-attempt') {
+          cancelAttemptedSession({ error: true });
+        } else {
+          // Persist never succeeded: finished freeze + terminal checkpoint remain.
+          // End the peer attempt only and warn — parse/start failures past the
+          // intake wall should never happen.
+          abandonFailedStartAttempt({ error: true });
+        }
       }
     },
     [
       stablePeerConn,
+      abandonFailedStartAttempt,
       bindPeerMessageHandler,
       cancelAttemptedSession,
       clearSessionPreservingHistory,
@@ -1742,6 +1757,13 @@ const Shell = () => {
               log(`[Shell] advisory_start ignored: invalid timeouts peer=${params.peer_id}`);
               return;
             }
+            if (
+              !isValidSessionAmountString(params.my_amount) ||
+              !isValidSessionAmountString(params.their_amount)
+            ) {
+              log(`[Shell] advisory_start ignored: invalid amounts peer=${params.peer_id}`);
+              return;
+            }
             setPendingAdvisoryState(params);
             setActiveTab('game');
           },
@@ -1768,6 +1790,14 @@ const Shell = () => {
                 !isValidTimeoutString(msg.unroll_timeout)
               ) {
                 log(`[Shell] session_reject to=${fromId}: proposal invalid timeouts`);
+                sendSessionReject(fromId);
+                return;
+              }
+              if (
+                !isValidSessionAmountString(msg.proposer_amount) ||
+                !isValidSessionAmountString(msg.responder_amount)
+              ) {
+                log(`[Shell] session_reject to=${fromId}: proposal invalid amounts`);
                 sendSessionReject(fromId);
                 return;
               }

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -89,11 +89,13 @@ import { RestoreStatus } from '../hooks/SessionController';
 import { useThemeSyncToIframe } from '../hooks/useThemeSyncToIframe';
 import {
   isRestoreBlocked,
+  restoreGateAfterTerminalFinalization,
   shouldCancelAttemptOnDisconnect,
   shouldCancelOnPeerUnreachable,
   shouldMountGameSession,
   shouldReportHubBusy,
   shouldReportHubBusyPresence,
+  shouldSuppressPhaseReporting,
   shouldSwitchToHubOnResolved,
   transitionToFreshSession,
 } from '../lib/restoreLifecycle';
@@ -1404,9 +1406,7 @@ const Shell = () => {
                 ...(channelTimeout !== undefined
                   ? { channelTimeout: channelTimeout.toString() }
                   : {}),
-                ...(unrollTimeout !== undefined
-                  ? { unrollTimeout: unrollTimeout.toString() }
-                  : {}),
+                ...(unrollTimeout !== undefined ? { unrollTimeout: unrollTimeout.toString() } : {}),
               },
               identity: {
                 sessionId: hubSessionId,
@@ -1943,6 +1943,7 @@ const Shell = () => {
       bindPeerMessageHandler,
       setActiveTab,
       setHubAlert,
+      setRestoreHubReconciled,
     ],
   );
 
@@ -2312,12 +2313,32 @@ const Shell = () => {
       sessionSaveRef.current = null;
       sessionSavePropRef.current = undefined;
       clearSessionTimers();
-      setRestoreStatus('idle');
+      // Drop the restore mount flag before resetting status/hub gates. A resumed
+      // session keeps params.restoring=true; resetting gates alone would re-arm
+      // restoreBlocked and GameSession would show "Restoring session..." over
+      // the terminal presentation (visible on slash because hasError stays on game).
+      const restoreGate = restoreGateAfterTerminalFinalization();
+      const liveConfig = sessionConfigRef.current;
+      if (liveConfig?.restoring) {
+        setSessionConfig({ ...liveConfig, restoring: restoreGate.restoring });
+      }
+      setRestoreStatus(restoreGate.restoreStatus);
       setRestoreError(null);
-      setRestoreHubReconciled(false);
+      setRestoreHubReconciled(restoreGate.hubReconciled);
       return true;
     },
-    [clearSessionTimers, frozenCoins, resetPeerRelayState],
+    [
+      clearSessionTimers,
+      frozenCoins,
+      resetPeerRelayState,
+      setDashboardSessionModel,
+      setRestoreError,
+      setRestoreHubReconciled,
+      setRestoreStatus,
+      setSessionConfig,
+      setSessionError,
+      setSessionPhase,
+    ],
   );
 
   const handleSessionPhaseChange = useCallback(
@@ -2339,7 +2360,13 @@ const Shell = () => {
       setSessionError(!!hasError);
       hubConnRef.current?.setBusy(shouldReportHubBusy(phase, walletConnectedRef.current));
     },
-    [finishResolvedSessionDisplay, setActiveTab, startBalancePolling],
+    [
+      finishResolvedSessionDisplay,
+      setActiveTab,
+      setSessionError,
+      setSessionPhase,
+      startBalancePolling,
+    ],
   );
 
   const handleRestoreStatusChange = useCallback(
@@ -2443,7 +2470,17 @@ const Shell = () => {
       );
       setResuming(false);
     },
-    [setActiveTab],
+    [
+      setActiveTab,
+      setDashboardSessionModel,
+      setPeerConn,
+      setRestoreError,
+      setRestoreHubReconciled,
+      setRestoreStatus,
+      setSessionConfig,
+      setSessionError,
+      setSessionPhase,
+    ],
   );
 
   // Hydrate local UI state from a SessionSave and kick off a backend connect.
@@ -2580,7 +2617,20 @@ const Shell = () => {
         }
       })();
     },
-    [uniqueId, completeConnection, stablePeerConn, setActiveTab, setWalletAlert],
+    [
+      uniqueId,
+      completeConnection,
+      stablePeerConn,
+      setActiveTab,
+      setWalletAlert,
+      setPeerConn,
+      setRestoreError,
+      setRestoreHubReconciled,
+      setRestoreStatus,
+      setSessionConfig,
+      setSessionError,
+      setSessionPhase,
+    ],
   );
 
   // User clicked "Resume Session" in the resumeDialog, or boot landed on
@@ -2944,7 +2994,7 @@ const Shell = () => {
       prev ? { ...prev, channel: { ...prev.channel, cleanShutdownStarted: true } } : prev,
     );
     sessionController?.cleanShutdown();
-  }, [startCleanShutdownGrace]);
+  }, [setDashboardSessionModel, startCleanShutdownGrace]);
 
   const performDashboardGoOnChain = useCallback(() => {
     if (!sessionController?.goOnChain()) return;
@@ -2953,7 +3003,7 @@ const Shell = () => {
     hubConnRef.current?.setBusy(shouldReportHubBusy('on-chain'));
     peerSessionRef.current?.markDead();
     syncPeerLiveness();
-  }, [syncPeerLiveness]);
+  }, [setSessionPhase, syncPeerLiveness]);
 
   const requestDashboardGoOnChain = useCallback(() => {
     const channelState = dashboardSessionModel?.channel.status.state;
@@ -3781,7 +3831,10 @@ const Shell = () => {
                       onSessionModelChange={handleSessionModelChange}
                       onProtocolStateProviderChange={handleProtocolStateProviderChange}
                       onCoinsProviderChange={handleCoinsProviderChange}
-                      suppressPhaseReporting={restoreBlocked}
+                      suppressPhaseReporting={shouldSuppressPhaseReporting(
+                        restoreBlocked,
+                        terminalPresentation != null,
+                      )}
                       terminalPresentation={terminalPresentation}
                     />
                   </GameSessionErrorBoundary>
@@ -3792,11 +3845,10 @@ const Shell = () => {
                   )}
                   {sessionConsentOverlay}
                 </div>
-              ) : sessionCanMount ? (
-                <div className="w-full h-full flex items-center justify-center text-canvas-solid">
-                  Restoring session...
-                </div>
               ) : sessionPhase === 'resolved' && dashboardSessionModel ? (
+                // Prefer the finished freeze over sessionCanMount+"Restoring session...".
+                // After live terminal finalization, sessionConfig/peerConn often remain
+                // (warm GameSession path); if keepSession drops, we must not claim restore.
                 <div className="relative w-full h-full">
                   <FinishedSessionGameView
                     model={sessionModelForReactProps(dashboardSessionModel)}
@@ -3805,6 +3857,10 @@ const Shell = () => {
                     iStarted={finishedSessionIdentity?.iStarted ?? false}
                   />
                   {sessionConsentOverlay}
+                </div>
+              ) : sessionCanMount ? (
+                <div className="w-full h-full flex items-center justify-center text-canvas-solid">
+                  Restoring session...
                 </div>
               ) : (
                 <div className="relative w-full h-full">

--- a/front-end/src/hooks/useAcceptLifecycle.ts
+++ b/front-end/src/hooks/useAcceptLifecycle.ts
@@ -1,0 +1,81 @@
+import { useCallback, useRef } from 'react';
+import { startFailureDisposition, type AcceptReason } from '../lib/session/acceptLifecycle';
+import { isAcceptSessionTransition } from '../lib/session/shellSessionState';
+import type { ShellSessionTransition } from '../lib/session/shellSessionState';
+
+export type AcceptAbortOptions = {
+  error?: boolean;
+  /** When set, Accept abort owns sending session_reject to this peer. */
+  peerId?: string;
+};
+
+export type AcceptAbortHandlers = {
+  getTransition: () => ShellSessionTransition;
+  /** Peer-only abandon (pre-persist): clear provisional Accept without wiping freeze. */
+  abandonPeerOnly: (options?: { error?: boolean }) => void;
+  /** Full attempt teardown after persist committed. */
+  cancelAttempt: (options?: { error?: boolean }) => void;
+  sendSessionReject: (peerId: string) => void;
+};
+
+/**
+ * Accept epoch + persist flags and the single abortAccept API.
+ * beginAccept / startFreshSessionWithPeer stay composed in Shell with these refs.
+ */
+export function useAcceptLifecycle() {
+  const sessionStartEpochRef = useRef(0);
+  const freshStartPersistCommittedRef = useRef(false);
+  const freshStartPersistInFlightRef = useRef(false);
+
+  const bumpStartEpoch = useCallback(() => {
+    sessionStartEpochRef.current += 1;
+    freshStartPersistCommittedRef.current = false;
+  }, []);
+
+  const beginPersistFlight = useCallback(() => {
+    freshStartPersistCommittedRef.current = false;
+    freshStartPersistInFlightRef.current = true;
+  }, []);
+
+  const endPersistFlight = useCallback(() => {
+    freshStartPersistInFlightRef.current = false;
+  }, []);
+
+  const markPersistCommitted = useCallback(() => {
+    freshStartPersistCommittedRef.current = true;
+  }, []);
+
+  /**
+   * Abort an in-flight Accept with freeze-safe disposition.
+   * Owns session_reject when peerId is provided.
+   * Returns false when no Accept transition is active.
+   */
+  const abortAccept = useCallback(
+    (handlers: AcceptAbortHandlers, options?: AcceptAbortOptions): boolean => {
+      if (!isAcceptSessionTransition(handlers.getTransition())) return false;
+      if (options?.peerId) {
+        handlers.sendSessionReject(options.peerId);
+      }
+      if (startFailureDisposition(freshStartPersistCommittedRef.current) === 'abandon-peer-only') {
+        handlers.abandonPeerOnly(options);
+      } else {
+        handlers.cancelAttempt(options);
+      }
+      return true;
+    },
+    [],
+  );
+
+  return {
+    sessionStartEpochRef,
+    freshStartPersistCommittedRef,
+    freshStartPersistInFlightRef,
+    bumpStartEpoch,
+    beginPersistFlight,
+    endPersistFlight,
+    markPersistCommitted,
+    abortAccept,
+  };
+}
+
+export type { AcceptReason };

--- a/front-end/src/hooks/useShellSessionState.ts
+++ b/front-end/src/hooks/useShellSessionState.ts
@@ -5,57 +5,45 @@ import {
   type ShellSessionAction,
   type ShellSessionState,
   type ShellSessionTransitionReason,
-  type ShellSessionTransitionScope,
 } from '../lib/session/shellSessionState';
 
 export type TransitionWork = () => void | Promise<void>;
-export type TransitionOptions =
-  | {
-      scope: ShellSessionTransitionScope;
-      waitForReady?: false;
-    }
-  | {
-      scope: ShellSessionTransitionScope;
-      waitForReady: true;
-      readyKey: string;
-    };
 
-export interface UseShellSessionTransitionResult {
+export interface UseShellSessionStateResult {
   state: ShellSessionState;
   dispatch: React.Dispatch<ShellSessionAction>;
-  runTransition: (
+  /**
+   * Start an Accept transition (clears consent atomically) and run work.
+   * Completes when `completeTransition(readyKey)` fires, or ends on throw.
+   */
+  beginAcceptTransition: (
     reason: ShellSessionTransitionReason,
+    readyKey: string,
     work: TransitionWork,
-    options: TransitionOptions,
   ) => Promise<void>;
   completeTransition: (readyKey: string) => void;
   cancelTransition: () => void;
 }
 
-export function useShellSessionTransition(): UseShellSessionTransitionResult {
+/**
+ * Shell session fields + Accept session-pane transition bookkeeping.
+ * Accept abort/persist/epoch live in `useAcceptLifecycle`.
+ */
+export function useShellSessionState(): UseShellSessionStateResult {
   const [state, dispatch] = useReducer(shellSessionReducer, initialShellSessionState);
 
-  const runTransition = useCallback(
+  const beginAcceptTransition = useCallback(
     async (
       reason: ShellSessionTransitionReason,
+      readyKey: string,
       work: TransitionWork,
-      options: TransitionOptions,
     ): Promise<void> => {
-      dispatch({
-        type: 'startTransition',
-        reason,
-        scope: options.scope,
-        readyKey: options.waitForReady ? options.readyKey : null,
-      });
+      dispatch({ type: 'beginAccept', reason, readyKey });
       try {
         await work();
       } catch (error) {
         dispatch({ type: 'endTransition' });
         throw error;
-      } finally {
-        if (!options.waitForReady) {
-          dispatch({ type: 'endTransition' });
-        }
       }
     },
     [dispatch],
@@ -71,7 +59,7 @@ export function useShellSessionTransition(): UseShellSessionTransitionResult {
   return {
     state,
     dispatch,
-    runTransition,
+    beginAcceptTransition,
     completeTransition,
     cancelTransition,
   };

--- a/front-end/src/hooks/useShellSessionTransition.ts
+++ b/front-end/src/hooks/useShellSessionTransition.ts
@@ -1,0 +1,78 @@
+import { useCallback, useReducer } from 'react';
+import {
+  initialShellSessionState,
+  shellSessionReducer,
+  type ShellSessionAction,
+  type ShellSessionState,
+  type ShellSessionTransitionReason,
+  type ShellSessionTransitionScope,
+} from '../lib/session/shellSessionState';
+
+export type TransitionWork = () => void | Promise<void>;
+export type TransitionOptions =
+  | {
+      scope: ShellSessionTransitionScope;
+      waitForReady?: false;
+    }
+  | {
+      scope: ShellSessionTransitionScope;
+      waitForReady: true;
+      readyKey: string;
+    };
+
+export interface UseShellSessionTransitionResult {
+  state: ShellSessionState;
+  dispatch: React.Dispatch<ShellSessionAction>;
+  runTransition: (
+    reason: ShellSessionTransitionReason,
+    work: TransitionWork,
+    options: TransitionOptions,
+  ) => Promise<void>;
+  completeTransition: (readyKey: string) => void;
+  cancelTransition: () => void;
+}
+
+export function useShellSessionTransition(): UseShellSessionTransitionResult {
+  const [state, dispatch] = useReducer(shellSessionReducer, initialShellSessionState);
+
+  const runTransition = useCallback(
+    async (
+      reason: ShellSessionTransitionReason,
+      work: TransitionWork,
+      options: TransitionOptions,
+    ): Promise<void> => {
+      dispatch({
+        type: 'startTransition',
+        reason,
+        scope: options.scope,
+        readyKey: options.waitForReady ? options.readyKey : null,
+      });
+      try {
+        await work();
+      } catch (error) {
+        dispatch({ type: 'endTransition' });
+        throw error;
+      } finally {
+        if (!options.waitForReady) {
+          dispatch({ type: 'endTransition' });
+        }
+      }
+    },
+    [dispatch],
+  );
+
+  const completeTransition = useCallback((readyKey: string) => {
+    dispatch({ type: 'completeTransition', readyKey });
+  }, []);
+  const cancelTransition = useCallback(() => {
+    dispatch({ type: 'endTransition' });
+  }, []);
+
+  return {
+    state,
+    dispatch,
+    runTransition,
+    completeTransition,
+    cancelTransition,
+  };
+}

--- a/front-end/src/lib/restoreLifecycle.ts
+++ b/front-end/src/lib/restoreLifecycle.ts
@@ -45,6 +45,19 @@ export function shouldSuppressPhaseReporting(
   return restoreBlocked && !hasTerminalPresentation;
 }
 
+/**
+ * `setupPending` covers only the pre-first-model gap (and a finished freeze still
+ * mounted until retireTerminalDisplay). Once a live SessionModel exists, dashboard
+ * labels must be core-derived even while the session-pane transition remains
+ * pending through handshake Cancel states.
+ */
+export function shouldSynthesizeSetupPending(
+  sessionPaneTransition: boolean,
+  hasLiveSessionModel: boolean,
+): boolean {
+  return sessionPaneTransition && !hasLiveSessionModel;
+}
+
 export function shouldAdvertiseAvailable(
   sessionPhase: SessionPhase,
   restoreBlocked: boolean,

--- a/front-end/src/lib/restoreLifecycle.ts
+++ b/front-end/src/lib/restoreLifecycle.ts
@@ -100,11 +100,17 @@ export async function transitionToFreshSession(dependencies: {
   retireTerminalDisplay: () => void;
   mountLiveSession: () => void;
   reportBusy: () => void;
-}): Promise<void> {
+  /** When true after persist, skip retire/mount — caller already cancelled. */
+  shouldAbort?: () => boolean;
+}): Promise<'completed' | 'aborted'> {
   dependencies.reportBusy();
   await dependencies.persistLiveCheckpoint();
+  if (dependencies.shouldAbort?.()) {
+    return 'aborted';
+  }
   dependencies.retireTerminalDisplay();
   dependencies.mountLiveSession();
+  return 'completed';
 }
 
 /**

--- a/front-end/src/lib/restoreLifecycle.ts
+++ b/front-end/src/lib/restoreLifecycle.ts
@@ -19,6 +19,32 @@ export function isRestoreBlocked(
   );
 }
 
+/**
+ * After live terminal finalization the GameSession mount is no longer a restore.
+ * Clearing `restoring` prevents re-arming the "Restoring session..." gate when
+ * finishResolvedSessionDisplay resets status/hubReconciled — a resumed session
+ * otherwise keeps params.restoring=true forever and would flash that UI on slash
+ * (or any error resolution that stays on the game tab).
+ */
+export function restoreGateAfterTerminalFinalization(): {
+  restoring: false;
+  restoreStatus: 'idle';
+  hubReconciled: false;
+} {
+  return { restoring: false, restoreStatus: 'idle', hubReconciled: false };
+}
+
+/**
+ * GameSession's "Restoring session..." placeholder is only for an in-progress
+ * restore. Once Shell has a terminal presentation, the finished freeze must show.
+ */
+export function shouldSuppressPhaseReporting(
+  restoreBlocked: boolean,
+  hasTerminalPresentation: boolean,
+): boolean {
+  return restoreBlocked && !hasTerminalPresentation;
+}
+
 export function shouldAdvertiseAvailable(
   sessionPhase: SessionPhase,
   restoreBlocked: boolean,

--- a/front-end/src/lib/restoreLifecycle.ts
+++ b/front-end/src/lib/restoreLifecycle.ts
@@ -45,19 +45,6 @@ export function shouldSuppressPhaseReporting(
   return restoreBlocked && !hasTerminalPresentation;
 }
 
-/**
- * `setupPending` covers only the pre-first-model gap (and a finished freeze still
- * mounted until retireTerminalDisplay). Once a live SessionModel exists, dashboard
- * labels must be core-derived even while the session-pane transition remains
- * pending through handshake Cancel states.
- */
-export function shouldSynthesizeSetupPending(
-  sessionPaneTransition: boolean,
-  hasLiveSessionModel: boolean,
-): boolean {
-  return sessionPaneTransition && !hasLiveSessionModel;
-}
-
 export function shouldAdvertiseAvailable(
   sessionPhase: SessionPhase,
   restoreBlocked: boolean,

--- a/front-end/src/lib/session/acceptLifecycle.ts
+++ b/front-end/src/lib/session/acceptLifecycle.ts
@@ -1,0 +1,154 @@
+/**
+ * Accept lifecycle: peer consent → live checkpoint → GameSession mount.
+ *
+ * Owns freeze-safe disposition for Cancel / peer reject / delivery failure /
+ * remap during Accept. Failures before replaceSession lands abandon the peer
+ * attempt only; after the write, full attempt teardown is required.
+ */
+
+import type {
+  SessionHistorySave,
+  SessionIdentitySave,
+  SessionPairingSave,
+  SessionPresentationSave,
+  SessionSave,
+  TerminalSessionSave,
+} from './saveEnvelope';
+import type { ChannelStatus } from '../../types/ChiaGaming';
+import type { SessionModel } from './types';
+
+export type AcceptPhase = 'idle' | 'accepting' | 'persistDraining' | 'liveMounting' | 'active';
+
+export type AcceptReason = 'accept-advisory' | 'accept-proposal';
+
+export type StartFailureDisposition = 'abandon-peer-only' | 'cancel-attempt';
+
+/** Single setup copy for Accept session-pane covers. */
+export const ACCEPT_SETTING_UP_COPY = 'Setting up channel…';
+
+/**
+ * Channel states whose dashboard action is still Cancel during Accept setup.
+ * Leaving these (or never entering them) means the session-pane cover can drop.
+ */
+export const ACCEPT_SETUP_CANCEL_CHANNEL_STATES = new Set<ChannelStatus>([
+  'Handshaking',
+  'WaitingForHeightToOffer',
+  'WaitingForHeightToAccept',
+  'OurWalletMakingOffer',
+  'OurWalletMakingOfferAcceptance',
+]);
+
+/**
+ * After Accept, `transitionToFreshSession` only retires the finished freeze once
+ * the live checkpoint write has landed. Failures or user Cancel before that must
+ * end the peer attempt only — never clear IndexedDB / blank results. Once
+ * replaceSession has successfully replaced the checkpoint, full attempt teardown
+ * is required.
+ */
+export function startFailureDisposition(persistCommitted: boolean): StartFailureDisposition {
+  return persistCommitted ? 'cancel-attempt' : 'abandon-peer-only';
+}
+
+/**
+ * `setupPending` covers only the pre-first-model gap (and a finished freeze still
+ * mounted until retireTerminalDisplay). Once a live SessionModel exists, dashboard
+ * labels must be core-derived even while the session-pane transition remains
+ * pending through handshake Cancel states.
+ */
+export function shouldSynthesizeSetupPending(
+  sessionPaneTransition: boolean,
+  hasLiveSessionModel: boolean,
+): boolean {
+  return sessionPaneTransition && !hasLiveSessionModel;
+}
+
+/**
+ * Explicit ready predicate for completing an Accept session-pane transition.
+ * True once the projected channel has left Cancel-only setup states.
+ */
+export function shouldCompleteAcceptTransition(model: SessionModel): boolean {
+  return !ACCEPT_SETUP_CANCEL_CHANNEL_STATES.has(model.channel.status.state);
+}
+
+export type TerminalSessionBackup = {
+  terminal: TerminalSessionSave['terminal'];
+  presentation: SessionPresentationSave;
+} | null;
+
+export type FreshStartCheckpoint = {
+  pairing: SessionPairingSave;
+  identity?: Partial<SessionIdentitySave>;
+  history?: Partial<SessionHistorySave>;
+};
+
+/**
+ * Persist the pre-cradle live checkpoint for a fresh Accept start.
+ * Backs up a finished terminal envelope from `loadState()` so Cancel mid-write
+ * can restore the freeze rather than leaving preferences-only IndexedDB under
+ * a still-visible results UI. `onCommitted` runs as soon as `replaceSession`
+ * lands so a later restore failure still takes full-attempt teardown disposition.
+ */
+export async function persistFreshStartCheckpoint(args: {
+  epoch: number;
+  getCurrentEpoch: () => number;
+  loadState: () => SessionSave;
+  replaceSession: (checkpoint: FreshStartCheckpoint) => Promise<void>;
+  saveTerminalSession: (fields: NonNullable<TerminalSessionBackup>) => Promise<void>;
+  clearSessionPreservingHistory: () => void;
+  checkpoint: FreshStartCheckpoint;
+  onCommitted: () => void;
+}): Promise<void> {
+  const {
+    epoch,
+    getCurrentEpoch,
+    loadState,
+    replaceSession,
+    saveTerminalSession,
+    clearSessionPreservingHistory,
+    checkpoint,
+    onCommitted,
+  } = args;
+
+  // Cancel / epoch bump before the write lands: keep the finished freeze.
+  if (epoch !== getCurrentEpoch()) return;
+
+  // Prefer durable cache over sessionSaveRef — finishResolvedSessionDisplay
+  // nulls the ref while loadState() still holds the terminal envelope.
+  const prior = loadState();
+  const terminalBackup: TerminalSessionBackup =
+    prior.phase === 'terminal'
+      ? {
+          terminal: structuredClone(prior.terminal),
+          presentation: structuredClone(prior.presentation),
+        }
+      : null;
+
+  await replaceSession(checkpoint);
+
+  // Write landed: from here, failure disposition is full attempt teardown so we
+  // never leave a live cradle under a finished freeze / abandon-peer-only path.
+  onCommitted();
+
+  // Cancel raced the write: restore the finished freeze rather than leaving
+  // preferences-only IndexedDB under a still-visible results UI.
+  if (epoch !== getCurrentEpoch()) {
+    if (terminalBackup) {
+      await saveTerminalSession(terminalBackup);
+    } else {
+      clearSessionPreservingHistory();
+    }
+    return;
+  }
+}
+/** Clear waiting / abandon / clean-shutdown timers and related UI flags. */
+export function clearLiveSessionTimerState(setters: {
+  clearTimeouts: () => void;
+  clearWaitingRefs: () => void;
+  setAbandonEnabled: (value: boolean) => void;
+  setCleanShutdownGraceActive: (value: boolean) => void;
+}): void {
+  setters.clearTimeouts();
+  setters.clearWaitingRefs();
+  setters.setAbandonEnabled(false);
+  setters.setCleanShutdownGraceActive(false);
+}

--- a/front-end/src/lib/session/gamePane.ts
+++ b/front-end/src/lib/session/gamePane.ts
@@ -1,0 +1,54 @@
+/**
+ * Game-tab pane discriminant derived from Accept / mount / terminal state.
+ * Replaces the ad-hoc predicate ladder in Shell's game tab.
+ */
+
+export type GamePaneKind =
+  | { kind: 'transitionCover' }
+  | { kind: 'restoreFailed'; error: string | null }
+  | { kind: 'gameSession'; showTransitionSurface: boolean }
+  | { kind: 'finishedFreeze' }
+  | { kind: 'restoringPlaceholder' }
+  | { kind: 'empty' };
+
+export function selectGamePaneKind(input: {
+  sessionPaneTransition: boolean;
+  keepSession: boolean;
+  restoreStatus: string;
+  restoreError: string | null;
+  sessionPhase: string;
+  hasDashboardModel: boolean;
+  sessionCanMount: boolean;
+}): GamePaneKind {
+  const {
+    sessionPaneTransition,
+    keepSession,
+    restoreStatus,
+    restoreError,
+    sessionPhase,
+    hasDashboardModel,
+    sessionCanMount,
+  } = input;
+
+  // Shell owns the cover only before GameSession is kept; once mounted,
+  // GameSession hosts SessionTransitionSurface under its notification stack.
+  if (sessionPaneTransition && !keepSession) {
+    return { kind: 'transitionCover' };
+  }
+  if (keepSession && restoreStatus === 'failed') {
+    return { kind: 'restoreFailed', error: restoreError };
+  }
+  if (keepSession) {
+    return { kind: 'gameSession', showTransitionSurface: sessionPaneTransition };
+  }
+  // Prefer finished freeze over sessionCanMount+"Restoring session...".
+  // After live terminal finalization, sessionConfig/peerConn often remain
+  // (warm GameSession path); if keepSession drops, we must not claim restore.
+  if (sessionPhase === 'resolved' && hasDashboardModel) {
+    return { kind: 'finishedFreeze' };
+  }
+  if (sessionCanMount) {
+    return { kind: 'restoringPlaceholder' };
+  }
+  return { kind: 'empty' };
+}

--- a/front-end/src/lib/session/peerSessionParams.ts
+++ b/front-end/src/lib/session/peerSessionParams.ts
@@ -9,8 +9,11 @@
 export const MIN_TIMEOUT_BLOCKS = 3;
 export const MAX_TIMEOUT_BLOCKS = 30;
 
+/** Canonical decimal bigint text: no sign, no hex, no leading zeros (`08`). */
+const DECIMAL_BIGINT_STRING = /^(0|[1-9]\d*)$/;
+
 export function parseOptionalBigInt(raw: string | undefined): bigint | undefined {
-  if (!raw) return undefined;
+  if (!raw || !DECIMAL_BIGINT_STRING.test(raw)) return undefined;
   try {
     return BigInt(raw);
   } catch {
@@ -20,7 +23,7 @@ export function parseOptionalBigInt(raw: string | undefined): bigint | undefined
 
 /** Positive decimal bigint string (session buy-in amounts). */
 export function isValidSessionAmountString(raw: string | undefined): boolean {
-  if (raw === undefined || !/^\d+$/.test(raw)) return false;
+  if (raw === undefined || !DECIMAL_BIGINT_STRING.test(raw)) return false;
   try {
     return BigInt(raw) > 0n;
   } catch {
@@ -29,10 +32,15 @@ export function isValidSessionAmountString(raw: string | undefined): boolean {
 }
 
 export function parseSessionAmount(raw: string): bigint {
-  if (!/^\d+$/.test(raw)) {
+  if (!DECIMAL_BIGINT_STRING.test(raw)) {
     throw new Error(`invalid session amount: ${raw}`);
   }
-  const amount = BigInt(raw);
+  let amount: bigint;
+  try {
+    amount = BigInt(raw);
+  } catch (e) {
+    throw new Error(`invalid session amount: ${raw}`, { cause: e });
+  }
   if (amount <= 0n) {
     throw new Error(`session amount must be positive, got ${raw}`);
   }
@@ -41,9 +49,8 @@ export function parseSessionAmount(raw: string): bigint {
 
 export function isValidTimeoutString(v: string | undefined): boolean {
   if (v === undefined) return true;
-  if (!/^\d+$/.test(v)) return false;
-  const n = BigInt(v);
-  return n >= BigInt(MIN_TIMEOUT_BLOCKS) && n <= BigInt(MAX_TIMEOUT_BLOCKS);
+  const n = parseOptionalBigInt(v);
+  return n !== undefined && n >= BigInt(MIN_TIMEOUT_BLOCKS) && n <= BigInt(MAX_TIMEOUT_BLOCKS);
 }
 
 /**

--- a/front-end/src/lib/session/peerSessionParams.ts
+++ b/front-end/src/lib/session/peerSessionParams.ts
@@ -1,0 +1,59 @@
+/**
+ * Trust-boundary validation for peer/hub session start parameters.
+ *
+ * Bad inbound amounts or timeouts must be rejected at intake (reject the peer
+ * proposal / ignore the advisory). They must never reach session start logic
+ * that could tear down a finished freeze or IndexedDB checkpoint.
+ */
+
+export const MIN_TIMEOUT_BLOCKS = 3;
+export const MAX_TIMEOUT_BLOCKS = 30;
+
+export function parseOptionalBigInt(raw: string | undefined): bigint | undefined {
+  if (!raw) return undefined;
+  try {
+    return BigInt(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Positive decimal bigint string (session buy-in amounts). */
+export function isValidSessionAmountString(raw: string | undefined): boolean {
+  if (raw === undefined || !/^\d+$/.test(raw)) return false;
+  try {
+    return BigInt(raw) > 0n;
+  } catch {
+    return false;
+  }
+}
+
+export function parseSessionAmount(raw: string): bigint {
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`invalid session amount: ${raw}`);
+  }
+  const amount = BigInt(raw);
+  if (amount <= 0n) {
+    throw new Error(`session amount must be positive, got ${raw}`);
+  }
+  return amount;
+}
+
+export function isValidTimeoutString(v: string | undefined): boolean {
+  if (v === undefined) return true;
+  if (!/^\d+$/.test(v)) return false;
+  const n = BigInt(v);
+  return n >= BigInt(MIN_TIMEOUT_BLOCKS) && n <= BigInt(MAX_TIMEOUT_BLOCKS);
+}
+
+/**
+ * After Accept, `transitionToFreshSession` only retires the finished freeze once
+ * persist succeeds. A start failure before that must end the peer attempt only —
+ * never `cancelAttemptedSession`, which clears IndexedDB and blanks results.
+ * Once persist has replaced the checkpoint, full attempt teardown is required.
+ */
+export function startFailureDisposition(
+  checkpointPersisted: boolean,
+): 'abandon-peer-only' | 'cancel-attempt' {
+  return checkpointPersisted ? 'cancel-attempt' : 'abandon-peer-only';
+}

--- a/front-end/src/lib/session/peerSessionParams.ts
+++ b/front-end/src/lib/session/peerSessionParams.ts
@@ -55,12 +55,13 @@ export function isValidTimeoutString(v: string | undefined): boolean {
 
 /**
  * After Accept, `transitionToFreshSession` only retires the finished freeze once
- * persist succeeds. A start failure before that must end the peer attempt only —
- * never `cancelAttemptedSession`, which clears IndexedDB and blanks results.
- * Once persist has replaced the checkpoint, full attempt teardown is required.
+ * the live checkpoint write has landed. Failures or user Cancel before that must
+ * end the peer attempt only — never clear IndexedDB / blank results. Once
+ * replaceSession has successfully replaced the checkpoint, full attempt teardown
+ * is required.
  */
 export function startFailureDisposition(
-  checkpointPersisted: boolean,
+  persistCommitted: boolean,
 ): 'abandon-peer-only' | 'cancel-attempt' {
-  return checkpointPersisted ? 'cancel-attempt' : 'abandon-peer-only';
+  return persistCommitted ? 'cancel-attempt' : 'abandon-peer-only';
 }

--- a/front-end/src/lib/session/peerSessionParams.ts
+++ b/front-end/src/lib/session/peerSessionParams.ts
@@ -52,16 +52,3 @@ export function isValidTimeoutString(v: string | undefined): boolean {
   const n = parseOptionalBigInt(v);
   return n !== undefined && n >= BigInt(MIN_TIMEOUT_BLOCKS) && n <= BigInt(MAX_TIMEOUT_BLOCKS);
 }
-
-/**
- * After Accept, `transitionToFreshSession` only retires the finished freeze once
- * the live checkpoint write has landed. Failures or user Cancel before that must
- * end the peer attempt only — never clear IndexedDB / blank results. Once
- * replaceSession has successfully replaced the checkpoint, full attempt teardown
- * is required.
- */
-export function startFailureDisposition(
-  persistCommitted: boolean,
-): 'abandon-peer-only' | 'cancel-attempt' {
-  return persistCommitted ? 'cancel-attempt' : 'abandon-peer-only';
-}

--- a/front-end/src/lib/session/selectors.ts
+++ b/front-end/src/lib/session/selectors.ts
@@ -273,6 +273,7 @@ export function selectGameTabDotColor(args: {
 
 export interface GameDashboardSelectorOptions {
   hasSession?: boolean;
+  setupPending?: boolean;
   cleanShutdownGraceActive?: boolean;
   abandonEnabled?: boolean;
 }
@@ -486,6 +487,19 @@ export function selectGameDashboardView(
   model: SessionModel | null,
   options: GameDashboardSelectorOptions = {},
 ): GameDashboardViewModel {
+  if (!model && options.setupPending) {
+    return {
+      channelStatusLabel: 'Setting Up',
+      channelDetail: null,
+      havePotato: false,
+      handStatusLabel: 'No hand',
+      handDetail: null,
+      lifecycleRows: [],
+      actionLabel: 'Cancel',
+      actionEnabled: true,
+      actionKind: 'cancel',
+    };
+  }
   if (!model || options.hasSession === false) {
     return {
       channelStatusLabel: 'No Session',

--- a/front-end/src/lib/session/selectors.ts
+++ b/front-end/src/lib/session/selectors.ts
@@ -487,7 +487,11 @@ export function selectGameDashboardView(
   model: SessionModel | null,
   options: GameDashboardSelectorOptions = {},
 ): GameDashboardViewModel {
-  if (!model && options.setupPending) {
+  // setupPending must win even when a finished freeze model is still mounted.
+  // Accepting a new session after a terminal display leaves that model in place
+  // until retireTerminalDisplay runs after async replaceSession; without this
+  // override the dashboard would keep a disabled Done action for that window.
+  if (options.setupPending) {
     return {
       channelStatusLabel: 'Setting Up',
       channelDetail: null,

--- a/front-end/src/lib/session/selectors.ts
+++ b/front-end/src/lib/session/selectors.ts
@@ -29,6 +29,18 @@ import type {
   StatusBarBalanceSegment,
 } from './types';
 
+/** Shared empty dashboard fields; setupPending / no-session override labels + action. */
+export const EMPTY_DASHBOARD_VIEW_BASE: Omit<
+  GameDashboardViewModel,
+  'channelStatusLabel' | 'actionLabel' | 'actionEnabled' | 'actionKind'
+> = {
+  channelDetail: null,
+  havePotato: false,
+  handStatusLabel: 'No hand',
+  handDetail: null,
+  lifecycleRows: [],
+};
+
 export function selectProposalGroupByMemberId(
   model: SessionModel,
   memberId: string,
@@ -493,12 +505,8 @@ export function selectGameDashboardView(
   // override the dashboard would keep a disabled Done action for that window.
   if (options.setupPending) {
     return {
+      ...EMPTY_DASHBOARD_VIEW_BASE,
       channelStatusLabel: 'Setting Up',
-      channelDetail: null,
-      havePotato: false,
-      handStatusLabel: 'No hand',
-      handDetail: null,
-      lifecycleRows: [],
       actionLabel: 'Cancel',
       actionEnabled: true,
       actionKind: 'cancel',
@@ -506,12 +514,8 @@ export function selectGameDashboardView(
   }
   if (!model || options.hasSession === false) {
     return {
+      ...EMPTY_DASHBOARD_VIEW_BASE,
       channelStatusLabel: 'No Session',
-      channelDetail: null,
-      havePotato: false,
-      handStatusLabel: 'No hand',
-      handDetail: null,
-      lifecycleRows: [],
       actionLabel: 'No Session',
       actionEnabled: false,
       actionKind: 'none',

--- a/front-end/src/lib/session/shellSessionState.ts
+++ b/front-end/src/lib/session/shellSessionState.ts
@@ -32,6 +32,14 @@ export type ShellSessionTransition =
       readyKey: string | null;
     };
 
+/** True while Accept (advisory/proposal) transition work is in flight. */
+export function isAcceptSessionTransition(transition: ShellSessionTransition): boolean {
+  return (
+    transition.kind === 'pending' &&
+    (transition.reason === 'accept-advisory' || transition.reason === 'accept-proposal')
+  );
+}
+
 export interface ShellSessionState {
   sessionConfig: GameSessionParams | null;
   peerConn: PeerConnectionResult | null;

--- a/front-end/src/lib/session/shellSessionState.ts
+++ b/front-end/src/lib/session/shellSessionState.ts
@@ -1,0 +1,127 @@
+import type { GameSessionParams, PeerConnectionResult, SessionPhase } from '../../types/ChiaGaming';
+import type { AdvisoryStartParams } from '../../services/HubConnection';
+import type { RestoreStatus } from '../../hooks/SessionController';
+import type { SessionModel } from './model';
+
+export type PendingSessionProposal = {
+  from_id: string;
+  from_alias: string;
+  proposer_amount: string;
+  responder_amount: string;
+  channel_timeout?: string;
+  unroll_timeout?: string;
+  game_session_id?: string;
+};
+
+export type ShellSessionTransitionReason =
+  | 'accept-advisory'
+  | 'accept-proposal'
+  | 'resume'
+  | 'start-over'
+  | 'disconnect'
+  | 'finish';
+
+export type ShellSessionTransitionScope = 'shell' | 'session-pane';
+
+export type ShellSessionTransition =
+  | { kind: 'idle' }
+  | {
+      kind: 'pending';
+      reason: ShellSessionTransitionReason;
+      scope: ShellSessionTransitionScope;
+      readyKey: string | null;
+    };
+
+export interface ShellSessionState {
+  sessionConfig: GameSessionParams | null;
+  peerConn: PeerConnectionResult | null;
+  dashboardSessionModel: SessionModel | null;
+  sessionPhase: SessionPhase;
+  pendingAdvisory: AdvisoryStartParams | null;
+  pendingProposal: PendingSessionProposal | null;
+  sessionError: boolean;
+  restoreStatus: RestoreStatus;
+  restoreError: string | null;
+  restoreHubReconciled: boolean;
+  transition: ShellSessionTransition;
+}
+
+export type ShellSessionAction =
+  | { type: 'setSessionConfig'; value: GameSessionParams | null }
+  | { type: 'setPeerConn'; value: PeerConnectionResult | null }
+  | { type: 'setDashboardSessionModel'; value: SessionModel | null }
+  | { type: 'setSessionPhase'; value: SessionPhase }
+  | { type: 'setPendingAdvisory'; value: AdvisoryStartParams | null }
+  | { type: 'setPendingProposal'; value: PendingSessionProposal | null }
+  | { type: 'setSessionError'; value: boolean }
+  | { type: 'setRestoreStatus'; value: RestoreStatus }
+  | { type: 'setRestoreError'; value: string | null }
+  | { type: 'setRestoreHubReconciled'; value: boolean }
+  | {
+      type: 'startTransition';
+      reason: ShellSessionTransitionReason;
+      scope: ShellSessionTransitionScope;
+      readyKey: string | null;
+    }
+  | { type: 'completeTransition'; readyKey: string }
+  | { type: 'endTransition' };
+
+export const initialShellSessionState: ShellSessionState = {
+  sessionConfig: null,
+  peerConn: null,
+  dashboardSessionModel: null,
+  sessionPhase: 'none',
+  pendingAdvisory: null,
+  pendingProposal: null,
+  sessionError: false,
+  restoreStatus: 'idle',
+  restoreError: null,
+  restoreHubReconciled: false,
+  transition: { kind: 'idle' },
+};
+
+export function shellSessionReducer(
+  state: ShellSessionState,
+  action: ShellSessionAction,
+): ShellSessionState {
+  switch (action.type) {
+    case 'setSessionConfig':
+      return { ...state, sessionConfig: action.value };
+    case 'setPeerConn':
+      return { ...state, peerConn: action.value };
+    case 'setDashboardSessionModel':
+      return { ...state, dashboardSessionModel: action.value };
+    case 'setSessionPhase':
+      return { ...state, sessionPhase: action.value };
+    case 'setPendingAdvisory':
+      return { ...state, pendingAdvisory: action.value };
+    case 'setPendingProposal':
+      return { ...state, pendingProposal: action.value };
+    case 'setSessionError':
+      return { ...state, sessionError: action.value };
+    case 'setRestoreStatus':
+      return { ...state, restoreStatus: action.value };
+    case 'setRestoreError':
+      return { ...state, restoreError: action.value };
+    case 'setRestoreHubReconciled':
+      return { ...state, restoreHubReconciled: action.value };
+    case 'startTransition':
+      return {
+        ...state,
+        transition: {
+          kind: 'pending',
+          reason: action.reason,
+          scope: action.scope,
+          readyKey: action.readyKey,
+        },
+      };
+    case 'completeTransition':
+      return state.transition.kind === 'pending' && state.transition.readyKey === action.readyKey
+        ? { ...state, transition: { kind: 'idle' } }
+        : state;
+    case 'endTransition':
+      return { ...state, transition: { kind: 'idle' } };
+    default:
+      return state;
+  }
+}

--- a/front-end/src/lib/session/shellSessionState.ts
+++ b/front-end/src/lib/session/shellSessionState.ts
@@ -1,6 +1,7 @@
 import type { GameSessionParams, PeerConnectionResult, SessionPhase } from '../../types/ChiaGaming';
 import type { AdvisoryStartParams } from '../../services/HubConnection';
 import type { RestoreStatus } from '../../hooks/SessionController';
+import type { AcceptReason } from './acceptLifecycle';
 import type { SessionModel } from './model';
 
 export type PendingSessionProposal = {
@@ -13,15 +14,11 @@ export type PendingSessionProposal = {
   game_session_id?: string;
 };
 
-export type ShellSessionTransitionReason =
-  | 'accept-advisory'
-  | 'accept-proposal'
-  | 'resume'
-  | 'start-over'
-  | 'disconnect'
-  | 'finish';
+/** Accept is the only remaining session-pane transition reason. */
+export type ShellSessionTransitionReason = AcceptReason;
 
-export type ShellSessionTransitionScope = 'shell' | 'session-pane';
+/** Session-pane only — unused shell-scope overlays were deleted. */
+export type ShellSessionTransitionScope = 'session-pane';
 
 export type ShellSessionTransition =
   | { kind: 'idle' }
@@ -66,11 +63,18 @@ export type ShellSessionAction =
   | { type: 'setRestoreError'; value: string | null }
   | { type: 'setRestoreHubReconciled'; value: boolean }
   | {
+      type: 'beginAccept';
+      reason: ShellSessionTransitionReason;
+      readyKey: string;
+    }
+  | {
       type: 'startTransition';
       reason: ShellSessionTransitionReason;
       scope: ShellSessionTransitionScope;
       readyKey: string | null;
     }
+  | { type: 'liveMounted'; sessionConfig: GameSessionParams; peerConn: PeerConnectionResult }
+  | { type: 'acceptAborted'; error?: boolean }
   | { type: 'completeTransition'; readyKey: string }
   | { type: 'endTransition' };
 
@@ -113,6 +117,19 @@ export function shellSessionReducer(
       return { ...state, restoreError: action.value };
     case 'setRestoreHubReconciled':
       return { ...state, restoreHubReconciled: action.value };
+    case 'beginAccept':
+      // Clears consent prompts atomically with entering the Accept transition.
+      return {
+        ...state,
+        pendingAdvisory: null,
+        pendingProposal: null,
+        transition: {
+          kind: 'pending',
+          reason: action.reason,
+          scope: 'session-pane',
+          readyKey: action.readyKey,
+        },
+      };
     case 'startTransition':
       return {
         ...state,
@@ -122,6 +139,20 @@ export function shellSessionReducer(
           scope: action.scope,
           readyKey: action.readyKey,
         },
+      };
+    case 'liveMounted':
+      return {
+        ...state,
+        sessionConfig: action.sessionConfig,
+        peerConn: action.peerConn,
+      };
+    case 'acceptAborted':
+      return {
+        ...state,
+        pendingAdvisory: null,
+        pendingProposal: null,
+        sessionError: !!action.error,
+        transition: { kind: 'idle' },
       };
     case 'completeTransition':
       return state.transition.kind === 'pending' && state.transition.readyKey === action.readyKey

--- a/front-end/src/lib/tests/accept_lifecycle.test.ts
+++ b/front-end/src/lib/tests/accept_lifecycle.test.ts
@@ -1,0 +1,168 @@
+import {
+  ACCEPT_SETUP_CANCEL_CHANNEL_STATES,
+  persistFreshStartCheckpoint,
+  shouldCompleteAcceptTransition,
+  shouldSynthesizeSetupPending,
+  startFailureDisposition,
+  type FreshStartCheckpoint,
+  type TerminalSessionBackup,
+} from '../session/acceptLifecycle';
+import type { SessionModel } from '../session/types';
+import type { ChannelStatus } from '../../types/ChiaGaming';
+
+function modelWithChannelState(state: ChannelStatus): SessionModel {
+  return {
+    channel: {
+      status: {
+        state,
+        sessionDisposition: undefined,
+      },
+    },
+  } as SessionModel;
+}
+
+describe('acceptLifecycle', () => {
+  describe('startFailureDisposition', () => {
+    it('abandons the peer attempt only when persist has not committed', () => {
+      expect(startFailureDisposition(false)).toBe('abandon-peer-only');
+    });
+
+    it('cancels the full attempt once replaceSession has landed', () => {
+      expect(startFailureDisposition(true)).toBe('cancel-attempt');
+    });
+  });
+
+  describe('shouldSynthesizeSetupPending', () => {
+    it('limits synthesis to the pre-first-model / finished-freeze window', () => {
+      expect(shouldSynthesizeSetupPending(false, false)).toBe(false);
+      expect(shouldSynthesizeSetupPending(true, false)).toBe(true);
+      expect(shouldSynthesizeSetupPending(true, true)).toBe(false);
+    });
+  });
+
+  describe('shouldCompleteAcceptTransition', () => {
+    it('stays pending through Cancel-only setup channel states', () => {
+      for (const state of ACCEPT_SETUP_CANCEL_CHANNEL_STATES) {
+        expect(shouldCompleteAcceptTransition(modelWithChannelState(state))).toBe(false);
+      }
+    });
+
+    it('completes once the channel leaves Cancel-only setup', () => {
+      expect(shouldCompleteAcceptTransition(modelWithChannelState('OfferSent'))).toBe(true);
+      expect(shouldCompleteAcceptTransition(modelWithChannelState('Active'))).toBe(true);
+    });
+  });
+
+  describe('persistFreshStartCheckpoint', () => {
+    const checkpoint: FreshStartCheckpoint = {
+      pairing: {
+        token: 't1',
+        peerId: 'peer',
+        gameSessionId: 'gs',
+        iStarted: true,
+        myContribution: '10',
+        theirContribution: '10',
+        perGameAmount: '1',
+      },
+    };
+
+    it('skips the write when the start epoch already advanced', async () => {
+      const replaceSession = jest.fn();
+      await persistFreshStartCheckpoint({
+        epoch: 1,
+        getCurrentEpoch: () => 2,
+        loadState: () =>
+          ({ phase: 'none' }) as ReturnType<
+            Parameters<typeof persistFreshStartCheckpoint>[0]['loadState']
+          >,
+        replaceSession,
+        saveTerminalSession: jest.fn(),
+        clearSessionPreservingHistory: jest.fn(),
+        checkpoint,
+        onCommitted: jest.fn(),
+      });
+      expect(replaceSession).not.toHaveBeenCalled();
+    });
+
+    it('marks committed after a successful write that is still current', async () => {
+      const onCommitted = jest.fn();
+      const replaceSession = jest.fn().mockResolvedValue(undefined);
+      await persistFreshStartCheckpoint({
+        epoch: 3,
+        getCurrentEpoch: () => 3,
+        loadState: () =>
+          ({ phase: 'none' }) as ReturnType<
+            Parameters<typeof persistFreshStartCheckpoint>[0]['loadState']
+          >,
+        replaceSession,
+        saveTerminalSession: jest.fn(),
+        clearSessionPreservingHistory: jest.fn(),
+        checkpoint,
+        onCommitted,
+      });
+      expect(replaceSession).toHaveBeenCalledWith(checkpoint);
+      expect(onCommitted).toHaveBeenCalled();
+    });
+
+    it('marks committed once replaceSession lands, including Cancel-race restore', async () => {
+      let epoch = 5;
+      const terminalBackup: NonNullable<TerminalSessionBackup> = {
+        terminal: { coinsOfInterest: [] } as NonNullable<TerminalSessionBackup>['terminal'],
+        presentation: {} as NonNullable<TerminalSessionBackup>['presentation'],
+      };
+      const saveTerminalSession = jest.fn().mockResolvedValue(undefined);
+      const onCommitted = jest.fn();
+      const clearSessionPreservingHistory = jest.fn();
+
+      await persistFreshStartCheckpoint({
+        epoch,
+        getCurrentEpoch: () => epoch,
+        loadState: () =>
+          ({
+            phase: 'terminal',
+            terminal: terminalBackup.terminal,
+            presentation: terminalBackup.presentation,
+          }) as ReturnType<Parameters<typeof persistFreshStartCheckpoint>[0]['loadState']>,
+        replaceSession: async () => {
+          epoch += 1;
+        },
+        saveTerminalSession,
+        clearSessionPreservingHistory,
+        checkpoint,
+        onCommitted,
+      });
+
+      expect(onCommitted).toHaveBeenCalled();
+      expect(saveTerminalSession).toHaveBeenCalled();
+      expect(clearSessionPreservingHistory).not.toHaveBeenCalled();
+    });
+
+    it('leaves persist committed when terminal restore fails after Cancel raced the write', async () => {
+      let epoch = 7;
+      const onCommitted = jest.fn();
+      await expect(
+        persistFreshStartCheckpoint({
+          epoch,
+          getCurrentEpoch: () => epoch,
+          loadState: () =>
+            ({
+              phase: 'terminal',
+              terminal: { coinsOfInterest: [] },
+              presentation: {},
+            }) as ReturnType<Parameters<typeof persistFreshStartCheckpoint>[0]['loadState']>,
+          replaceSession: async () => {
+            epoch += 1;
+          },
+          saveTerminalSession: async () => {
+            throw new Error('restore failed');
+          },
+          clearSessionPreservingHistory: jest.fn(),
+          checkpoint,
+          onCommitted,
+        }),
+      ).rejects.toThrow(/restore failed/);
+      expect(onCommitted).toHaveBeenCalled();
+      expect(startFailureDisposition(true)).toBe('cancel-attempt');
+    });
+  });
+});

--- a/front-end/src/lib/tests/game_pane.test.ts
+++ b/front-end/src/lib/tests/game_pane.test.ts
@@ -1,0 +1,33 @@
+import { selectGamePaneKind } from '../session/gamePane';
+
+describe('selectGamePaneKind', () => {
+  const base = {
+    sessionPaneTransition: false,
+    keepSession: false,
+    restoreStatus: 'idle',
+    restoreError: null as string | null,
+    sessionPhase: 'none',
+    hasDashboardModel: false,
+    sessionCanMount: false,
+  };
+
+  it('gives Shell the cover only before GameSession is kept', () => {
+    expect(
+      selectGamePaneKind({ ...base, sessionPaneTransition: true, keepSession: false }),
+    ).toEqual({ kind: 'transitionCover' });
+    expect(selectGamePaneKind({ ...base, sessionPaneTransition: true, keepSession: true })).toEqual(
+      { kind: 'gameSession', showTransitionSurface: true },
+    );
+  });
+
+  it('prefers finished freeze over restoring placeholder', () => {
+    expect(
+      selectGamePaneKind({
+        ...base,
+        sessionPhase: 'resolved',
+        hasDashboardModel: true,
+        sessionCanMount: true,
+      }),
+    ).toEqual({ kind: 'finishedFreeze' });
+  });
+});

--- a/front-end/src/lib/tests/peer_session_params.test.ts
+++ b/front-end/src/lib/tests/peer_session_params.test.ts
@@ -21,6 +21,7 @@ describe('peerSessionParams', () => {
       expect(isValidSessionAmountString('not-a-number')).toBe(false);
       expect(isValidSessionAmountString('1.5')).toBe(false);
       expect(isValidSessionAmountString('0x10')).toBe(false);
+      expect(isValidSessionAmountString('08')).toBe(false);
     });
   });
 
@@ -37,6 +38,11 @@ describe('peerSessionParams', () => {
       expect(isValidTimeoutString('31')).toBe(false);
       expect(isValidTimeoutString('nope')).toBe(false);
     });
+
+    it('rejects leading-zero decimals without throwing', () => {
+      expect(isValidTimeoutString('08')).toBe(false);
+      expect(isValidTimeoutString('015')).toBe(false);
+    });
   });
 
   describe('parseSessionAmount', () => {
@@ -47,6 +53,7 @@ describe('peerSessionParams', () => {
     it('throws on invalid amounts', () => {
       expect(() => parseSessionAmount('0')).toThrow(/positive/);
       expect(() => parseSessionAmount('bad')).toThrow(/invalid session amount/);
+      expect(() => parseSessionAmount('08')).toThrow(/invalid session amount/);
     });
   });
 

--- a/front-end/src/lib/tests/peer_session_params.test.ts
+++ b/front-end/src/lib/tests/peer_session_params.test.ts
@@ -2,7 +2,6 @@ import {
   isValidSessionAmountString,
   isValidTimeoutString,
   parseSessionAmount,
-  startFailureDisposition,
 } from '../session/peerSessionParams';
 
 describe('peerSessionParams', () => {
@@ -54,16 +53,6 @@ describe('peerSessionParams', () => {
       expect(() => parseSessionAmount('0')).toThrow(/positive/);
       expect(() => parseSessionAmount('bad')).toThrow(/invalid session amount/);
       expect(() => parseSessionAmount('08')).toThrow(/invalid session amount/);
-    });
-  });
-
-  describe('startFailureDisposition', () => {
-    it('abandons the peer attempt only when persist has not committed', () => {
-      expect(startFailureDisposition(false)).toBe('abandon-peer-only');
-    });
-
-    it('cancels the full attempt once replaceSession has landed', () => {
-      expect(startFailureDisposition(true)).toBe('cancel-attempt');
     });
   });
 });

--- a/front-end/src/lib/tests/peer_session_params.test.ts
+++ b/front-end/src/lib/tests/peer_session_params.test.ts
@@ -1,0 +1,62 @@
+import {
+  isValidSessionAmountString,
+  isValidTimeoutString,
+  parseSessionAmount,
+  startFailureDisposition,
+} from '../session/peerSessionParams';
+
+describe('peerSessionParams', () => {
+  describe('isValidSessionAmountString', () => {
+    it('accepts positive decimal bigint strings', () => {
+      expect(isValidSessionAmountString('1')).toBe(true);
+      expect(isValidSessionAmountString('100')).toBe(true);
+      expect(isValidSessionAmountString('999999999999')).toBe(true);
+    });
+
+    it('rejects empty, zero, negative, and non-numeric values', () => {
+      expect(isValidSessionAmountString(undefined)).toBe(false);
+      expect(isValidSessionAmountString('')).toBe(false);
+      expect(isValidSessionAmountString('0')).toBe(false);
+      expect(isValidSessionAmountString('-1')).toBe(false);
+      expect(isValidSessionAmountString('not-a-number')).toBe(false);
+      expect(isValidSessionAmountString('1.5')).toBe(false);
+      expect(isValidSessionAmountString('0x10')).toBe(false);
+    });
+  });
+
+  describe('isValidTimeoutString', () => {
+    it('treats omitted timeouts as valid (defaults apply later)', () => {
+      expect(isValidTimeoutString(undefined)).toBe(true);
+    });
+
+    it('accepts only the hub range 3-30', () => {
+      expect(isValidTimeoutString('3')).toBe(true);
+      expect(isValidTimeoutString('15')).toBe(true);
+      expect(isValidTimeoutString('30')).toBe(true);
+      expect(isValidTimeoutString('2')).toBe(false);
+      expect(isValidTimeoutString('31')).toBe(false);
+      expect(isValidTimeoutString('nope')).toBe(false);
+    });
+  });
+
+  describe('parseSessionAmount', () => {
+    it('parses positive amounts', () => {
+      expect(parseSessionAmount('42')).toBe(42n);
+    });
+
+    it('throws on invalid amounts', () => {
+      expect(() => parseSessionAmount('0')).toThrow(/positive/);
+      expect(() => parseSessionAmount('bad')).toThrow(/invalid session amount/);
+    });
+  });
+
+  describe('startFailureDisposition', () => {
+    it('abandons the peer attempt only when persist never succeeded', () => {
+      expect(startFailureDisposition(false)).toBe('abandon-peer-only');
+    });
+
+    it('cancels the full attempt once the live checkpoint replaced the freeze', () => {
+      expect(startFailureDisposition(true)).toBe('cancel-attempt');
+    });
+  });
+});

--- a/front-end/src/lib/tests/peer_session_params.test.ts
+++ b/front-end/src/lib/tests/peer_session_params.test.ts
@@ -58,11 +58,11 @@ describe('peerSessionParams', () => {
   });
 
   describe('startFailureDisposition', () => {
-    it('abandons the peer attempt only when persist never succeeded', () => {
+    it('abandons the peer attempt only when persist has not committed', () => {
       expect(startFailureDisposition(false)).toBe('abandon-peer-only');
     });
 
-    it('cancels the full attempt once the live checkpoint replaced the freeze', () => {
+    it('cancels the full attempt once replaceSession has landed', () => {
       expect(startFailureDisposition(true)).toBe('cancel-attempt');
     });
   });

--- a/front-end/src/lib/tests/restore_lifecycle.test.ts
+++ b/front-end/src/lib/tests/restore_lifecycle.test.ts
@@ -1,5 +1,6 @@
 import {
   isRestoreBlocked,
+  restoreGateAfterTerminalFinalization,
   shouldAdvertiseAvailable,
   shouldAwaitShutdownOnPeerUnreachable,
   shouldCancelAttemptOnDisconnect,
@@ -8,6 +9,7 @@ import {
   shouldReportHubBusy,
   shouldReportHubBusyPresence,
   shouldReportSessionPhase,
+  shouldSuppressPhaseReporting,
   shouldSwitchToHubOnResolved,
 } from '../restoreLifecycle';
 
@@ -19,6 +21,26 @@ describe('restore lifecycle gates', () => {
     expect(isRestoreBlocked(true, 'failed', true)).toBe(true);
     expect(isRestoreBlocked(true, 'restored', true)).toBe(false);
     expect(isRestoreBlocked(false, 'idle', false)).toBe(false);
+  });
+
+  it('does not re-arm Restoring session after terminal finalization of a resumed mount', () => {
+    // Resumed live sessions keep params.restoring=true after WASM+hub succeed.
+    expect(isRestoreBlocked(true, 'restored', true)).toBe(false);
+
+    // The old finishResolvedSessionDisplay reset (idle + hubReconciled=false)
+    // while leaving restoring=true re-blocked GameSession via suppressPhaseReporting.
+    expect(isRestoreBlocked(true, 'idle', false)).toBe(true);
+    expect(shouldSuppressPhaseReporting(true, false)).toBe(true);
+
+    const after = restoreGateAfterTerminalFinalization();
+    expect(after.restoring).toBe(false);
+    expect(isRestoreBlocked(after.restoring, after.restoreStatus, after.hubReconciled)).toBe(false);
+
+    // Even if restoreBlocked were still true, a terminal presentation must win:
+    // slash stays on the game tab (hasError) and must show the finished freeze.
+    expect(shouldSuppressPhaseReporting(true, true)).toBe(false);
+    expect(shouldSwitchToHubOnResolved('on-chain', true)).toBe(false);
+    expect(shouldSwitchToHubOnResolved('off-chain', true)).toBe(false);
   });
 
   it('keeps the hub unavailable while restore is blocked', () => {

--- a/front-end/src/lib/tests/restore_lifecycle.test.ts
+++ b/front-end/src/lib/tests/restore_lifecycle.test.ts
@@ -11,6 +11,7 @@ import {
   shouldReportSessionPhase,
   shouldSuppressPhaseReporting,
   shouldSwitchToHubOnResolved,
+  shouldSynthesizeSetupPending,
 } from '../restoreLifecycle';
 
 describe('restore lifecycle gates', () => {
@@ -41,6 +42,14 @@ describe('restore lifecycle gates', () => {
     expect(shouldSuppressPhaseReporting(true, true)).toBe(false);
     expect(shouldSwitchToHubOnResolved('on-chain', true)).toBe(false);
     expect(shouldSwitchToHubOnResolved('off-chain', true)).toBe(false);
+  });
+
+  it('limits setupPending synthesis to the pre-first-model / finished-freeze window', () => {
+    expect(shouldSynthesizeSetupPending(false, false)).toBe(false);
+    // No live model yet (null model or finished freeze still mounted).
+    expect(shouldSynthesizeSetupPending(true, false)).toBe(true);
+    // First live handshake model must leave labels core-derived.
+    expect(shouldSynthesizeSetupPending(true, true)).toBe(false);
   });
 
   it('keeps the hub unavailable while restore is blocked', () => {

--- a/front-end/src/lib/tests/restore_lifecycle.test.ts
+++ b/front-end/src/lib/tests/restore_lifecycle.test.ts
@@ -11,7 +11,6 @@ import {
   shouldReportSessionPhase,
   shouldSuppressPhaseReporting,
   shouldSwitchToHubOnResolved,
-  shouldSynthesizeSetupPending,
 } from '../restoreLifecycle';
 
 describe('restore lifecycle gates', () => {
@@ -42,14 +41,6 @@ describe('restore lifecycle gates', () => {
     expect(shouldSuppressPhaseReporting(true, true)).toBe(false);
     expect(shouldSwitchToHubOnResolved('on-chain', true)).toBe(false);
     expect(shouldSwitchToHubOnResolved('off-chain', true)).toBe(false);
-  });
-
-  it('limits setupPending synthesis to the pre-first-model / finished-freeze window', () => {
-    expect(shouldSynthesizeSetupPending(false, false)).toBe(false);
-    // No live model yet (null model or finished freeze still mounted).
-    expect(shouldSynthesizeSetupPending(true, false)).toBe(true);
-    // First live handshake model must leave labels core-derived.
-    expect(shouldSynthesizeSetupPending(true, true)).toBe(false);
   });
 
   it('keeps the hub unavailable while restore is blocked', () => {

--- a/front-end/src/lib/tests/session_model.presentation.test.ts
+++ b/front-end/src/lib/tests/session_model.presentation.test.ts
@@ -53,6 +53,23 @@ describe('session model dashboard and on-chain presentation contracts', () => {
       actionKind: 'cancel',
     });
 
+    // Accepting after a finished freeze keeps the terminal model until
+    // retireTerminalDisplay; setupPending must still expose Cancel.
+    const finishedFreeze = createSessionModel({
+      channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'ResolvedClean' } },
+    });
+    expect(selectGameDashboardView(finishedFreeze)).toMatchObject({
+      actionLabel: 'Done',
+      actionEnabled: false,
+      actionKind: 'none',
+    });
+    expect(selectGameDashboardView(finishedFreeze, { setupPending: true })).toMatchObject({
+      channelStatusLabel: 'Setting Up',
+      actionLabel: 'Cancel',
+      actionEnabled: true,
+      actionKind: 'cancel',
+    });
+
     for (const state of [
       'Handshaking',
       'WaitingForHeightToOffer',

--- a/front-end/src/lib/tests/session_model.presentation.test.ts
+++ b/front-end/src/lib/tests/session_model.presentation.test.ts
@@ -70,6 +70,19 @@ describe('session model dashboard and on-chain presentation contracts', () => {
       actionKind: 'cancel',
     });
 
+    // Once a live handshake model exists, core labels must show even if a
+    // caller incorrectly left setupPending set (Shell should clear it).
+    expect(
+      selectGameDashboardView(
+        createSessionModel({
+          channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'Handshaking' } },
+        }),
+      ),
+    ).toMatchObject({
+      channelStatusLabel: 'Handshaking',
+      actionKind: 'cancel',
+    });
+
     for (const state of [
       'Handshaking',
       'WaitingForHeightToOffer',

--- a/front-end/src/lib/tests/session_model.presentation.test.ts
+++ b/front-end/src/lib/tests/session_model.presentation.test.ts
@@ -45,6 +45,45 @@ describe('session model dashboard and on-chain presentation contracts', () => {
     });
   });
 
+  it('uses the existing dashboard action across the setup commitment boundary', () => {
+    expect(selectGameDashboardView(null, { setupPending: true })).toMatchObject({
+      channelStatusLabel: 'Setting Up',
+      actionLabel: 'Cancel',
+      actionEnabled: true,
+      actionKind: 'cancel',
+    });
+
+    for (const state of [
+      'Handshaking',
+      'WaitingForHeightToOffer',
+      'WaitingForHeightToAccept',
+      'OurWalletMakingOffer',
+      'OurWalletMakingOfferAcceptance',
+    ] as const) {
+      expect(
+        selectGameDashboardView(
+          createSessionModel({
+            channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state } },
+          }),
+        ).actionKind,
+      ).toBe('cancel');
+    }
+
+    for (const state of ['OfferSent', 'TransactionPending'] as const) {
+      expect(
+        selectGameDashboardView(
+          createSessionModel({
+            channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state } },
+          }),
+        ),
+      ).toMatchObject({
+        actionLabel: 'Waiting',
+        actionEnabled: false,
+        actionKind: 'none',
+      });
+    }
+  });
+
   it('derives dashboard actions for no-session, waiting, active, and terminal states', () => {
     expect(selectGameDashboardView(null)).toMatchObject({
       channelStatusLabel: 'No Session',

--- a/front-end/src/lib/tests/shell-session-transitions.test.ts
+++ b/front-end/src/lib/tests/shell-session-transitions.test.ts
@@ -1,10 +1,39 @@
 import {
   initialShellSessionState,
+  isAcceptSessionTransition,
   shellSessionReducer,
   type ShellSessionState,
 } from '../session/shellSessionState';
 
 describe('shellSessionReducer', () => {
+  it('identifies accept transitions', () => {
+    expect(isAcceptSessionTransition({ kind: 'idle' })).toBe(false);
+    expect(
+      isAcceptSessionTransition({
+        kind: 'pending',
+        reason: 'accept-advisory',
+        scope: 'session-pane',
+        readyKey: 't',
+      }),
+    ).toBe(true);
+    expect(
+      isAcceptSessionTransition({
+        kind: 'pending',
+        reason: 'accept-proposal',
+        scope: 'session-pane',
+        readyKey: 't',
+      }),
+    ).toBe(true);
+    expect(
+      isAcceptSessionTransition({
+        kind: 'pending',
+        reason: 'resume',
+        scope: 'shell',
+        readyKey: null,
+      }),
+    ).toBe(false);
+  });
+
   it('returns the initial state', () => {
     expect(initialShellSessionState).toEqual({
       sessionConfig: null,

--- a/front-end/src/lib/tests/shell-session-transitions.test.ts
+++ b/front-end/src/lib/tests/shell-session-transitions.test.ts
@@ -24,14 +24,6 @@ describe('shellSessionReducer', () => {
         readyKey: 't',
       }),
     ).toBe(true);
-    expect(
-      isAcceptSessionTransition({
-        kind: 'pending',
-        reason: 'resume',
-        scope: 'shell',
-        readyKey: null,
-      }),
-    ).toBe(false);
   });
 
   it('returns the initial state', () => {
@@ -59,6 +51,55 @@ describe('shellSessionReducer', () => {
     expect(state.transition).toEqual({ kind: 'idle' });
   });
 
+  it('beginAccept clears consent prompts atomically with the transition', () => {
+    const withAdvisory: ShellSessionState = {
+      ...initialShellSessionState,
+      pendingAdvisory: {
+        peer_id: 'peer-1',
+        peer_alias: 'Alice',
+        my_amount: '100',
+        their_amount: '100',
+      },
+      pendingProposal: {
+        from_id: 'peer-2',
+        from_alias: 'Bob',
+        proposer_amount: '50',
+        responder_amount: '50',
+      },
+    };
+
+    const state = shellSessionReducer(withAdvisory, {
+      type: 'beginAccept',
+      reason: 'accept-advisory',
+      readyKey: 'token-1',
+    });
+
+    expect(state.transition).toEqual({
+      kind: 'pending',
+      reason: 'accept-advisory',
+      scope: 'session-pane',
+      readyKey: 'token-1',
+    });
+    expect(state.pendingAdvisory).toBeNull();
+    expect(state.pendingProposal).toBeNull();
+  });
+
+  it('liveMounted installs session config and peer connection together', () => {
+    const state = shellSessionReducer(initialShellSessionState, {
+      type: 'liveMounted',
+      sessionConfig: {
+        iStarted: false,
+        myContribution: 100n,
+        theirContribution: 100n,
+        perGameAmount: 10n,
+        pairingToken: 'token-1',
+      },
+      peerConn: { send: () => {}, close: () => {} } as never,
+    });
+    expect(state.sessionConfig?.pairingToken).toBe('token-1');
+    expect(state.peerConn).not.toBeNull();
+  });
+
   it('enters and leaves a transition', () => {
     const pending = shellSessionReducer(initialShellSessionState, {
       type: 'startTransition',
@@ -77,23 +118,8 @@ describe('shellSessionReducer', () => {
     expect(ended.transition).toEqual({ kind: 'idle' });
   });
 
-  it('records the last transition reason', () => {
-    const state = shellSessionReducer(initialShellSessionState, {
-      type: 'startTransition',
-      reason: 'resume',
-      scope: 'shell',
-      readyKey: null,
-    });
-    expect(state.transition).toEqual({
-      kind: 'pending',
-      reason: 'resume',
-      scope: 'shell',
-      readyKey: null,
-    });
-  });
-
-  it('clears the consent prompt while a transition is pending', () => {
-    const withAdvisory: ShellSessionState = {
+  it('acceptAborted clears consent, sets error, and ends the transition atomically', () => {
+    const withConsent: ShellSessionState = {
       ...initialShellSessionState,
       pendingAdvisory: {
         peer_id: 'peer-1',
@@ -101,61 +127,22 @@ describe('shellSessionReducer', () => {
         my_amount: '100',
         their_amount: '100',
       },
+      transition: {
+        kind: 'pending',
+        reason: 'accept-proposal',
+        scope: 'session-pane',
+        readyKey: 'token-1',
+      },
     };
 
-    const state = shellSessionReducer(withAdvisory, {
-      type: 'startTransition',
-      reason: 'accept-advisory',
-      scope: 'session-pane',
-      readyKey: null,
+    const state = shellSessionReducer(withConsent, {
+      type: 'acceptAborted',
+      error: true,
     });
-    const cleared = shellSessionReducer(state, {
-      type: 'setPendingAdvisory',
-      value: null,
-    });
-
-    expect(cleared.transition).toEqual({
-      kind: 'pending',
-      reason: 'accept-advisory',
-      scope: 'session-pane',
-      readyKey: null,
-    });
-    expect(cleared.pendingAdvisory).toBeNull();
-  });
-
-  it('installs the new session snapshot before ending the transition', () => {
-    let state = shellSessionReducer(initialShellSessionState, {
-      type: 'startTransition',
-      reason: 'accept-proposal',
-      scope: 'session-pane',
-      readyKey: null,
-    });
-
-    state = shellSessionReducer(state, {
-      type: 'setSessionConfig',
-      value: {
-        iStarted: false,
-        myContribution: 100n,
-        theirContribution: 100n,
-        perGameAmount: 10n,
-        pairingToken: 'token-1',
-      },
-    });
-    state = shellSessionReducer(state, {
-      type: 'setSessionPhase',
-      value: 'none',
-    });
-    state = shellSessionReducer(state, { type: 'endTransition' });
-
+    expect(state.pendingAdvisory).toBeNull();
+    expect(state.pendingProposal).toBeNull();
+    expect(state.sessionError).toBe(true);
     expect(state.transition).toEqual({ kind: 'idle' });
-    expect(state.sessionConfig).toEqual({
-      iStarted: false,
-      myContribution: 100n,
-      theirContribution: 100n,
-      perGameAmount: 10n,
-      pairingToken: 'token-1',
-    });
-    expect(state.sessionPhase).toBe('none');
   });
 
   it('releases a waiting transition only for its registered session', () => {

--- a/front-end/src/lib/tests/shell-session-transitions.test.ts
+++ b/front-end/src/lib/tests/shell-session-transitions.test.ts
@@ -1,0 +1,159 @@
+import {
+  initialShellSessionState,
+  shellSessionReducer,
+  type ShellSessionState,
+} from '../session/shellSessionState';
+
+describe('shellSessionReducer', () => {
+  it('returns the initial state', () => {
+    expect(initialShellSessionState).toEqual({
+      sessionConfig: null,
+      peerConn: null,
+      dashboardSessionModel: null,
+      sessionPhase: 'none',
+      pendingAdvisory: null,
+      pendingProposal: null,
+      sessionError: false,
+      restoreStatus: 'idle',
+      restoreError: null,
+      restoreHubReconciled: false,
+      transition: { kind: 'idle' },
+    });
+  });
+
+  it('sets lifecycle fields individually', () => {
+    const state = shellSessionReducer(initialShellSessionState, {
+      type: 'setSessionPhase',
+      value: 'off-chain',
+    });
+    expect(state.sessionPhase).toBe('off-chain');
+    expect(state.transition).toEqual({ kind: 'idle' });
+  });
+
+  it('enters and leaves a transition', () => {
+    const pending = shellSessionReducer(initialShellSessionState, {
+      type: 'startTransition',
+      reason: 'accept-advisory',
+      scope: 'session-pane',
+      readyKey: null,
+    });
+    expect(pending.transition).toEqual({
+      kind: 'pending',
+      reason: 'accept-advisory',
+      scope: 'session-pane',
+      readyKey: null,
+    });
+
+    const ended = shellSessionReducer(pending, { type: 'endTransition' });
+    expect(ended.transition).toEqual({ kind: 'idle' });
+  });
+
+  it('records the last transition reason', () => {
+    const state = shellSessionReducer(initialShellSessionState, {
+      type: 'startTransition',
+      reason: 'resume',
+      scope: 'shell',
+      readyKey: null,
+    });
+    expect(state.transition).toEqual({
+      kind: 'pending',
+      reason: 'resume',
+      scope: 'shell',
+      readyKey: null,
+    });
+  });
+
+  it('clears the consent prompt while a transition is pending', () => {
+    const withAdvisory: ShellSessionState = {
+      ...initialShellSessionState,
+      pendingAdvisory: {
+        peer_id: 'peer-1',
+        peer_alias: 'Alice',
+        my_amount: '100',
+        their_amount: '100',
+      },
+    };
+
+    const state = shellSessionReducer(withAdvisory, {
+      type: 'startTransition',
+      reason: 'accept-advisory',
+      scope: 'session-pane',
+      readyKey: null,
+    });
+    const cleared = shellSessionReducer(state, {
+      type: 'setPendingAdvisory',
+      value: null,
+    });
+
+    expect(cleared.transition).toEqual({
+      kind: 'pending',
+      reason: 'accept-advisory',
+      scope: 'session-pane',
+      readyKey: null,
+    });
+    expect(cleared.pendingAdvisory).toBeNull();
+  });
+
+  it('installs the new session snapshot before ending the transition', () => {
+    let state = shellSessionReducer(initialShellSessionState, {
+      type: 'startTransition',
+      reason: 'accept-proposal',
+      scope: 'session-pane',
+      readyKey: null,
+    });
+
+    state = shellSessionReducer(state, {
+      type: 'setSessionConfig',
+      value: {
+        iStarted: false,
+        myContribution: 100n,
+        theirContribution: 100n,
+        perGameAmount: 10n,
+        pairingToken: 'token-1',
+      },
+    });
+    state = shellSessionReducer(state, {
+      type: 'setSessionPhase',
+      value: 'none',
+    });
+    state = shellSessionReducer(state, { type: 'endTransition' });
+
+    expect(state.transition).toEqual({ kind: 'idle' });
+    expect(state.sessionConfig).toEqual({
+      iStarted: false,
+      myContribution: 100n,
+      theirContribution: 100n,
+      perGameAmount: 10n,
+      pairingToken: 'token-1',
+    });
+    expect(state.sessionPhase).toBe('none');
+  });
+
+  it('releases a waiting transition only for its registered session', () => {
+    const state = shellSessionReducer(initialShellSessionState, {
+      type: 'startTransition',
+      reason: 'accept-advisory',
+      scope: 'session-pane',
+      readyKey: 'new-session',
+    });
+
+    expect(
+      shellSessionReducer(state, {
+        type: 'completeTransition',
+        readyKey: 'old-session',
+      }).transition,
+    ).toEqual({
+      kind: 'pending',
+      reason: 'accept-advisory',
+      scope: 'session-pane',
+      readyKey: 'new-session',
+    });
+
+    expect(
+      shellSessionReducer(state, {
+        type: 'completeTransition',
+        readyKey: 'new-session',
+      }).transition,
+    ).toEqual({ kind: 'idle' });
+  });
+});

--- a/front-end/src/lib/tests/terminal_finalization.test.ts
+++ b/front-end/src/lib/tests/terminal_finalization.test.ts
@@ -14,7 +14,6 @@ import { krunkBoardNotice } from '../../features/krunk/useKrunkHand';
 import FinishedSessionGameView from '../../components/FinishedSessionGameView';
 import {
   _resetForTests,
-  clearSession,
   discardStagedTerminalSession,
   flushSessionSave,
   hasSavedSessionMarker,
@@ -415,6 +414,14 @@ it('aborts after persist when the start epoch advances during replaceSession', a
     reportBusy: () => {},
     shouldAbort: () => capturedEpoch !== startEpoch,
     persistLiveCheckpoint: async () => {
+      const prior = loadState();
+      const terminalBackup =
+        prior.phase === 'terminal'
+          ? {
+              terminal: structuredClone(prior.terminal),
+              presentation: structuredClone(prior.presentation),
+            }
+          : null;
       await replaceSession(
         baseSave({
           pairingToken: 'cancelled-token',
@@ -426,13 +433,14 @@ it('aborts after persist when the start epoch advances during replaceSession', a
           perGameAmount: '1',
         }),
       );
-      // Simulate dashboard Cancel bumping the epoch and clearing storage after
-      // replaceSession's awaits — the write must not survive as a resume target.
+      // Simulate dashboard Cancel bumping the epoch during replaceSession's
+      // awaits — restore the finished freeze rather than wiping IndexedDB.
       startEpoch += 1;
-      const humanHistory = loadState().history.humanHistory;
-      await clearSession();
-      if (humanHistory?.length) {
-        await saveSession({ scope: 'common', history: { humanHistory } });
+      if (capturedEpoch !== startEpoch) {
+        if (terminalBackup) {
+          await saveTerminalSession(terminalBackup);
+        }
+        return;
       }
     },
     retireTerminalDisplay: () => {
@@ -448,8 +456,59 @@ it('aborts after persist when the start epoch advances during replaceSession', a
   expect(displayedSession).toBe('resolved');
   expect(mounted).toBe(false);
   await flushSessionSave();
-  const record = await readSessionRecord();
-  expect(record == null || decodeSessionSaveEnvelope(record).phase === 'preferences').toBe(true);
+  expect(decodeSessionSaveEnvelope((await readSessionRecord())!).phase).toBe('terminal');
+});
+
+it('keeps the terminal checkpoint when Cancel aborts before replaceSession', async () => {
+  await saveTerminalSession(
+    terminalUpdate({
+      channelStatus: { state: 'ResolvedClean' },
+      coinsOfInterest: [{ label: 'Reward coin', id: 'coin-1' }],
+    }),
+  );
+  await flushSessionSave();
+
+  let displayedSession = 'resolved';
+  let mounted = false;
+  let startEpoch = 1;
+  const capturedEpoch = startEpoch;
+  let replaceCalled = false;
+
+  // Simulate dashboard Cancel before persist begins.
+  startEpoch += 1;
+
+  const outcome = await transitionToFreshSession({
+    reportBusy: () => {},
+    shouldAbort: () => capturedEpoch !== startEpoch,
+    persistLiveCheckpoint: async () => {
+      if (capturedEpoch !== startEpoch) return;
+      replaceCalled = true;
+      await replaceSession(
+        baseSave({
+          pairingToken: 'should-not-write',
+          sessionPeerId: 'peer',
+          gameSessionId: 'session',
+          iStarted: true,
+          myContribution: '10',
+          theirContribution: '10',
+          perGameAmount: '1',
+        }),
+      );
+    },
+    retireTerminalDisplay: () => {
+      displayedSession = 'none';
+    },
+    mountLiveSession: () => {
+      mounted = true;
+      displayedSession = 'live';
+    },
+  });
+
+  expect(outcome).toBe('aborted');
+  expect(replaceCalled).toBe(false);
+  expect(displayedSession).toBe('resolved');
+  expect(mounted).toBe(false);
+  expect(decodeSessionSaveEnvelope((await readSessionRecord())!).phase).toBe('terminal');
 });
 
 it('keeps the resolved display and terminal checkpoint when fresh persistence fails', async () => {

--- a/front-end/src/lib/tests/terminal_finalization.test.ts
+++ b/front-end/src/lib/tests/terminal_finalization.test.ts
@@ -14,6 +14,7 @@ import { krunkBoardNotice } from '../../features/krunk/useKrunkHand';
 import FinishedSessionGameView from '../../components/FinishedSessionGameView';
 import {
   _resetForTests,
+  clearSession,
   discardStagedTerminalSession,
   flushSessionSave,
   hasSavedSessionMarker,
@@ -363,7 +364,7 @@ it('retires a resolved display before accepting a fresh live session', async () 
   let hubBusy = false;
   const pairingToken = 'fresh-live-token';
 
-  await transitionToFreshSession({
+  const outcome = await transitionToFreshSession({
     retireTerminalDisplay: () => {
       displayedSession = 'none';
     },
@@ -389,10 +390,66 @@ it('retires a resolved display before accepting a fresh live session', async () 
     },
   });
 
+  expect(outcome).toBe('completed');
   expect(displayedSession).toBe('live');
   expect(mountedPairingToken).toBe(pairingToken);
   expect(hubBusy).toBe(true);
   expect(decodeSessionSaveEnvelope((await readSessionRecord())!).phase).toBe('pre-handshake');
+});
+
+it('aborts after persist when the start epoch advances during replaceSession', async () => {
+  await saveTerminalSession(
+    terminalUpdate({
+      channelStatus: { state: 'ResolvedClean' },
+      coinsOfInterest: [{ label: 'Reward coin', id: 'coin-1' }],
+    }),
+  );
+  await flushSessionSave();
+
+  let displayedSession = 'resolved';
+  let mounted = false;
+  let startEpoch = 1;
+  const capturedEpoch = startEpoch;
+
+  const outcome = await transitionToFreshSession({
+    reportBusy: () => {},
+    shouldAbort: () => capturedEpoch !== startEpoch,
+    persistLiveCheckpoint: async () => {
+      await replaceSession(
+        baseSave({
+          pairingToken: 'cancelled-token',
+          sessionPeerId: 'peer',
+          gameSessionId: 'session',
+          iStarted: true,
+          myContribution: '10',
+          theirContribution: '10',
+          perGameAmount: '1',
+        }),
+      );
+      // Simulate dashboard Cancel bumping the epoch and clearing storage after
+      // replaceSession's awaits — the write must not survive as a resume target.
+      startEpoch += 1;
+      const humanHistory = loadState().history.humanHistory;
+      await clearSession();
+      if (humanHistory?.length) {
+        await saveSession({ scope: 'common', history: { humanHistory } });
+      }
+    },
+    retireTerminalDisplay: () => {
+      displayedSession = 'none';
+    },
+    mountLiveSession: () => {
+      mounted = true;
+      displayedSession = 'live';
+    },
+  });
+
+  expect(outcome).toBe('aborted');
+  expect(displayedSession).toBe('resolved');
+  expect(mounted).toBe(false);
+  await flushSessionSave();
+  const record = await readSessionRecord();
+  expect(record == null || decodeSessionSaveEnvelope(record).phase === 'preferences').toBe(true);
 });
 
 it('keeps the resolved display and terminal checkpoint when fresh persistence fails', async () => {

--- a/src/common/types/divmod.rs
+++ b/src/common/types/divmod.rs
@@ -11,7 +11,8 @@ pub fn divmod(a: BigInt, b: BigInt) -> (BigInt, BigInt) {
     }
 }
 
-#[cfg(test)]
+// Collected only by the sim-tests runner (simulator is feature-gated).
+#[cfg(all(test, feature = "sim-tests"))]
 fn test_local_divmod() {
     assert_eq!(
         divmod((-7).to_bigint().unwrap(), 2.to_bigint().unwrap()),
@@ -31,7 +32,7 @@ fn test_local_divmod() {
     );
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sim-tests"))]
 pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
     vec![("test_local_divmod", &test_local_divmod)]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,5 +26,10 @@ mod manifest_guards;
 #[cfg(test)]
 pub mod test_support;
 
+// Sim-runner collectors (`test_funs`) are only referenced from `simulator`,
+// which is feature-gated. Without `sim-tests`, `cargo test --no-run` still
+// compiles this module (CI checks that config) but nothing calls the
+// collectors — allow dead_code there so that check stays quiet.
 #[cfg(test)]
+#[cfg_attr(not(feature = "sim-tests"), allow(dead_code))]
 mod tests;

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -1008,11 +1008,18 @@ pub(crate) fn current_test_name() -> Option<String> {
 #[cfg(test)]
 pub fn run_simulation_tests() {
     use std::backtrace::Backtrace;
-    std::panic::set_hook(Box::new(|panic_info| {
+    // Process-global hook shared with cargo's parallel unit tests (including
+    // #[should_panic]). Annotate panics from sim workers only; never exit —
+    // exit(1) when CURRENT_TEST_NAME is unset races with expected unit-test
+    // panics and aborts the whole suite.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
         let test_name = CURRENT_TEST_NAME.with(|cell| cell.borrow().clone());
-        if let Some(name) = &test_name {
-            eprintln!("PANIC IN TEST: {name}");
-        }
+        let Some(name) = test_name else {
+            previous_hook(panic_info);
+            return;
+        };
+        eprintln!("PANIC IN TEST: {name}");
         if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
             eprintln!("panic payload: {s}");
         } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
@@ -1022,9 +1029,6 @@ pub fn run_simulation_tests() {
         }
         let trace = Backtrace::force_capture();
         eprintln!("{trace}");
-        if test_name.is_none() {
-            std::process::exit(1);
-        }
     }));
     let ref_lists: Vec<Vec<(&str, &(dyn Fn() + Send + Sync))>> = vec![
         divmod_tests(),

--- a/src/tests/channel_state.rs
+++ b/src/tests/channel_state.rs
@@ -372,16 +372,24 @@ pub(crate) fn test_unroll_can_verify_own_signature() {
 }
 
 pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
-    let mut v: Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> = vec![(
-        "test_unroll_can_verify_own_signature",
-        &test_unroll_can_verify_own_signature,
-    )];
     #[cfg(feature = "sim-tests")]
     {
-        v.push((
-            "test_preemption_parity_constraint",
-            &sim_tests::test_preemption_parity_constraint,
-        ));
+        vec![
+            (
+                "test_unroll_can_verify_own_signature",
+                &test_unroll_can_verify_own_signature,
+            ),
+            (
+                "test_preemption_parity_constraint",
+                &sim_tests::test_preemption_parity_constraint,
+            ),
+        ]
     }
-    v
+    #[cfg(not(feature = "sim-tests"))]
+    {
+        vec![(
+            "test_unroll_can_verify_own_signature",
+            &test_unroll_can_verify_own_signature,
+        )]
+    }
 }


### PR DESCRIPTION
## Summary
- move Shell session lifecycle fields into a reducer-backed transition controller
- keep the game dashboard and mounted session stable while channel setup progresses behind a pane-scoped transition surface
- reuse the existing dashboard Cancel/Waiting/Abandon action policy and release setup only from authoritative core-derived state
- key readiness atomically to the new session and cover transition behavior with reducer and selector tests

## Test plan
- [x] `./ct.sh`
- [x] `./cb.sh`
- [x] `pnpm run lint:fix`
- [x] `pnpm run format`
- [x] `cargo clippy`
- [x] `cargo fmt`
- [x] Bugbot review


Made with [Cursor](https://cursor.com)