### PR TITLE
Improve session banner, unroll status, and on-chain timeout claims

### DIFF
--- a/CONNECTIVITY.md
+++ b/CONNECTIVITY.md
@@ -472,10 +472,10 @@ The hub does not create a session. It can only advise and relay:
 
 - **Peer degradation (no auto-cascade)**: When the peer becomes unreachable
   (delivery failures, 30-second silence, or hub disconnect) while the
-  session is off-chain, `peerLiveness` moves to `'degraded'` (yellow dot).
-  There is no automatic go-on-chain — the user must decide to escalate.
-  Only explicit terminal signals (user clicks "Go On-Chain" or receives a
-  FOAD) mark the peer as dead.
+  session is off-chain, `peerLiveness` moves to `'degraded'` (yellow banner
+  rail; tab stays a link). There is no automatic go-on-chain — the user must
+  decide to escalate. Only explicit terminal signals (user clicks "Go
+  On-Chain" or receives a FOAD) mark the peer as dead.
 
 - **Cascade warning dialogs**: Confirmation dialogs currently warn before
   disconnecting or switching hubs when a peer/session would be affected.
@@ -485,41 +485,48 @@ The hub does not create a session. It can only advise and relay:
 
 ## UX: Connectivity Indicators
 
-### Tab dots
+### Tab pipe marks
 
-Each tab in the tab bar has a small colored dot to the left of its label
-text, indicating the connectivity health of the axis associated with that
-tab. The dot is always present (gray when idle/irrelevant) so the tab bar
-layout never shifts.
+Wallet, Hub, and Game tabs show an uncolored link (connected) or broken-chain
+(disconnected) emoji to the left of the label. History and Log have no pipe
+mark. The existing upper-right notification dots indicate unread activity and
+are unchanged.
 
-Separately, the existing upper-right notification dots indicate unread
-activity (new game events, etc.). These are unchanged and serve a different
-purpose.
+Pipe marks answer only “is this pipe up?” Session mode lives on the game
+dashboard banner rail, not on the tabs.
 
-### Per-tab color semantics
+| Tab | Link | Broken chain |
+|-----|------|----------------|
+| Wallet | Connected. | Disconnected. The **Wallet** label is also red. |
+| Hub | `hubLiveness === 'connected'` | Reconnecting, inactive, disconnected, or never connected |
+| Game | Live session and peer is not `dead` | `sessionPhase` none/resolved, or `peerLiveness === 'dead'` |
 
-| Tab | Green | Yellow | Red | Gray |
-|-----|-------|--------|-----|------|
-| Wallet | Connected | — | Disconnected | — |
-| Hub | Connected | Reconnecting | Inactive (no heartbeat) | Not connected (null / disconnected) |
-| Game | Peer connected (incl. clean shutdown) | On-chain, peer degraded, or peer unreachable during clean shutdown | Error, or peer dead outside clean shutdown | No session / resolved |
-| History | — | — | — | Always gray |
-| Log | — | — | — | Always gray |
+Handshake with `peerLiveness === null` counts as connected. `degraded` pings
+stay a link; that warning is banner-only. `sessionError` does not affect the
+tab mark.
 
-### Game tab dot priority
+### Game dashboard banner rail
 
-The Game tab dot checks conditions in this order:
+The session dashboard has a full-height left-edge color rail:
 
-1. `sessionPhase === 'none' || 'resolved'` → **gray** (no active session)
-2. `sessionError` → **red** (genuine error — always wins)
-3. Clean shutdown in progress (`ShuttingDown` / `ShutdownTransactionPending` /
-   `cleanShutdownStarted`):
-   - peer degraded (or unexpectedly dead) → **yellow** (unreachable)
-   - otherwise → **green** (cooperative close in flight; keepalives continue)
-4. `peerLiveness === 'dead'` → **red** (terminal — go-on-chain or FOAD)
-5. `sessionPhase === 'on-chain'` or `peerLiveness === 'degraded'` → **yellow** (resolving or stale peer)
-6. `peerLiveness === 'connected'` → **green** (playing normally)
-7. Otherwise → **gray**
+| Tone | Color | When |
+|------|-------|------|
+| `idle` | Gray | No session / never set up |
+| `playing` | Green | Setup, handshake, off-chain play, cooperative shutdown |
+| `pings-bad` | Yellow | Same as playing, but `peerLiveness === 'degraded'` |
+| `on-chain` | Red | Going on-chain, unrolling, or a resolved unroll that still has games |
+| `ended` | Blue | Terminal dashboard still showing (clean resolve, failed, abandoned) |
+
+On-chain beats yellow. Failed/stale outcomes that are actually over stay
+`ended`; the Channel label still names the outcome. Yellow also shows
+“Peer pings look stuck.”
+
+### Game tab connectedness
+
+`selectGameTabConnected` is true unless:
+
+1. `sessionPhase === 'none' || 'resolved'`, or
+2. `peerLiveness === 'dead'`
 
 Clean shutdown does **not** mark the peer dead on its own. Keepalives and the
 small allowlist of shutdown-related peer messages continue until local
@@ -528,17 +535,14 @@ shutdown completes. Successful/terminal session exit does not send
 does arrive during pre-active matchmaking, it is honored as an abort: cancel
 the attempt (including any in-flight async session start), surface
 cancelled/error, and do not leave an orphan handshake. When the channel
-reaches a terminal state the session exits and the dot goes gray.
+reaches a terminal state the session exits and the game tab shows a broken
+chain.
 
-### Game tab error conditions (red dot)
+### Session error conditions
 
-The Game tab shows a red dot when `sessionError` is true, or when
-`peerLiveness === 'dead'` outside a clean shutdown (go-on-chain or FOAD).
 `sessionError` is derived from:
 
 - `Failed` channel state — the channel encountered an unrecoverable error
-- `ResolvedStale` channel state — the channel resolved but the outcome is
-  suspect (e.g., opponent exploited a timeout)
 - `ResolvedStale` channel state — the channel resolved but the outcome is
   suspect (e.g., opponent exploited a timeout)
 - `game-error` game terminal — a generic game-level error (`GameStatus` with
@@ -549,7 +553,8 @@ The Game tab shows a red dot when `sessionError` is true, or when
 
 Normal settlements such as `accept_settlement`, `settled_cleanly`,
 `opponent_timed_out`, `we_accepted`, and `slashed_opponent` are **not** session
-errors.
+errors. These conditions do not change the tab pipe mark; terminal outcomes
+use the `ended` banner rail.
 
 ### Settlement labels
 

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -902,8 +902,9 @@ delivery, ack reception, and keepalive reception.
 
 Peer liveness is measured passively from relay traffic. The `PeerSession` object
 derives liveness indicators using a 5-second polling interval. These feed into
-the **tab-dot connectivity indicators** — colored dots to the left of each tab
-label showing connection health (green / yellow / red / gray). They are also
+the **tab pipe marks** — uncolored link / broken-chain emojis to the left of
+Wallet, Hub, and Game tab labels — and into the game dashboard **banner rail**
+(session mode: idle / playing / pings-bad / on-chain / ended). They are also
 passed to `GameSession` for in-game display. Separately, Shell has a cascade
 rule: if the peer is marked lost while the session is still off-chain, it calls
 `goOnChain()` on the WASM cradle.
@@ -931,12 +932,12 @@ Connected, keepalive timeout while WS is up → Inactive.
 
 **Peer indicator** (`PeerLiveness`) has four states:
 
-| State       | Meaning                                                                             | Dot color |
-| ----------- | ----------------------------------------------------------------------------------- | --------- |
-| `connected` | Peer traffic received within the last 30 seconds                                    | Green     |
-| `degraded`  | Delivery failure reported by hub, or no peer traffic for 30+ seconds                | Yellow    |
-| `dead`      | Local go-on-chain or session rejection (FOAD) — terminal for this peer relationship | Red       |
-| `null`      | No active peer session                                                              | Grey      |
+| State       | Meaning                                                                             | Tab mark |
+| ----------- | ----------------------------------------------------------------------------------- | -------- |
+| `connected` | Peer traffic received within the last 30 seconds                                    | Link     |
+| `degraded`  | Delivery failure reported by hub, or no peer traffic for 30+ seconds                | Link (banner rail yellow) |
+| `dead`      | Local go-on-chain or session rejection (FOAD) — terminal for this peer relationship | Broken chain |
+| `null`      | No keepalive yet, or no active peer session                                         | Link if a session is live (handshake); broken chain if none/resolved |
 
 `dead` is sticky: incoming messages from that peer are ignored. Only a new session start resets to `null`.
 

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -398,11 +398,11 @@ resumable-session marker, and tab/reset coordination keys, inside the same-origi
 trust model described above.
 
 The current and only legal envelope schema is `chia-gaming-session` version
-`12`. Because the project is
+`13`. Because the project is
 still alpha, every other version is deleted wholesale without decoding or
-migration. A decoded v12 record must also satisfy the complete phase-owned
+migration. A decoded v13 record must also satisfy the complete phase-owned
 envelope contract (keyed game membership, game-owned payload/type agreement,
-terminal data, and frozen terminal coin list); malformed v12 records are
+terminal data, and frozen terminal coin list); malformed v13 records are
 deleted rather than partially restored. The boot marker is retained after an
 incompatible or malformed resumable record is discarded so the failure remains
 visible at the Resume / Start Over boundary. The `version` field is kept as a
@@ -426,7 +426,7 @@ are grouped under those phase-owned payloads:
 
 | Field                           | Type                                                                                                       | Purpose                                                                                                                                                                                                                                                                                                         |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`                       | `bigint`                                                                                                   | Save schema version; currently `12`.                                                                                                                                                                                                                                                                            |
+| `version`                       | `bigint`                                                                                                   | Save schema version; currently `13`.                                                                                                                                                                                                                                                                            |
 | `playerId`                      | `string`                                                                                                   | Stable local hub/player identity for this browser state.                                                                                                                                                                                                                                                        |
 | `sessionId`                     | `string?`                                                                                                  | Stable token linking the hub iframe and game-channel WebSocket.                                                                                                                                                                                                                                                 |
 | `alias`                         | `string?`                                                                                                  | Local hub display alias preference.                                                                                                                                                                                                                                                                             |
@@ -550,7 +550,7 @@ independently, and the accepted entry is removed only after the hand is fully
 settled. Schema version 12 also makes
 `gameInstances` plus `lastDisplayedGameId` the only persisted game protocol
 presentation and stores the canonical `GameProtocolPresentation` discriminant.
-Under the alpha no-migration policy, version 11 and all other incompatible
+Under the alpha no-migration policy, version 12 and all other incompatible
 records are deleted rather than translated from aggregate current-game fields.
 
 #### Delivery-critical saves
@@ -1572,8 +1572,8 @@ not to limit concurrency.
 | `front-end/src/components/GameSession.tsx`       | Game session UI: header, coin status, game area, overlays                                                               |
 | `front-end/src/hooks/useGameSession.ts`          | Thin React boundary: controller/runtime setup, host subscription, typed dispatch, selector projection                  |
 | `front-end/src/lib/session/sessionMachine*.ts`   | Root dispatcher plus cohesive channel, between-hand, proposal, durable-game, notification, command, effect, runtime, and persistence modules |
-| `front-end/src/lib/session/persistence*.ts`      | Canonical strict-v12 phase decoder plus primitive, between-hand/proposal, and phase-payload codecs; accepted records always produce a normalized `SessionModel` |
-| `front-end/src/lib/session/sessionSnapshot.ts`   | Canonical `SessionModel` → v12 presentation snapshot encoder                                                            |
+| `front-end/src/lib/session/persistence*.ts`      | Canonical strict-v13 phase decoder plus primitive, between-hand/proposal, and phase-payload codecs; accepted records always produce a normalized `SessionModel` |
+| `front-end/src/lib/session/sessionSnapshot.ts`   | Canonical `SessionModel` → v13 presentation snapshot encoder                                                            |
 | `front-end/src/lib/gameRegistry.ts`              | Exhaustive pure feature registration and game-owned codec/terms/compose dispatch                                        |
 | `front-end/src/lib/gameMountRegistry.tsx`        | Exhaustive React live/frozen mount registration                                                                         |
 | `front-end/src/features/calPoker/useCalpokerHand.ts` | Calpoker hook: five-step protocol, card parsing, move submission                                                     |
@@ -1581,7 +1581,7 @@ not to limit concurrency.
 | `front-end/src/hooks/WasmStateInit.ts`           | WASM initialization: load binary, deposit .hex files, create cradle                                                     |
 | `front-end/src/hooks/blobSingleton.ts`           | Singleton management: `getOrCreateSessionController` / `destroySessionController`; restore path for session persistence |
 | `front-end/src/services/PeerSession.ts`          | Per-session peer state: session ID, peer ID, liveness, message buffering/routing, send methods                          |
-| `front-end/src/hooks/save.ts`                    | v12 cache/write and live/terminal lifecycle facade                                                                      |
+| `front-end/src/hooks/save.ts`                    | v13 cache/write and live/terminal lifecycle facade                                                                      |
 | `front-end/src/hooks/saveCoordination.ts`        | Resume markers, active-tab lease, and cross-tab persistence fencing                                                     |
 | `front-end/src/hooks/saveHardReset.ts`           | Hard-reset and WalletConnect browser-storage cleanup                                                                     |
 | `front-end/src/hooks/savePreferences.ts`         | Local preference encoding and decoding                                                                                    |

--- a/ON_CHAIN.md
+++ b/ON_CHAIN.md
@@ -64,10 +64,11 @@ unroll is extracted from the on-chain conditions.
 
 ### Step 2: Preempt or Wait
 
-The player compares the on-chain unroll state number against their own latest
-state to decide whether to preempt or wait for the timeout path (see
-[Preemption](#preemption)). Both outcomes produce the same result: the unroll
-coin is spent, creating game coins and reward coins.
+`channel_coin_spent` classifies the parsed channel-coin spend (see
+[Preemption](#preemption)). Timeout and preempt both spend the unroll coin,
+creating game coins and reward coins. A spend we never signed (unknown puzzle
+hash) or whose conditions do not match the signed historical record is an
+error at parse time — it is not turned into a timeout.
 
 When the unroll coin spend is detected, a `ChannelStatus` notification with
 state `ResolvedUnrolled` (or `ResolvedStale` if the unroll was stale) is
@@ -347,12 +348,12 @@ a player sees the channel coin being spent to an unroll coin, they compare the
 on-chain sequence number against their own latest state:
 
 
-| On-chain SN vs ours | Action                  | Explanation                                                                         |
-| ------------------- | ----------------------- | ----------------------------------------------------------------------------------- |
-| On-chain < ours, opposite parity | **Preempt** (immediate) | Spend the unroll coin immediately with our higher SN and more up-to-date conditions |
-| On-chain < ours, same parity | **Wait for timeout** | The parity rule forbids our latest state from preempting this coin; use its compact historical timeout record |
-| On-chain == ours    | **Wait for timeout**    | The unroll is at the state we expect; wait for it to resolve                        |
-| On-chain > ours     | **Error**               | We've been hacked or something went very wrong                                      |
+| On-chain SN vs ours | Action | Explanation |
+| ------------------- | ------ | ----------- |
+| On-chain < ours, opposite parity, signed preemption source | **Preempt** (immediate) | Spend the unroll coin immediately with our higher SN and more up-to-date conditions |
+| On-chain < ours, same parity (or no signed preemption source) | **Wait for timeout** | The parity rule forbids preemption; use the compact historical timeout record we signed |
+| On-chain == ours | **Wait for timeout** | The unroll is at the state we expect; wait for it to resolve |
+| Unknown puzzle hash or conditions-hash mismatch | **Error** | Never signed, or not the unroll we signed — classified when the channel coin spend is parsed |
 
 
 Preemption is **immediate** — no timelock. This is by design: the preempting

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -188,11 +188,15 @@ conditions. The map deliberately does not retain historical signatures or
 preemption conditions; preemption always uses a latest full record. When a
 channel coin spend is detected, the `CREATE_COIN` puzzle hashes in the
 on-chain conditions are matched against this map to identify which unroll
-landed. An old opposite-parity state is preempted, while an old same-parity
-state is resolved with its stored timeout conditions. Those old puzzle hashes
-cannot be discarded: the opponent may publish any previously signed unroll,
-so recognizing every historical hash is the minimum needed to choose the
-correct timeout record safely.
+landed. Classification happens then, in `channel_coin_spent`: an old
+opposite-parity state is preempted, an old same-parity state we signed is
+resolved with its stored timeout conditions, and a spend we never signed
+(unknown puzzle hash) or whose conditions do not match the signed record is
+an error. A state we have not reached cannot be in the map, so it fails the
+same never-signed check. Those old puzzle hashes cannot be
+discarded: the opponent may publish any previously signed unroll, so
+recognizing every historical hash is how we tell a signed timeout record
+from a spend we never signed.
 
 Browser session persistence stores the serialized game session as raw binary in
 IndexedDB. Compact historical unroll records are therefore part of the durable

--- a/UX_NOTIFICATIONS.md
+++ b/UX_NOTIFICATIONS.md
@@ -201,10 +201,11 @@ advisory, coin identity and amount, both balances, game allocation,
 `havePotato`, `zeroPayout`, and optional on-chain progress context. During an
 unroll, `unrollInitiator` identifies whether we or the opponent caused the
 observed channel spend when that attribution is definitive; a locally queued
-spend or cooperative-close setup alone leaves it unknown. `semanticPhase` refines the existing `GoingOnChain` /
-`Unrolling` state as submitting or resolving the channel spend, preempting,
-waiting for the relative timeout, submitting the timeout finish, or resolving
-the unroll spend. These are display facts, not new lifecycle states. Banner text, the potato indicator, dashboard
+spend or cooperative-close setup alone leaves it unknown. `semanticPhase` is
+the situation within `GoingOnChain` / `Unrolling`: submitting or resolving a
+channel spend, finding the landed unroll state, preempting, waiting for the
+relative timeout, or spending the timeout finish. Actor is not encoded in the
+phase. These are display facts, not new lifecycle states. Banner text, the potato indicator, dashboard
 actions, phase selection, persistence, and restore all project from that one
 snapshot instead of maintaining parallel channel-status shapes.
 During a cooperative terminal handoff, Rust sets
@@ -226,12 +227,13 @@ Monotonicity applies across all three lenses:
 When a watched timeout spend becomes mature, `TransactionManager` is the sole
 component that queues its submission. Before the host drains the submission
 buffer, it updates the session's canonical status snapshot to
-`submitting_timeout_finish`; the normal `ChannelStatus` notification then
-persists and restores that fact. The UI never infers timeout maturity, submits
+`finishing_spending` (with `unrollInitiator` naming who started the unroll);
+the normal `ChannelStatus` notification then persists and restores that fact. The UI never infers timeout maturity, submits
 the transaction, or mutates a durable channel snapshot from a transient event.
 If a reorg changes or clears the watched coin's birthday, the manager re-arms
-the relative timeout and restores the canonical phase to `waiting_timeout`
-until the claim becomes mature again.
+the relative timeout and restores the canonical waiting phase
+(`finishing_waiting_timeout`) until the claim becomes mature
+again.
 
 ---
 

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -434,13 +434,13 @@ function GameDashboard({
                   <span className="font-medium text-canvas-text-contrast">
                     {view.channelStatusLabel}
                   </span>
+                  {view.channelDetail && (
+                    <span className="text-canvas-text">{view.channelDetail}</span>
+                  )}
                   {view.havePotato && (
                     <span aria-label="You have the potato" title="You have the potato">
                       🥔
                     </span>
-                  )}
-                  {view.channelDetail && (
-                    <span className="text-canvas-text">{view.channelDetail}</span>
                   )}
                   {view.bannerTone === 'pings-bad' && (
                     <span className="text-warning-text">Peer pings look stuck</span>

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -111,18 +111,17 @@ import {
 import {
   ABANDON_WAITING_STATES,
   isChannelAbandonable,
-  isCleanShutdownInProgress,
   PRE_ACTIVE_CHANNEL_STATES,
   selectGameDashboardView,
-  selectGameTabDotColor,
+  selectGameTabConnected,
   selectStatusBarBalances,
   sessionAmountsFromSave,
   sessionModelFromSave,
   DEFAULT_CHANNEL_TIMEOUT_BLOCKS,
   DEFAULT_UNROLL_TIMEOUT_BLOCKS,
+  type BannerTone,
   type GameDashboardActionKind,
   type GameDashboardViewModel,
-  type GameTabDotColor,
   type SessionModel,
   type StatusBarBalanceSegment,
 } from '../lib/session/model';
@@ -291,6 +290,17 @@ const TAB_DEFS: { id: TabId; label: string }[] = [
   { id: 'log', label: 'Log' },
 ];
 
+const TAB_PIPE_CONNECTED = '\u{1F517}';
+const TAB_PIPE_DISCONNECTED = '\u{26D3}\u{FE0F}\u{200D}\u{1F4A5}';
+
+const BANNER_TONE_BAR: Record<BannerTone, string> = {
+  idle: 'var(--color-canvas-text-subtle)',
+  playing: 'var(--color-success-solid)',
+  'pings-bad': 'var(--color-warning-solid)',
+  'on-chain': 'var(--color-alert-solid)',
+  ended: 'var(--color-info-solid)',
+};
+
 const ABANDON_DELAY_MS = 120_000n;
 const GRACE_DELAY_MS = 10_000n;
 
@@ -394,112 +404,121 @@ function GameDashboard({
     if (expanded) refreshProtocolState();
   }, [expanded, refreshProtocolState]);
 
+  const barColor = BANNER_TONE_BAR[view.bannerTone];
   return (
-    <div className="flex-shrink-0 border-b border-canvas-border bg-canvas-bg-subtle px-4 py-2 text-canvas-text sm:px-6 md:px-8">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex min-w-0 items-center gap-2 text-sm">
-          <button
-            type="button"
-            onClick={() => setExpanded((prev) => !prev)}
-            aria-expanded={expanded}
-            aria-label={expanded ? 'Hide dashboard details' : 'Show dashboard details'}
-            className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-canvas-text transition-colors hover:bg-canvas-bg-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid"
-          >
-            <span
-              aria-hidden="true"
-              className={`text-sm leading-none transition-transform ${expanded ? 'rotate-90' : ''}`}
+    <div className="flex flex-shrink-0 border-b border-canvas-border bg-canvas-bg-subtle text-canvas-text">
+      <div aria-hidden="true" className="w-10 shrink-0" style={{ background: barColor }} />
+      <div className="min-w-0 flex-1 px-4 py-2 sm:px-6 md:px-8">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-2 text-sm">
+            <button
+              type="button"
+              onClick={() => setExpanded((prev) => !prev)}
+              aria-expanded={expanded}
+              aria-label={expanded ? 'Hide dashboard details' : 'Show dashboard details'}
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-canvas-text transition-colors hover:bg-canvas-bg-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid"
             >
-              ▶
-            </span>
-          </button>
-          <div className="flex min-w-0 flex-col gap-y-0.5">
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-0.5">
-              <span className="flex min-w-0 flex-wrap gap-x-1">
-                <span className="text-canvas-solid">Channel:</span>
-                <span className="font-medium text-canvas-text-contrast">
-                  {view.channelStatusLabel}
-                </span>
-                {view.havePotato && (
-                  <span aria-label="You have the potato" title="You have the potato">
-                    🥔
-                  </span>
-                )}
-                {view.channelDetail && (
-                  <span className="text-canvas-text">{view.channelDetail}</span>
-                )}
+              <span
+                aria-hidden="true"
+                className={`text-sm leading-none transition-transform ${expanded ? 'rotate-90' : ''}`}
+              >
+                ▶
               </span>
-              {view.lifecycleRows.length === 0 &&
-                view.handStatusLabel !== 'Active' &&
-                view.handStatusLabel !== 'No hand' && (
-                  <span className="flex min-w-0 flex-wrap gap-x-1">
-                    <span className="text-canvas-solid">Hand:</span>
-                    <span className="font-medium text-canvas-text-contrast">
-                      {view.handStatusLabel}
-                    </span>
-                    {view.handDetail && <span className="text-canvas-text">{view.handDetail}</span>}
-                  </span>
-                )}
-              {view.lifecycleRows.map((row) => (
-                <span key={row.id} className="flex min-w-0 flex-wrap gap-x-1">
-                  <span className="text-canvas-solid">{row.label}:</span>
-                  <span className="font-medium text-canvas-text-contrast">{row.statusLabel}</span>
-                  {row.detail && <span className="text-canvas-text">{row.detail}</span>}
-                </span>
-              ))}
-            </div>
-            {balances && (
+            </button>
+            <div className="flex min-w-0 flex-col gap-y-0.5">
               <div className="flex flex-wrap items-center gap-x-4 gap-y-0.5">
-                {balances.map((seg) => (
-                  <span key={seg.label} className="flex min-w-0 flex-wrap gap-x-1">
-                    <span className="text-canvas-solid">{seg.label}:</span>
-                    <span className="font-medium text-canvas-text-contrast">
-                      {formatBalanceValue(seg.value)}
-                      {seg.value2 !== undefined ? ` / ${formatBalanceValue(seg.value2)}` : ''}
+                <span className="flex min-w-0 flex-wrap gap-x-1">
+                  <span className="text-canvas-solid">Channel:</span>
+                  <span className="font-medium text-canvas-text-contrast">
+                    {view.channelStatusLabel}
+                  </span>
+                  {view.havePotato && (
+                    <span aria-label="You have the potato" title="You have the potato">
+                      🥔
+                    </span>
+                  )}
+                  {view.channelDetail && (
+                    <span className="text-canvas-text">{view.channelDetail}</span>
+                  )}
+                  {view.bannerTone === 'pings-bad' && (
+                    <span className="text-warning-text">Peer pings look stuck</span>
+                  )}
+                </span>
+                {view.lifecycleRows.length === 0 &&
+                  view.handStatusLabel !== 'Active' &&
+                  view.handStatusLabel !== 'No hand' && (
+                    <span className="flex min-w-0 flex-wrap gap-x-1">
+                      <span className="text-canvas-solid">Hand:</span>
+                      <span className="font-medium text-canvas-text-contrast">
+                        {view.handStatusLabel}
+                      </span>
+                      {view.handDetail && (
+                        <span className="text-canvas-text">{view.handDetail}</span>
+                      )}
+                    </span>
+                  )}
+                {view.lifecycleRows.map((row) => (
+                  <span key={row.id} className="flex min-w-0 flex-wrap gap-x-1">
+                    <span className="text-canvas-solid">{row.label}:</span>
+                    <span className="font-medium text-canvas-text-contrast">{row.statusLabel}</span>
+                    {row.detail && <span className="text-canvas-text">{row.detail}</span>}
+                  </span>
+                ))}
+              </div>
+              {balances && (
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-0.5">
+                  {balances.map((seg) => (
+                    <span key={seg.label} className="flex min-w-0 flex-wrap gap-x-1">
+                      <span className="text-canvas-solid">{seg.label}:</span>
+                      <span className="font-medium text-canvas-text-contrast">
+                        {formatBalanceValue(seg.value)}
+                        {seg.value2 !== undefined ? ` / ${formatBalanceValue(seg.value2)}` : ''}
+                      </span>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="solid"
+              color="primary"
+              size="sm"
+              className="min-w-40"
+              disabled={!view.actionEnabled}
+              onClick={() => onAction(view.actionKind)}
+            >
+              {view.actionLabel}
+            </Button>
+          </div>
+        </div>
+        {expanded && (
+          <div className="mt-2">
+            {coins.length > 0 && (
+              <div className="mb-2 flex flex-col gap-y-0.5 text-xs">
+                {coins.map((coin) => (
+                  <span key={`${coin.label}:${coin.id}`} className="flex min-w-0 flex-wrap gap-x-1">
+                    <span className="text-canvas-solid">{coin.label}:</span>
+                    <span className="break-all font-mono text-canvas-text-contrast select-text cursor-text">
+                      {coin.id}
                     </span>
                   </span>
                 ))}
               </div>
             )}
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            variant="solid"
-            color="primary"
-            size="sm"
-            className="min-w-40"
-            disabled={!view.actionEnabled}
-            onClick={() => onAction(view.actionKind)}
-          >
-            {view.actionLabel}
-          </Button>
-        </div>
-      </div>
-      {expanded && (
-        <div className="mt-2">
-          {coins.length > 0 && (
-            <div className="mb-2 flex flex-col gap-y-0.5 text-xs">
-              {coins.map((coin) => (
-                <span key={`${coin.label}:${coin.id}`} className="flex min-w-0 flex-wrap gap-x-1">
-                  <span className="text-canvas-solid">{coin.label}:</span>
-                  <span className="break-all font-mono text-canvas-text-contrast select-text cursor-text">
-                    {coin.id}
-                  </span>
-                </span>
-              ))}
+            <div className="mb-1 flex items-center justify-between">
+              <span className="text-xs text-canvas-solid">Protocol state</span>
+              <Button variant="ghost" color="neutral" size="sm" onClick={refreshProtocolState}>
+                Refresh
+              </Button>
             </div>
-          )}
-          <div className="mb-1 flex items-center justify-between">
-            <span className="text-xs text-canvas-solid">Protocol state</span>
-            <Button variant="ghost" color="neutral" size="sm" onClick={refreshProtocolState}>
-              Refresh
-            </Button>
+            <pre className="max-h-80 overflow-auto whitespace-pre rounded border border-canvas-line bg-canvas-bg p-2 text-[11px] font-mono text-canvas-text-contrast select-text cursor-text">
+              {protocolText ?? 'No active channel.'}
+            </pre>
           </div>
-          <pre className="max-h-80 overflow-auto whitespace-pre rounded border border-canvas-line bg-canvas-bg p-2 text-[11px] font-mono text-canvas-text-contrast select-text cursor-text">
-            {protocolText ?? 'No active channel.'}
-          </pre>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }
@@ -751,8 +770,6 @@ const Shell = () => {
   const setSessionError = useCallback((value: boolean) => {
     shellDispatchRef.current({ type: 'setSessionError', value });
   }, []);
-
-  const sessionError = shellState.sessionError;
 
   const setRestoreStatus = useCallback((value: RestoreStatus) => {
     shellDispatchRef.current({ type: 'setRestoreStatus', value });
@@ -3418,6 +3435,7 @@ const Shell = () => {
     setupPending: shouldSynthesizeSetupPending(sessionPaneTransition, hasLiveSessionModel),
     cleanShutdownGraceActive,
     abandonEnabled,
+    peerLiveness,
   });
   const statusBarBalances = selectStatusBarBalances(dashboardSessionModel);
   const sessionConsentOverlay = pendingAdvisory ? (
@@ -3520,46 +3538,29 @@ const Shell = () => {
                 (tab.id === 'wallet' && walletAlert) ||
                 (tab.id === 'hub' && hubAlert));
 
-            let dotColor: string | null = null;
+            let pipeConnected: boolean | null = null;
             switch (tab.id) {
               case 'wallet':
-                dotColor = walletConnected
-                  ? 'var(--color-success-solid)'
-                  : 'var(--color-alert-solid)';
+                pipeConnected = walletConnected;
                 break;
               case 'hub':
-                if (hubLiveness === 'connected') {
-                  dotColor = 'var(--color-success-solid)';
-                } else if (hubLiveness === 'reconnecting') {
-                  dotColor = 'var(--color-warning-solid)';
-                } else if (hubLiveness === 'inactive') {
-                  dotColor = 'var(--color-alert-solid)';
-                } else {
-                  dotColor = 'var(--color-canvas-text-subtle)';
-                }
+                pipeConnected = hubLiveness === 'connected';
                 break;
-              case 'game': {
-                const gameDot: GameTabDotColor = selectGameTabDotColor({
-                  sessionPhase,
-                  sessionError,
-                  peerLiveness,
-                  cleanShutdownInProgress: isCleanShutdownInProgress(dashboardSessionModel),
-                });
-                const gameDotCss: Record<GameTabDotColor, string> = {
-                  green: 'var(--color-success-solid)',
-                  yellow: 'var(--color-warning-solid)',
-                  red: 'var(--color-alert-solid)',
-                  gray: 'var(--color-canvas-text-subtle)',
-                };
-                dotColor = gameDotCss[gameDot];
+              case 'game':
+                pipeConnected = selectGameTabConnected({ sessionPhase, peerLiveness });
                 break;
-              }
             }
+            const walletDisconnected = tab.id === 'wallet' && !walletConnected;
+            const pipeLabel =
+              pipeConnected === null
+                ? tab.label
+                : `${tab.label}, ${pipeConnected ? 'connected' : 'disconnected'}`;
 
             return (
               <button
                 key={tab.id}
                 onClick={() => handleTabChange(tab.id)}
+                aria-label={pipeLabel}
                 style={
                   active
                     ? {
@@ -3577,18 +3578,14 @@ const Shell = () => {
                     : 'text-canvas-text hover:text-canvas-text-contrast hover:bg-canvas-bg-hover')
                 }
               >
-                {dotColor && (
-                  <span
-                    style={{
-                      width: 8,
-                      height: 8,
-                      borderRadius: '50%',
-                      background: dotColor,
-                      flexShrink: 0,
-                    }}
-                  />
+                {pipeConnected !== null && (
+                  <span aria-hidden="true" className="text-base leading-none">
+                    {pipeConnected ? TAB_PIPE_CONNECTED : TAB_PIPE_DISCONNECTED}
+                  </span>
                 )}
-                {tab.label}
+                <span className={walletDisconnected ? 'text-alert-text' : undefined}>
+                  {tab.label}
+                </span>
                 {showDot && (
                   <span className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-alert-text" />
                 )}

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -77,6 +77,7 @@ import {
   onFenced,
   offFenced,
   peekAlias,
+  releaseLeaseIfOwner,
   setAlias,
 } from '../hooks/save';
 import {
@@ -106,6 +107,7 @@ import {
   shouldReportHubBusyPresence,
   shouldSuppressPhaseReporting,
   shouldSwitchToHubOnResolved,
+  shouldWarnOnSessionUnload,
   transitionToFreshSession,
 } from '../lib/restoreLifecycle';
 import {
@@ -941,10 +943,18 @@ const Shell = () => {
     };
   }, []);
 
-  // Close WebSocket connections on page unload/reload so the browser doesn't
-  // leave stale TCP sockets that block new connections in the reloaded page.
+  // Warn before closing a tab with a live session. Disconnect sockets only on
+  // actual leave (`pagehide`): `beforeunload` also runs if the user stays, and
+  // dropping the hub there would strand a session they chose to keep.
   useEffect(() => {
-    const cleanup = () => {
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!shouldWarnOnSessionUnload(sessionPhaseRef.current)) return;
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    const cleanup = (event: PageTransitionEvent) => {
+      if (event.persisted) return;
+      releaseLeaseIfOwner();
       hubConnRef.current?.disconnect();
       // WalletConnect sessions are intentionally durable across reloads.
       // Calling disconnect() here sends a protocol-level session_delete.
@@ -952,9 +962,11 @@ const Shell = () => {
         activeBlockchainRef.current?.disconnect().catch(() => {});
       }
     };
-    window.addEventListener('beforeunload', cleanup);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    window.addEventListener('pagehide', cleanup);
     return () => {
-      window.removeEventListener('beforeunload', cleanup);
+      window.removeEventListener('beforeunload', onBeforeUnload);
+      window.removeEventListener('pagehide', cleanup);
     };
   }, []);
 

--- a/front-end/src/hooks/SessionController.ts
+++ b/front-end/src/hooks/SessionController.ts
@@ -17,7 +17,7 @@ import {
 import { BlockchainPoller, PollingGameSession } from './BlockchainPoller';
 import { spend_bundle_to_clvm, coerceToBytes } from '../util';
 import { log, diagStack } from '../services/log';
-import { jsonStringify } from '../util/jsonSafe';
+import { integersToBigInt, jsonStringify } from '../util/jsonSafe';
 import { flushSessionSave } from './save';
 import type { PersistedGameState } from './save';
 import type { RegisteredGameType } from '../lib/session/types';
@@ -733,6 +733,7 @@ export class SessionController implements PollingGameSession {
     if (this.protocolStopped) {
       return;
     }
+    result = integersToBigInt(result);
 
     const disposition = result.disposition ?? { kind: 'active' as const };
     const terminal = disposition.kind === 'terminal';

--- a/front-end/src/hooks/WalletConnectRpc.ts
+++ b/front-end/src/hooks/WalletConnectRpc.ts
@@ -25,7 +25,7 @@ import {
 import { PushTransactionsRequest, PushTransactionsResponse } from '../types/rpc/PushTransactions';
 import { SelectCoinsRequest, SelectCoinsResponse } from '../types/rpc/SelectCoins';
 import { log } from '../services/log';
-import { jsonStringify } from '../util/jsonSafe';
+import { integersToBigInt, jsonStringify } from '../util/jsonSafe';
 
 import { walletConnectState } from './useWalletConnect';
 
@@ -90,19 +90,6 @@ function shouldLogRpcTraffic(method: ChiaMethod): boolean {
 function summarizeRpcValue(value: unknown, maxLen = 400): string {
   const text = toDebugJson(value);
   return text.length > maxLen ? `${text.slice(0, maxLen)}…` : text;
-}
-
-function deepNumbersToBigInt(value: unknown): unknown {
-  if (typeof value === 'number' && Number.isInteger(value)) return BigInt(value);
-  if (Array.isArray(value)) return value.map(deepNumbersToBigInt);
-  if (value !== null && typeof value === 'object') {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) {
-      out[k] = deepNumbersToBigInt(v);
-    }
-    return out;
-  }
-  return value;
 }
 
 /** WC wire hack: negative BigInt → decimal string (avoids WC "-100n" leftover). Positives stay bigint. */
@@ -235,7 +222,7 @@ class WalletConnectRpcClient {
   }
 
   private normalizeResult<T>(prepared: PreparedRpc, raw: unknown): T {
-    const result = deepNumbersToBigInt(raw) as Record<string, unknown> | undefined;
+    const result = integersToBigInt(raw) as Record<string, unknown> | undefined;
     if (result?.error) {
       const errorText = toDebugJson(result.error);
       const trace = new Error().stack?.split('\n').slice(1, 6).join('\n') ?? '';

--- a/front-end/src/hooks/save.ts
+++ b/front-end/src/hooks/save.ts
@@ -50,6 +50,7 @@ import {
   peekAutoResumeOnce,
   randomHex,
   reclaimLease,
+  releaseLeaseIfOwner,
   resetStorageCoordinationForTests,
 } from './saveCoordination';
 
@@ -68,6 +69,7 @@ export {
   onFenced,
   peekAutoResumeOnce,
   reclaimLease,
+  releaseLeaseIfOwner,
 };
 
 export type { PersistedGameState } from '../lib/session/gameStateCodec';

--- a/front-end/src/hooks/saveCoordination.ts
+++ b/front-end/src/hooks/saveCoordination.ts
@@ -88,6 +88,17 @@ export function clearLease(): void {
   }
 }
 
+/** Drop the lease only if this tab still holds it, so a closed owner does not look like a live conflict. */
+export function releaseLeaseIfOwner(): void {
+  try {
+    if (localStorage.getItem(LEASE_KEY) === tabId) {
+      localStorage.removeItem(LEASE_KEY);
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
 export function isFenced(): boolean {
   return fenced;
 }

--- a/front-end/src/lib/restoreLifecycle.ts
+++ b/front-end/src/lib/restoreLifecycle.ts
@@ -72,6 +72,11 @@ export function shouldReportHubBusy(sessionPhase: SessionPhase, walletConnected 
   return sessionPhase !== 'none' && sessionPhase !== 'resolved';
 }
 
+/** Native leave-page warning: an off-chain or on-chain session is still live. */
+export function shouldWarnOnSessionUnload(sessionPhase: SessionPhase): boolean {
+  return sessionPhase === 'off-chain' || sessionPhase === 'on-chain';
+}
+
 /**
  * Full hub presence busy signal (matches Shell getPresence).
  *

--- a/front-end/src/lib/session/normalization.ts
+++ b/front-end/src/lib/session/normalization.ts
@@ -25,6 +25,9 @@ export const INITIAL_CHANNEL_STATUS_MODEL: ChannelStatusModel = {
   zeroPayout: null,
   unrollInitiator: null,
   semanticPhase: null,
+  stateNumber: null,
+  unrollingStateNumber: null,
+  preemptingStateNumber: null,
 };
 export const DEFAULT_GAME_TIMEOUT_BLOCKS = 15n;
 export const DEFAULT_CHANNEL_TIMEOUT_BLOCKS = 15n;
@@ -66,6 +69,9 @@ export function channelStatusModelFromPayload(status: ChannelStatusPayload): Cha
     zeroPayout: status.zero_payout ?? null,
     unrollInitiator: status.unroll_initiator ?? null,
     semanticPhase: status.semantic_phase ?? null,
+    stateNumber: status.state_number ?? null,
+    unrollingStateNumber: status.unrolling_state_number ?? null,
+    preemptingStateNumber: status.preempting_state_number ?? null,
   };
 }
 export function channelStatusPayloadFromModel(status: ChannelStatusModel): ChannelStatusPayload {
@@ -81,6 +87,9 @@ export function channelStatusPayloadFromModel(status: ChannelStatusModel): Chann
     zero_payout: status.zeroPayout,
     unroll_initiator: status.unrollInitiator,
     semantic_phase: status.semanticPhase,
+    state_number: status.stateNumber,
+    unrolling_state_number: status.unrollingStateNumber,
+    preempting_state_number: status.preemptingStateNumber,
   };
 }
 

--- a/front-end/src/lib/session/persistence.ts
+++ b/front-end/src/lib/session/persistence.ts
@@ -1,4 +1,5 @@
 import type { ChannelStatus, ChannelStatusPayload } from '../../types/ChiaGaming';
+import { CHANNEL_SEMANTIC_PHASES } from '../../types/ChiaGaming';
 import type {
   LiveSessionSave,
   PreHandshakeSessionSave,
@@ -56,6 +57,7 @@ import {
   parseDiscriminant,
   requireBigintString,
   requireBigint,
+  requireOptionalBigint,
   requireBoolean,
   requireNullableString,
   requireRecord,
@@ -243,16 +245,12 @@ export function decodeChannelStatusPayload(value: unknown): ChannelStatusPayload
       ? fields.semantic_phase
       : parseDiscriminant<NonNullable<ChannelStatusPayload['semantic_phase']>>(
           fields.semantic_phase,
-          new Set([
-            'submitting_channel_spend',
-            'resolving_opponent_channel_spend',
-            'preempting',
-            'waiting_timeout',
-            'submitting_timeout_finish',
-            'resolving',
-          ]),
+          new Set<string>(CHANNEL_SEMANTIC_PHASES),
           'channelStatus.semantic_phase',
         );
+  const optionalStateNumber = (
+    field: 'state_number' | 'unrolling_state_number' | 'preempting_state_number',
+  ) => requireOptionalBigint(fields[field], `channelStatus.${field}`);
   return {
     state: parseDiscriminant<ChannelStatus>(fields.state, CHANNEL_STATUSES, 'channelStatus.state'),
     session_disposition: sessionDisposition,
@@ -265,6 +263,9 @@ export function decodeChannelStatusPayload(value: unknown): ChannelStatusPayload
     zero_payout: zeroPayout,
     unroll_initiator: unrollInitiator,
     semantic_phase: semanticPhase,
+    state_number: optionalStateNumber('state_number'),
+    unrolling_state_number: optionalStateNumber('unrolling_state_number'),
+    preempting_state_number: optionalStateNumber('preempting_state_number'),
   };
 }
 

--- a/front-end/src/lib/session/persistencePayloads.ts
+++ b/front-end/src/lib/session/persistencePayloads.ts
@@ -82,6 +82,8 @@ const SAVED_GAME_PRESENTATIONS: ReadonlySet<string> = new Set<GameProtocolPresen
   'illegal-move',
   'submitting-timeout',
   'finishing',
+  'finishing-waiting-timeout',
+  'finishing-spending',
   'ended',
 ]);
 

--- a/front-end/src/lib/session/persistencePayloads.ts
+++ b/front-end/src/lib/session/persistencePayloads.ts
@@ -1,4 +1,5 @@
 import type { ChannelStatus } from '../../types/ChiaGaming';
+import { CHANNEL_SEMANTIC_PHASES } from '../../types/ChiaGaming';
 import { isSettlementOutcome, type SettlementOutcome } from '../settlement';
 import type {
   LiveSessionSave,
@@ -62,14 +63,7 @@ const NOTIFICATION_KINDS = new Set([
   'insufficient-bal',
 ]);
 const SESSION_DISPOSITIONS = new Set(['AwaitOutboundTerminal', 'Abandoned']);
-const CHANNEL_SEMANTIC_PHASES = new Set([
-  'submitting_channel_spend',
-  'resolving_opponent_channel_spend',
-  'preempting',
-  'waiting_timeout',
-  'submitting_timeout_finish',
-  'resolving',
-]);
+const CHANNEL_SEMANTIC_PHASE_SET = new Set<string>(CHANNEL_SEMANTIC_PHASES);
 const OUTCOME_FLAGS = new Set(['win', 'lose', 'tie']);
 const GAME_TERMINAL_TYPES: ReadonlySet<string> = new Set<GameTerminalType>([
   'none',
@@ -377,9 +371,24 @@ export function validateChannelStatus(value: unknown): void {
     status.semantic_phase !== undefined &&
     status.semantic_phase !== null &&
     (typeof status.semantic_phase !== 'string' ||
-      !CHANNEL_SEMANTIC_PHASES.has(status.semantic_phase))
+      !CHANNEL_SEMANTIC_PHASE_SET.has(status.semantic_phase))
   ) {
     throw new Error('Garbled save: invalid channelStatus.semantic_phase');
+  }
+  for (const field of [
+    'state_number',
+    'unrolling_state_number',
+    'preempting_state_number',
+  ] as const) {
+    const value = status[field];
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'bigint') {
+      if (value < 0n) throw new Error(`Garbled save: invalid channelStatus.${field}`);
+      continue;
+    }
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+      throw new Error(`Garbled save: invalid channelStatus.${field}`);
+    }
   }
 }
 

--- a/front-end/src/lib/session/persistencePrimitives.ts
+++ b/front-end/src/lib/session/persistencePrimitives.ts
@@ -51,6 +51,25 @@ export function requireBigint(value: unknown, label: string, minimum = 0n): bigi
   return value;
 }
 
+/** Inbound integer (`bigint` or JS `number`) → `bigint`. */
+export function requireOptionalBigint(
+  value: unknown,
+  label: string,
+  minimum = 0n,
+): bigint | null | undefined {
+  if (value === undefined || value === null) return value;
+  if (typeof value === 'bigint') {
+    if (value < minimum) throw new Error(`Garbled save: invalid ${label}`);
+    return value;
+  }
+  if (typeof value === 'number' && Number.isInteger(value)) {
+    const parsed = BigInt(value);
+    if (parsed < minimum) throw new Error(`Garbled save: invalid ${label}`);
+    return parsed;
+  }
+  throw new Error(`Garbled save: invalid ${label}`);
+}
+
 export function parseDecimalString(value: unknown, label: string, minimum?: bigint): bigint {
   if (typeof value !== 'string' || !/^-?\d+$/.test(value)) {
     throw new Error(`Garbled save: invalid ${label}: ${String(value)}`);

--- a/front-end/src/lib/session/presentation.ts
+++ b/front-end/src/lib/session/presentation.ts
@@ -291,14 +291,16 @@ type UnrollCopyChannel = Pick<
   'semanticPhase' | 'unrollInitiator' | 'unrollingStateNumber' | 'preemptingStateNumber'
 >;
 
+const finishingUnrollLabel = (opponent: boolean) =>
+  opponent ? 'Finishing opponent unroll' : 'Finishing unroll';
+
 const UNROLL_PHASE_LABEL: Record<ChannelSemanticPhase, (opponent: boolean) => string | null> = {
   submitting_channel_spend: () => null,
   unrolling: () => 'Unrolling',
   finding_state: (opponent) => (opponent ? 'Opponent unrolled' : 'Unrolled'),
   preempting: () => 'Preempting',
-  finishing_waiting_timeout: (opponent) =>
-    opponent ? 'Finishing opponent unroll' : 'Finishing unroll',
-  finishing_spending: (opponent) => (opponent ? 'Finishing opponent unroll' : 'Finishing unroll'),
+  finishing_waiting_timeout: finishingUnrollLabel,
+  finishing_spending: finishingUnrollLabel,
   resolving: () => null,
 };
 

--- a/front-end/src/lib/session/presentation.ts
+++ b/front-end/src/lib/session/presentation.ts
@@ -72,6 +72,8 @@ export function gameCoinIdentityForGameStatus(
     'replaying',
     'playing-move',
     'illegal-move-detected',
+    'finishing-waiting-timeout',
+    'finishing-spending',
   ].includes(status);
   return {
     coinHex: hasNewCoinIdentity ? null : previous.coinHex,
@@ -104,6 +106,18 @@ export function projectGameStatus({
     (status === 'on-chain-my-turn' && isActivelyPlayingOnChain(previous.coin.turnState))
   ) {
     return { coin: { ...previous.coin, ...identity }, handStatus: previous.handStatus };
+  }
+  if (status === 'finishing-waiting-timeout') {
+    return {
+      coin: { ...identity, turnState: 'finishing-waiting-timeout', onChain: true },
+      handStatus: 'finishing-waiting-timeout',
+    };
+  }
+  if (status === 'finishing-spending') {
+    return {
+      coin: { ...identity, turnState: 'finishing-spending', onChain: true },
+      handStatus: 'finishing-spending',
+    };
   }
   if (status === 'my-turn' || status === 'on-chain-my-turn') {
     return {
@@ -185,6 +199,10 @@ export function presentationFromView(instance: GameInstanceViewModel): GameProto
       return 'submitting-timeout';
     case 'finishing':
       return 'finishing';
+    case 'finishing-waiting-timeout':
+      return 'finishing-waiting-timeout';
+    case 'finishing-spending':
+      return 'finishing-spending';
     case 'ended':
       return 'ended';
   }
@@ -241,6 +259,18 @@ export function gameInstanceView(instance: GameInstanceModel): GameInstanceViewM
     finishing: {
       coin: { coinHex: instance.coinHex, turnState: 'finishing' },
       handStatus: 'finishing',
+    },
+    'finishing-waiting-timeout': {
+      coin: {
+        coinHex: instance.coinHex,
+        turnState: 'finishing-waiting-timeout',
+        onChain: true,
+      },
+      handStatus: 'finishing-waiting-timeout',
+    },
+    'finishing-spending': {
+      coin: { coinHex: instance.coinHex, turnState: 'finishing-spending', onChain: true },
+      handStatus: 'finishing-spending',
     },
     ended: { coin: { coinHex: instance.coinHex, turnState: 'ended' }, handStatus: 'ended' },
   };

--- a/front-end/src/lib/session/presentation.ts
+++ b/front-end/src/lib/session/presentation.ts
@@ -1,5 +1,11 @@
-import type { ChannelStatus, GameStatusPayload, GameStatusState } from '../../types/ChiaGaming';
 import type {
+  ChannelSemanticPhase,
+  ChannelStatus,
+  GameStatusPayload,
+  GameStatusState,
+} from '../../types/ChiaGaming';
+import type {
+  ChannelStatusModel,
   GameCoinModel,
   GameInstanceModel,
   GameInstanceViewModel,
@@ -248,4 +254,54 @@ export function nextGameInstanceAfterLocalTurn(
 ): GameInstanceViewModel {
   const next = nextGamePresentationAfterLocalTurn(instance, isMyTurn, channelState);
   return next === instance ? instance : { ...instance, ...next };
+}
+
+type UnrollCopyChannel = Pick<
+  ChannelStatusModel,
+  'semanticPhase' | 'unrollInitiator' | 'unrollingStateNumber' | 'preemptingStateNumber'
+>;
+
+const UNROLL_PHASE_LABEL: Record<ChannelSemanticPhase, (opponent: boolean) => string | null> = {
+  submitting_channel_spend: () => null,
+  unrolling: () => 'Unrolling',
+  finding_state: (opponent) => (opponent ? 'Opponent unrolled' : 'Unrolled'),
+  preempting: () => 'Preempting',
+  finishing_waiting_timeout: (opponent) =>
+    opponent ? 'Finishing opponent unroll' : 'Finishing unroll',
+  finishing_spending: (opponent) => (opponent ? 'Finishing opponent unroll' : 'Finishing unroll'),
+  resolving: () => null,
+};
+
+const UNROLL_PHASE_DETAIL: Record<
+  ChannelSemanticPhase,
+  (channel: UnrollCopyChannel) => string | null
+> = {
+  submitting_channel_spend: () => 'Submitting channel spend',
+  unrolling: (channel) =>
+    channel.unrollingStateNumber != null ? `to state ${channel.unrollingStateNumber}` : null,
+  finding_state: () => 'finding state',
+  preempting: (channel) => {
+    const landed = channel.unrollingStateNumber;
+    const preempting = channel.preemptingStateNumber;
+    if (landed != null && preempting != null) return `from ${landed} to ${preempting}`;
+    if (landed != null) return `from ${landed}`;
+    return null;
+  },
+  finishing_waiting_timeout: (channel) =>
+    channel.unrollingStateNumber != null
+      ? `waiting for timeout state ${channel.unrollingStateNumber}`
+      : 'waiting for timeout',
+  finishing_spending: (channel) =>
+    channel.unrollingStateNumber != null ? `spending state ${channel.unrollingStateNumber}` : null,
+  resolving: () => 'Resolving',
+};
+
+export function unrollActionLabel(channel: UnrollCopyChannel): string | null {
+  return channel.semanticPhase
+    ? UNROLL_PHASE_LABEL[channel.semanticPhase](channel.unrollInitiator === 'opponent')
+    : null;
+}
+
+export function unrollActionDetail(channel: UnrollCopyChannel): string | null {
+  return channel.semanticPhase ? UNROLL_PHASE_DETAIL[channel.semanticPhase](channel) : null;
 }

--- a/front-end/src/lib/session/saveEnvelope.ts
+++ b/front-end/src/lib/session/saveEnvelope.ts
@@ -10,7 +10,7 @@ import type {
 } from './types';
 
 export const SESSION_SAVE_SCHEMA = 'chia-gaming-session' as const;
-export const SESSION_SAVE_VERSION = 12n;
+export const SESSION_SAVE_VERSION = 13n;
 
 export type BlockchainType = 'simulator' | 'walletconnect';
 

--- a/front-end/src/lib/session/selectors.ts
+++ b/front-end/src/lib/session/selectors.ts
@@ -10,6 +10,8 @@ import {
   INITIAL_GAME_TERMINAL_MODEL,
   ON_CHAIN_CHANNEL_STATES,
   gameInstanceView,
+  unrollActionDetail,
+  unrollActionLabel,
 } from './presentation';
 import { RESOLVED_CHANNEL_STATES, WINDING_DOWN_CHANNEL_STATES } from './normalization';
 import type {
@@ -298,26 +300,27 @@ function channelStatusDetail(model: SessionModel): string | null {
   if (channel.sessionDisposition === 'AwaitOutboundTerminal') {
     return channel.advisory ?? 'Waiting for peer to acknowledge close';
   }
-  const phaseLabels: Record<NonNullable<ChannelStatusModel['semanticPhase']>, string> = {
-    submitting_channel_spend: 'Submitting channel spend',
-    resolving_opponent_channel_spend: 'Resolving opponent channel spend',
-    preempting: 'Preempting unroll',
-    waiting_timeout: 'Waiting for timeout',
-    submitting_timeout_finish: 'Submitting timeout finish',
-    resolving: 'Resolving',
-  };
+  const unrollLabel = unrollActionLabel(channel);
+  if (unrollLabel) {
+    const unrollDetail = unrollActionDetail(channel);
+    if (unrollDetail) {
+      return channel.advisory ? `${unrollDetail}: ${channel.advisory}` : unrollDetail;
+    }
+    return channel.advisory;
+  }
   if (channel.semanticPhase) {
-    const phase = phaseLabels[channel.semanticPhase];
-    const initiator =
-      channel.unrollInitiator === 'us'
-        ? ' (initiated by you)'
-        : channel.unrollInitiator === 'opponent'
-          ? ' (initiated by opponent)'
-          : '';
-    const detail = `${phase}${initiator}`;
-    return channel.advisory ? `${detail}: ${channel.advisory}` : detail;
+    const detail = unrollActionDetail(channel);
+    if (detail) {
+      return channel.advisory ? `${detail}: ${channel.advisory}` : detail;
+    }
   }
   switch (channel.state) {
+    case 'Active':
+      if (channel.stateNumber != null) {
+        const stateDetail = `state ${channel.stateNumber}`;
+        return channel.advisory ? `${stateDetail}: ${channel.advisory}` : stateDetail;
+      }
+      return channel.advisory;
     case 'Failed':
       return channel.advisory ?? model.restore.error ?? 'Channel failed';
     default:
@@ -535,7 +538,7 @@ export function selectGameDashboardView(
         ? 'Abandoned'
         : channel.sessionDisposition === 'AwaitOutboundTerminal'
           ? 'Waiting for Peer'
-          : CHANNEL_STATUS_LABELS[channel.state],
+          : (unrollActionLabel(channel) ?? CHANNEL_STATUS_LABELS[channel.state]),
     channelDetail: channelStatusDetail(model),
     havePotato: channel.havePotato === true,
     handStatusLabel: collapsedHandStatusLabel(model),

--- a/front-end/src/lib/session/selectors.ts
+++ b/front-end/src/lib/session/selectors.ts
@@ -313,19 +313,9 @@ function channelStatusDetail(model: SessionModel): string | null {
   if (channel.sessionDisposition === 'AwaitOutboundTerminal') {
     return channel.advisory ?? 'Waiting for peer to acknowledge close';
   }
-  const unrollLabel = unrollActionLabel(channel);
-  if (unrollLabel) {
-    const unrollDetail = unrollActionDetail(channel);
-    if (unrollDetail) {
-      return channel.advisory ? `${unrollDetail}: ${channel.advisory}` : unrollDetail;
-    }
-    return channel.advisory;
-  }
-  if (channel.semanticPhase) {
-    const detail = unrollActionDetail(channel);
-    if (detail) {
-      return channel.advisory ? `${detail}: ${channel.advisory}` : detail;
-    }
+  const unrollDetail = unrollActionDetail(channel);
+  if (unrollDetail) {
+    return channel.advisory ? `${unrollDetail}: ${channel.advisory}` : unrollDetail;
   }
   switch (channel.state) {
     case 'Active':

--- a/front-end/src/lib/session/selectors.ts
+++ b/front-end/src/lib/session/selectors.ts
@@ -155,6 +155,8 @@ const HAND_STATUS_LABELS: Record<HandStatus, string> = {
   slashing: 'Slashing cheater',
   'submitting-timeout': 'Submitting timeout claim',
   finishing: 'Finishing',
+  'finishing-waiting-timeout': 'Finalizing waiting for timeout',
+  'finishing-spending': 'Finalizing spending',
   ended: 'Ended',
 };
 
@@ -362,6 +364,10 @@ function selectHandStatus(model: SessionModel): HandStatus {
         return 'replaying-move';
       case 'finishing':
         return 'finishing';
+      case 'finishing-waiting-timeout':
+        return 'finishing-waiting-timeout';
+      case 'finishing-spending':
+        return 'finishing-spending';
     }
   }
   return 'active';

--- a/front-end/src/lib/session/selectors.ts
+++ b/front-end/src/lib/session/selectors.ts
@@ -15,6 +15,7 @@ import {
 } from './presentation';
 import { RESOLVED_CHANNEL_STATES, WINDING_DOWN_CHANNEL_STATES } from './normalization';
 import type {
+  BannerTone,
   BetweenHandModeModel,
   ChannelStatusModel,
   GameCoinModel,
@@ -34,7 +35,7 @@ import type {
 /** Shared empty dashboard fields; setupPending / no-session override labels + action. */
 export const EMPTY_DASHBOARD_VIEW_BASE: Omit<
   GameDashboardViewModel,
-  'channelStatusLabel' | 'actionLabel' | 'actionEnabled' | 'actionKind'
+  'bannerTone' | 'channelStatusLabel' | 'actionLabel' | 'actionEnabled' | 'actionKind'
 > = {
   channelDetail: null,
   havePotato: false,
@@ -248,8 +249,6 @@ export function selectShellView(model: SessionModel, phase: SessionPhase): Shell
   };
 }
 
-export type GameTabDotColor = 'green' | 'yellow' | 'red' | 'gray';
-
 /** True while a cooperative close is in flight (not yet terminal). */
 export function isCleanShutdownInProgress(model: SessionModel | null): boolean {
   if (!model) return false;
@@ -262,29 +261,18 @@ export function isCleanShutdownInProgress(model: SessionModel | null): boolean {
 }
 
 /**
- * Game-tab connectivity dot. Clean shutdown keeps the peer live (keepalives
- * continue); yellow only if the peer becomes unreachable. Red is for genuine
- * errors / FOAD-style peer death outside cooperative close.
+ * Game-tab pipe mark. A live session counts as connected, including handshake
+ * before the first keepalive (`peerLiveness === null`). Degraded pings stay
+ * connected; `dead` or no/resolved session is disconnected.
  */
-export function selectGameTabDotColor(args: {
+export function selectGameTabConnected(args: {
   sessionPhase: SessionPhase;
-  sessionError: boolean;
   peerLiveness: PeerLiveness;
-  cleanShutdownInProgress: boolean;
-}): GameTabDotColor {
-  const { sessionPhase, sessionError, peerLiveness, cleanShutdownInProgress } = args;
-  if (sessionPhase === 'none' || sessionPhase === 'resolved') return 'gray';
-  if (sessionError) return 'red';
-  if (cleanShutdownInProgress) {
-    // Peer should not be marked dead during cooperative close; if liveness
-    // still reports dead/degraded, treat it as unreachable rather than error.
-    if (peerLiveness === 'dead' || peerLiveness === 'degraded') return 'yellow';
-    return 'green';
-  }
-  if (peerLiveness === 'dead') return 'red';
-  if (sessionPhase === 'on-chain' || peerLiveness === 'degraded') return 'yellow';
-  if (peerLiveness === 'connected') return 'green';
-  return 'gray';
+}): boolean {
+  const { sessionPhase, peerLiveness } = args;
+  if (sessionPhase === 'none' || sessionPhase === 'resolved') return false;
+  if (peerLiveness === 'dead') return false;
+  return true;
 }
 
 export interface GameDashboardSelectorOptions {
@@ -292,6 +280,29 @@ export interface GameDashboardSelectorOptions {
   setupPending?: boolean;
   cleanShutdownGraceActive?: boolean;
   abandonEnabled?: boolean;
+  peerLiveness?: PeerLiveness;
+}
+
+function isOnChainBanner(model: SessionModel): boolean {
+  const state = model.channel.status.state;
+  if (state === 'GoingOnChain' || state === 'Unrolling') return true;
+  return (
+    (state === 'ResolvedUnrolled' || state === 'ResolvedStale') && model.game.activeIds.length > 0
+  );
+}
+
+function selectBannerTone(
+  model: SessionModel | null,
+  options: GameDashboardSelectorOptions,
+): BannerTone {
+  if (options.setupPending) {
+    return options.peerLiveness === 'degraded' ? 'pings-bad' : 'playing';
+  }
+  if (!model || options.hasSession === false) return 'idle';
+  if (isOnChainBanner(model)) return 'on-chain';
+  if (isTerminalChannelSnapshot(model.channel.status)) return 'ended';
+  if (options.peerLiveness === 'degraded') return 'pings-bad';
+  return 'playing';
 }
 
 function channelStatusDetail(model: SessionModel): string | null {
@@ -512,9 +523,11 @@ export function selectGameDashboardView(
   // Accepting a new session after a terminal display leaves that model in place
   // until retireTerminalDisplay runs after async replaceSession; without this
   // override the dashboard would keep a disabled Done action for that window.
+  const bannerTone = selectBannerTone(model, options);
   if (options.setupPending) {
     return {
       ...EMPTY_DASHBOARD_VIEW_BASE,
+      bannerTone,
       channelStatusLabel: 'Setting Up',
       actionLabel: 'Cancel',
       actionEnabled: true,
@@ -524,6 +537,7 @@ export function selectGameDashboardView(
   if (!model || options.hasSession === false) {
     return {
       ...EMPTY_DASHBOARD_VIEW_BASE,
+      bannerTone,
       channelStatusLabel: 'No Session',
       actionLabel: 'No Session',
       actionEnabled: false,
@@ -539,6 +553,7 @@ export function selectGameDashboardView(
   );
 
   return {
+    bannerTone,
     channelStatusLabel:
       channel.sessionDisposition === 'Abandoned'
         ? 'Abandoned'

--- a/front-end/src/lib/session/types.ts
+++ b/front-end/src/lib/session/types.ts
@@ -107,6 +107,9 @@ export interface ChannelStatusModel {
   zeroPayout: boolean | null;
   unrollInitiator: 'us' | 'opponent' | null;
   semanticPhase: ChannelStatusPayload['semantic_phase'] | null;
+  stateNumber: bigint | null;
+  unrollingStateNumber: bigint | null;
+  preemptingStateNumber: bigint | null;
 }
 
 export interface QueuedNotificationModel {

--- a/front-end/src/lib/session/types.ts
+++ b/front-end/src/lib/session/types.ts
@@ -246,7 +246,10 @@ export type GameDashboardActionLabel =
   | 'Abandon'
   | 'Done';
 
+export type BannerTone = 'idle' | 'playing' | 'pings-bad' | 'on-chain' | 'ended';
+
 export interface GameDashboardViewModel {
+  bannerTone: BannerTone;
   channelStatusLabel: string;
   channelDetail: string | null;
   havePotato: boolean;

--- a/front-end/src/lib/session/types.ts
+++ b/front-end/src/lib/session/types.ts
@@ -19,6 +19,8 @@ export type GameTurnState =
   | 'opponent-illegal-move'
   | 'submitting-timeout'
   | 'finishing'
+  | 'finishing-waiting-timeout'
+  | 'finishing-spending'
   | 'ended';
 
 export type HandStatus =
@@ -31,6 +33,8 @@ export type HandStatus =
   | 'slashing'
   | 'submitting-timeout'
   | 'finishing'
+  | 'finishing-waiting-timeout'
+  | 'finishing-spending'
   | 'ended';
 
 export type GameProtocolPresentation =
@@ -43,6 +47,8 @@ export type GameProtocolPresentation =
   | 'illegal-move'
   | 'submitting-timeout'
   | 'finishing'
+  | 'finishing-waiting-timeout'
+  | 'finishing-spending'
   | 'ended';
 
 export type GameTerminalType =

--- a/front-end/src/lib/tests/jsonSafe.test.ts
+++ b/front-end/src/lib/tests/jsonSafe.test.ts
@@ -1,4 +1,5 @@
 import {
+  integersToBigInt,
   jsonParse,
   jsonParseLossless,
   jsonStringify,
@@ -41,5 +42,21 @@ describe('jsonSafe codecs', () => {
   it('keeps the existing rpc/debug codec shape unchanged', () => {
     expect(jsonStringify({ value: 42n })).toBe('{"value":42}');
     expect(jsonParse('{"value":42}')).toEqual({ value: 42n });
+  });
+
+  it('promotes integer numbers to bigint and leaves typed arrays alone', () => {
+    const coin = new Uint8Array([1, 2, 3]);
+    expect(
+      integersToBigInt({
+        state_number: 0,
+        nested: { count: 7 },
+        coin,
+      }),
+    ).toEqual({
+      state_number: 0n,
+      nested: { count: 7n },
+      coin,
+    });
+    expect(integersToBigInt({ coin }).coin).toBe(coin);
   });
 });

--- a/front-end/src/lib/tests/message_protocol.terminal.test.ts
+++ b/front-end/src/lib/tests/message_protocol.terminal.test.ts
@@ -315,7 +315,7 @@ describe('terminal protocol cleanup', () => {
             ChannelStatus: channelStatus({
               state: 'Unrolling',
               unroll_initiator: 'opponent',
-              semantic_phase: 'submitting_timeout_finish',
+              semantic_phase: 'finishing_spending',
             }),
           },
         },
@@ -326,7 +326,7 @@ describe('terminal protocol cleanup', () => {
     expect((blob as any).lastChannelStatus).toMatchObject({
       state: 'Unrolling',
       unroll_initiator: 'opponent',
-      semantic_phase: 'submitting_timeout_finish',
+      semantic_phase: 'finishing_spending',
     });
   });
 });

--- a/front-end/src/lib/tests/restore_lifecycle.test.ts
+++ b/front-end/src/lib/tests/restore_lifecycle.test.ts
@@ -11,6 +11,7 @@ import {
   shouldReportSessionPhase,
   shouldSuppressPhaseReporting,
   shouldSwitchToHubOnResolved,
+  shouldWarnOnSessionUnload,
 } from '../restoreLifecycle';
 
 describe('restore lifecycle gates', () => {
@@ -59,6 +60,13 @@ describe('restore lifecycle gates', () => {
     // Once the restore gate opens, report the current authoritative phase once.
     expect(shouldReportSessionPhase('resolved', false, false)).toBe(true);
     expect(shouldReportSessionPhase('resolved', false, true)).toBe(false);
+  });
+
+  it('warns before unload only while a session is off-chain or on-chain', () => {
+    expect(shouldWarnOnSessionUnload('none')).toBe(false);
+    expect(shouldWarnOnSessionUnload('resolved')).toBe(false);
+    expect(shouldWarnOnSessionUnload('off-chain')).toBe(true);
+    expect(shouldWarnOnSessionUnload('on-chain')).toBe(true);
   });
 
   it('keeps hub presence busy until the session is resolved', () => {

--- a/front-end/src/lib/tests/save.maintenance.test.ts
+++ b/front-end/src/lib/tests/save.maintenance.test.ts
@@ -12,6 +12,7 @@ import {
   claimLease,
   checkLease,
   isLeaseConflict,
+  releaseLeaseIfOwner,
 } from '../../hooks/save';
 import { SESSION_DB_NAME } from '../session/indexedDb';
 import { makeStorage, sampleSession, saveLiveFields, setTestGlobal } from './save.harness';
@@ -25,6 +26,19 @@ describe('tab lease', () => {
     localStorage.setItem('appState_activeTab', 'another-tab');
 
     expect(checkLease()).toBe(false);
+    expect(isLeaseConflict()).toBe(true);
+  });
+
+  it('clears the lease on close only when this tab still owns it', () => {
+    claimLease();
+    releaseLeaseIfOwner();
+    expect(localStorage.getItem('appState_activeTab')).toBeNull();
+    expect(checkLease()).toBe(true);
+    expect(isLeaseConflict()).toBe(false);
+
+    localStorage.setItem('appState_activeTab', 'another-tab');
+    releaseLeaseIfOwner();
+    expect(localStorage.getItem('appState_activeTab')).toBe('another-tab');
     expect(isLeaseConflict()).toBe(true);
   });
 });

--- a/front-end/src/lib/tests/session_model.presentation.test.ts
+++ b/front-end/src/lib/tests/session_model.presentation.test.ts
@@ -12,6 +12,7 @@ import {
   sessionModelFromSave,
   nextGameInstanceAfterLocalTurn,
 } from '../session/model';
+import { decodeChannelStatusPayload } from '../session/persistence';
 import type { SessionSave } from '../../hooks/save';
 import { baseSave, liveSave } from './session_save_envelope.fixtures';
 
@@ -165,6 +166,25 @@ describe('session model dashboard and on-chain presentation contracts', () => {
       selectGameDashboardView(
         createSessionModel({
           channel: {
+            status: {
+              ...INITIAL_CHANNEL_STATUS_MODEL,
+              state: 'Active',
+              stateNumber: 7n,
+              havePotato: true,
+            },
+          },
+          game: { activeIds: [] },
+        }),
+      ),
+    ).toMatchObject({
+      channelStatusLabel: 'Active',
+      channelDetail: 'state 7',
+      havePotato: true,
+    });
+    expect(
+      selectGameDashboardView(
+        createSessionModel({
+          channel: {
             status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'Active', havePotato: true },
           },
           game: { activeIds: [] },
@@ -251,7 +271,10 @@ describe('session model dashboard and on-chain presentation contracts', () => {
         have_potato: true,
         zero_payout: true,
         unroll_initiator: 'opponent',
-        semantic_phase: 'waiting_timeout',
+        semantic_phase: 'finishing_waiting_timeout',
+        state_number: 4n,
+        unrolling_state_number: 3n,
+        preempting_state_number: 5n,
       }),
     ).toMatchObject({
       state: 'ShuttingDown',
@@ -262,68 +285,155 @@ describe('session model dashboard and on-chain presentation contracts', () => {
       havePotato: true,
       zeroPayout: true,
       unrollInitiator: 'opponent',
-      semanticPhase: 'waiting_timeout',
+      semanticPhase: 'finishing_waiting_timeout',
+      stateNumber: 4n,
+      unrollingStateNumber: 3n,
+      preemptingStateNumber: 5n,
     });
   });
 
-  it('shows semantic progress alongside the authoritative channel advisory', () => {
-    const view = selectGameDashboardView(
-      createSessionModel({
-        channel: {
-          status: {
-            ...INITIAL_CHANNEL_STATUS_MODEL,
-            state: 'Unrolling',
-            semanticPhase: 'waiting_timeout',
-            advisory: 'The observed spend needs manual review',
-          },
-        },
+  it('promotes inbound integer state numbers to bigint before persistence', () => {
+    expect(
+      decodeChannelStatusPayload({
+        state: 'Active',
+        advisory: null,
+        coin: null,
+        our_balance: null,
+        their_balance: null,
+        game_allocated: null,
+        state_number: 0,
+        unrolling_state_number: 2,
+        preempting_state_number: 3,
       }),
-    );
-
-    expect(view.channelDetail).toBe('Waiting for timeout: The observed spend needs manual review');
+    ).toMatchObject({
+      state_number: 0n,
+      unrolling_state_number: 2n,
+      preempting_state_number: 3n,
+    });
   });
 
-  it('renders known unroll initiators without inventing an unknown label', () => {
-    const opponent = selectGameDashboardView(
-      createSessionModel({
-        channel: {
-          status: {
-            ...INITIAL_CHANNEL_STATUS_MODEL,
-            state: 'Unrolling',
-            semanticPhase: 'waiting_timeout',
-            unrollInitiator: 'opponent',
-          },
-        },
-      }),
-    );
-    expect(opponent.channelDetail).toBe('Waiting for timeout (initiated by opponent)');
+  it('names unroll, preempt, and finish-unroll actions with the relevant state numbers', () => {
+    const view = (status: Partial<typeof INITIAL_CHANNEL_STATUS_MODEL>) =>
+      selectGameDashboardView(
+        createSessionModel({
+          channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, ...status } },
+        }),
+      );
 
-    const us = selectGameDashboardView(
-      createSessionModel({
-        channel: {
-          status: {
-            ...INITIAL_CHANNEL_STATUS_MODEL,
-            state: 'Unrolling',
-            semanticPhase: 'preempting',
-            unrollInitiator: 'us',
-          },
-        },
+    expect(
+      view({
+        state: 'GoingOnChain',
+        semanticPhase: 'unrolling',
+        stateNumber: 7n,
+        unrollingStateNumber: 7n,
       }),
-    );
-    expect(us.channelDetail).toBe('Preempting unroll (initiated by you)');
+    ).toMatchObject({
+      channelStatusLabel: 'Unrolling',
+      channelDetail: 'to state 7',
+    });
 
-    const unknown = selectGameDashboardView(
-      createSessionModel({
-        channel: {
-          status: {
-            ...INITIAL_CHANNEL_STATUS_MODEL,
-            state: 'Unrolling',
-            semanticPhase: 'resolving',
-          },
-        },
+    expect(
+      view({
+        state: 'GoingOnChain',
+        semanticPhase: 'unrolling',
+        stateNumber: 7n,
+        unrollingStateNumber: 6n,
       }),
-    );
-    expect(unknown.channelDetail).toBe('Resolving');
+    ).toMatchObject({
+      channelStatusLabel: 'Unrolling',
+      channelDetail: 'to state 6',
+    });
+
+    expect(
+      view({
+        state: 'GoingOnChain',
+        semanticPhase: 'finding_state',
+        unrollInitiator: 'opponent',
+      }),
+    ).toMatchObject({
+      channelStatusLabel: 'Opponent unrolled',
+      channelDetail: 'finding state',
+    });
+
+    expect(
+      view({
+        state: 'GoingOnChain',
+        semanticPhase: 'finding_state',
+        stateNumber: 7n,
+      }),
+    ).toMatchObject({
+      channelStatusLabel: 'Unrolled',
+      channelDetail: 'finding state',
+    });
+
+    expect(
+      view({
+        state: 'Unrolling',
+        semanticPhase: 'finishing_waiting_timeout',
+        unrollingStateNumber: 7n,
+      }),
+    ).toMatchObject({
+      channelStatusLabel: 'Finishing unroll',
+      channelDetail: 'waiting for timeout state 7',
+    });
+
+    expect(
+      view({
+        state: 'Unrolling',
+        semanticPhase: 'finishing_spending',
+        unrollingStateNumber: 7n,
+      }),
+    ).toMatchObject({
+      channelStatusLabel: 'Finishing unroll',
+      channelDetail: 'spending state 7',
+    });
+
+    expect(
+      view({
+        state: 'Unrolling',
+        semanticPhase: 'preempting',
+        unrollingStateNumber: 2n,
+        preemptingStateNumber: 5n,
+      }),
+    ).toMatchObject({
+      channelStatusLabel: 'Preempting',
+      channelDetail: 'from 2 to 5',
+    });
+
+    expect(
+      view({
+        state: 'Unrolling',
+        semanticPhase: 'finishing_waiting_timeout',
+        unrollInitiator: 'opponent',
+        unrollingStateNumber: 2n,
+        advisory: 'The observed spend needs manual review',
+      }),
+    ).toMatchObject({
+      channelStatusLabel: 'Finishing opponent unroll',
+      channelDetail: 'waiting for timeout state 2: The observed spend needs manual review',
+    });
+
+    expect(
+      view({
+        state: 'Unrolling',
+        semanticPhase: 'finishing_spending',
+        unrollInitiator: 'opponent',
+        unrollingStateNumber: 2n,
+      }),
+    ).toMatchObject({
+      channelStatusLabel: 'Finishing opponent unroll',
+      channelDetail: 'spending state 2',
+    });
+
+    expect(
+      view({
+        state: 'ShutdownTransactionPending',
+        semanticPhase: 'submitting_channel_spend',
+      }),
+    ).toMatchObject({
+      channelStatusLabel: 'Shutting Down',
+      channelDetail: 'Submitting channel spend',
+    });
   });
 
   it('prioritizes terminal disposition details over stale semantic progress', () => {
@@ -334,7 +444,7 @@ describe('session model dashboard and on-chain presentation contracts', () => {
             ...INITIAL_CHANNEL_STATUS_MODEL,
             state: 'Unrolling',
             sessionDisposition: 'Abandoned',
-            semanticPhase: 'waiting_timeout',
+            semanticPhase: 'finishing_waiting_timeout',
             advisory: 'Local session was abandoned',
           },
         },
@@ -352,7 +462,7 @@ describe('session model dashboard and on-chain presentation contracts', () => {
             ...INITIAL_CHANNEL_STATUS_MODEL,
             state: 'Unrolling',
             sessionDisposition: 'AwaitOutboundTerminal',
-            semanticPhase: 'submitting_timeout_finish',
+            semanticPhase: 'finishing_spending',
             advisory: null,
           },
         },
@@ -377,7 +487,7 @@ describe('session model dashboard and on-chain presentation contracts', () => {
       have_potato: false,
       zero_payout: false,
       unroll_initiator: 'us' as const,
-      semantic_phase: 'submitting_timeout_finish' as const,
+      semantic_phase: 'finishing_spending' as const,
     };
     const restored = sessionModelFromSave(
       baseSave({
@@ -393,7 +503,7 @@ describe('session model dashboard and on-chain presentation contracts', () => {
     expect(restored.channel.status.ourBalance).toBe('42');
     expect(restored.channel.status).toMatchObject({
       unrollInitiator: 'us',
-      semanticPhase: 'submitting_timeout_finish',
+      semanticPhase: 'finishing_spending',
     });
   });
 
@@ -415,6 +525,9 @@ describe('session model dashboard and on-chain presentation contracts', () => {
     expect(restored.channel.status).toMatchObject({
       unrollInitiator: null,
       semanticPhase: null,
+      stateNumber: null,
+      unrollingStateNumber: null,
+      preemptingStateNumber: null,
     });
   });
 

--- a/front-end/src/lib/tests/session_model.presentation.test.ts
+++ b/front-end/src/lib/tests/session_model.presentation.test.ts
@@ -48,6 +48,7 @@ describe('session model dashboard and on-chain presentation contracts', () => {
 
   it('uses the existing dashboard action across the setup commitment boundary', () => {
     expect(selectGameDashboardView(null, { setupPending: true })).toMatchObject({
+      bannerTone: 'playing',
       channelStatusLabel: 'Setting Up',
       actionLabel: 'Cancel',
       actionEnabled: true,
@@ -60,6 +61,7 @@ describe('session model dashboard and on-chain presentation contracts', () => {
       channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'ResolvedClean' } },
     });
     expect(selectGameDashboardView(finishedFreeze)).toMatchObject({
+      bannerTone: 'ended',
       actionLabel: 'Done',
       actionEnabled: false,
       actionKind: 'none',
@@ -115,8 +117,59 @@ describe('session model dashboard and on-chain presentation contracts', () => {
     }
   });
 
+  it('derives banner tone from session mode and peer liveness', () => {
+    expect(selectGameDashboardView(null)).toMatchObject({ bannerTone: 'idle' });
+    expect(selectGameDashboardView(null, { setupPending: true })).toMatchObject({
+      bannerTone: 'playing',
+    });
+    expect(
+      selectGameDashboardView(null, { setupPending: true, peerLiveness: 'degraded' }),
+    ).toMatchObject({ bannerTone: 'pings-bad' });
+
+    const active = createSessionModel({
+      channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'Active' } },
+    });
+    expect(selectGameDashboardView(active)).toMatchObject({ bannerTone: 'playing' });
+    expect(selectGameDashboardView(active, { peerLiveness: 'connected' })).toMatchObject({
+      bannerTone: 'playing',
+    });
+    expect(selectGameDashboardView(active, { peerLiveness: 'degraded' })).toMatchObject({
+      bannerTone: 'pings-bad',
+    });
+
+    const handshaking = createSessionModel({
+      channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'Handshaking' } },
+    });
+    expect(selectGameDashboardView(handshaking, { peerLiveness: null })).toMatchObject({
+      bannerTone: 'playing',
+    });
+
+    const unrolling = createSessionModel({
+      channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'Unrolling' } },
+    });
+    expect(selectGameDashboardView(unrolling)).toMatchObject({ bannerTone: 'on-chain' });
+    expect(selectGameDashboardView(unrolling, { peerLiveness: 'degraded' })).toMatchObject({
+      bannerTone: 'on-chain',
+    });
+
+    const resolvedUnrolledLive = createSessionModel({
+      channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'ResolvedUnrolled' } },
+      game: { activeIds: ['1'] },
+    });
+    expect(selectGameDashboardView(resolvedUnrolledLive)).toMatchObject({ bannerTone: 'on-chain' });
+
+    expect(
+      selectGameDashboardView(
+        createSessionModel({
+          channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'ResolvedClean' } },
+        }),
+      ),
+    ).toMatchObject({ bannerTone: 'ended' });
+  });
+
   it('derives dashboard actions for no-session, waiting, active, and terminal states', () => {
     expect(selectGameDashboardView(null)).toMatchObject({
+      bannerTone: 'idle',
       channelStatusLabel: 'No Session',
       handStatusLabel: 'No hand',
       actionLabel: 'No Session',

--- a/front-end/src/lib/tests/session_model.presentation.test.ts
+++ b/front-end/src/lib/tests/session_model.presentation.test.ts
@@ -704,6 +704,8 @@ describe('session model dashboard and on-chain presentation contracts', () => {
         | 'playing-on-chain'
         | 'replaying'
         | 'finishing'
+        | 'finishing-waiting-timeout'
+        | 'finishing-spending'
         | 'opponent-illegal-move',
       coinHex: string | null,
     ) => ({
@@ -775,6 +777,24 @@ describe('session model dashboard and on-chain presentation contracts', () => {
         }),
       ).handStatusLabel,
     ).toBe('Finishing');
+
+    expect(
+      selectGameDashboardView(
+        createSessionModel({
+          channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'ResolvedUnrolled' } },
+          game: game('finishing-waiting-timeout', 'abcd'),
+        }),
+      ).handStatusLabel,
+    ).toBe('Finalizing waiting for timeout');
+
+    expect(
+      selectGameDashboardView(
+        createSessionModel({
+          channel: { status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'ResolvedUnrolled' } },
+          game: game('finishing-spending', 'abcd'),
+        }),
+      ).handStatusLabel,
+    ).toBe('Finalizing spending');
 
     // Detecting the opponent's illegal on-chain move puts us in the slash flow;
     // the bar should say so explicitly instead of a generic "Your turn".

--- a/front-end/src/lib/tests/session_model.restore.test.ts
+++ b/front-end/src/lib/tests/session_model.restore.test.ts
@@ -9,7 +9,7 @@ import {
   selectShouldAdvertiseAvailable,
   selectSessionPhase,
   selectShellView,
-  selectGameTabDotColor,
+  selectGameTabConnected,
   isCleanShutdownInProgress,
   sessionAmountsFromSave,
   sessionModelFromSave,
@@ -60,7 +60,7 @@ describe('session model restore, schema, and event contracts', () => {
     });
   });
 
-  it('keeps the game tab green during clean shutdown, yellow if peer drops, gray when done', () => {
+  it('treats a live game tab as connected until the peer is dead or the session ends', () => {
     const shuttingDown = createSessionModel({
       channel: {
         status: { ...INITIAL_CHANNEL_STATUS_MODEL, state: 'ShuttingDown' },
@@ -71,50 +71,54 @@ describe('session model restore, schema, and event contracts', () => {
       },
     });
     expect(isCleanShutdownInProgress(shuttingDown)).toBe(true);
-    // Peer stays live through cooperative close (keepalives continue).
     expect(
-      selectGameTabDotColor({
+      selectGameTabConnected({
         sessionPhase: 'off-chain',
-        sessionError: false,
         peerLiveness: 'connected',
-        cleanShutdownInProgress: true,
       }),
-    ).toBe('green');
-    // Real unreachability (silence / delivery failure) is yellow, not red.
+    ).toBe(true);
     expect(
-      selectGameTabDotColor({
+      selectGameTabConnected({
         sessionPhase: 'off-chain',
-        sessionError: false,
         peerLiveness: 'degraded',
-        cleanShutdownInProgress: true,
       }),
-    ).toBe('yellow');
-    // Dead should not occur during clean shutdown; if it does, treat as yellow.
+    ).toBe(true);
     expect(
-      selectGameTabDotColor({
+      selectGameTabConnected({
         sessionPhase: 'off-chain',
-        sessionError: false,
-        peerLiveness: 'dead',
-        cleanShutdownInProgress: true,
+        peerLiveness: null,
       }),
-    ).toBe('yellow');
+    ).toBe(true);
     expect(
-      selectGameTabDotColor({
+      selectGameTabConnected({
+        sessionPhase: 'off-chain',
+        peerLiveness: 'dead',
+      }),
+    ).toBe(false);
+    expect(
+      selectGameTabConnected({
+        sessionPhase: 'none',
+        peerLiveness: null,
+      }),
+    ).toBe(false);
+    expect(
+      selectGameTabConnected({
         sessionPhase: 'resolved',
-        sessionError: false,
         peerLiveness: 'connected',
-        cleanShutdownInProgress: false,
       }),
-    ).toBe('gray');
-    // Outside clean shutdown, peer dead is still red.
+    ).toBe(false);
     expect(
-      selectGameTabDotColor({
-        sessionPhase: 'off-chain',
-        sessionError: false,
+      selectGameTabConnected({
+        sessionPhase: 'on-chain',
         peerLiveness: 'dead',
-        cleanShutdownInProgress: false,
       }),
-    ).toBe('red');
+    ).toBe(false);
+    expect(
+      selectGameTabConnected({
+        sessionPhase: 'on-chain',
+        peerLiveness: 'connected',
+      }),
+    ).toBe(true);
   });
 
   it('restores between-hand state into the same game view shape live state uses', () => {

--- a/front-end/src/lib/tests/session_model.restore.test.ts
+++ b/front-end/src/lib/tests/session_model.restore.test.ts
@@ -484,6 +484,46 @@ describe('session model restore, schema, and event contracts', () => {
     });
   });
 
+  it('maps WASM finishing-timeout statuses to wait versus spend', () => {
+    const previous = {
+      id: '7',
+      amount: '100',
+      coin: { coinHex: 'coin', turnState: 'my-turn' as const, onChain: true },
+      handStatus: 'our-turn' as const,
+      terminal: INITIAL_GAME_TERMINAL_MODEL,
+    };
+    expect(
+      projectGameStatus({
+        previous,
+        payload: {
+          id: '7',
+          status: 'finishing-waiting-timeout',
+          coin_id: 'coin',
+          other_params: { game_finished: true },
+        },
+        channelState: 'ResolvedUnrolled',
+      }),
+    ).toMatchObject({
+      coin: { turnState: 'finishing-waiting-timeout', onChain: true },
+      handStatus: 'finishing-waiting-timeout',
+    });
+    expect(
+      projectGameStatus({
+        previous,
+        payload: {
+          id: '7',
+          status: 'finishing-spending',
+          coin_id: 'coin',
+          other_params: { game_finished: true, submitting_timeout_claim: true },
+        },
+        channelState: 'ResolvedUnrolled',
+      }),
+    ).toMatchObject({
+      coin: { turnState: 'finishing-spending', onChain: true },
+      handStatus: 'finishing-spending',
+    });
+  });
+
   it('orders readable gameplay events before the Settled marker', () => {
     const notification = {
       GameStatus: {

--- a/front-end/src/lib/tests/session_save_envelope.boundary.test.ts
+++ b/front-end/src/lib/tests/session_save_envelope.boundary.test.ts
@@ -54,7 +54,7 @@ describe('save boundary enforcement', () => {
     expect(await readSessionRecord()).toBeNull();
   });
 
-  it('deletes an invalid current-v12 game envelope while retaining the boot marker', async () => {
+  it('deletes an invalid current-v13 game envelope while retaining the boot marker', async () => {
     markSavedSession();
     await writeSessionRecord(
       activeSave({
@@ -69,7 +69,7 @@ describe('save boundary enforcement', () => {
     errorSpy.mockRestore();
   });
 
-  it('deletes a cross-phase v12 payload during hydration', async () => {
+  it('deletes a cross-phase v13 payload during hydration', async () => {
     markSavedSession();
     await writeSessionRecord(
       baseSave({
@@ -99,7 +99,7 @@ describe('save boundary enforcement', () => {
     errorSpy.mockRestore();
   });
 
-  it('deletes a live v12 record that restoreSession cannot consume', async () => {
+  it('deletes a live v13 record that restoreSession cannot consume', async () => {
     markSavedSession();
     await writeSessionRecord(liveSave({ messageNumber: undefined }));
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -125,7 +125,7 @@ describe('save boundary enforcement', () => {
     errorSpy.mockRestore();
   });
 
-  it('deletes a malformed current-v12 metadata envelope read from IndexedDB', async () => {
+  it('deletes a malformed current-v13 metadata envelope read from IndexedDB', async () => {
     markSavedSession();
     await writeSessionRecord(
       baseSave({

--- a/front-end/src/lib/tests/session_save_envelope.validation.test.ts
+++ b/front-end/src/lib/tests/session_save_envelope.validation.test.ts
@@ -111,7 +111,7 @@ describe('validateSessionSaveEnvelope', () => {
     ).toThrow('unexpected');
   });
 
-  it('decodes one legitimate snapshot for every v12 phase', () => {
+  it('decodes one legitimate snapshot for every v13 phase', () => {
     const preferences = baseSave({ blockchainType: 'simulator' });
     const preHandshake = baseSave({
       pairingToken: 'pair',
@@ -190,7 +190,7 @@ describe('validateSessionSaveEnvelope', () => {
     'waitingStateEnteredAt',
     'cleanShutdownGraceStartedAt',
   ] satisfies Array<keyof SessionPresentationSave>)(
-    'rejects a v12 presentation missing required %s',
+    'rejects a v13 presentation missing required %s',
     (field) => {
       const save = liveSave();
       if (save.phase !== 'live') throw new Error('expected live fixture');

--- a/front-end/src/lib/tests/terminal_finalization.test.ts
+++ b/front-end/src/lib/tests/terminal_finalization.test.ts
@@ -97,6 +97,9 @@ const model = createSessionModel({
       zeroPayout: null,
       unrollInitiator: null,
       semanticPhase: null,
+      stateNumber: null,
+      unrollingStateNumber: null,
+      preemptingStateNumber: null,
     },
   },
   game: {

--- a/front-end/src/types/ChiaGaming.ts
+++ b/front-end/src/types/ChiaGaming.ts
@@ -193,15 +193,22 @@ export interface ChannelStatusPayload {
   zero_payout?: boolean | null;
   unroll_initiator?: 'us' | 'opponent' | null;
   semantic_phase?: ChannelSemanticPhase | null;
+  state_number?: bigint | null;
+  unrolling_state_number?: bigint | null;
+  preempting_state_number?: bigint | null;
 }
 
-export type ChannelSemanticPhase =
-  | 'submitting_channel_spend'
-  | 'resolving_opponent_channel_spend'
-  | 'preempting'
-  | 'waiting_timeout'
-  | 'submitting_timeout_finish'
-  | 'resolving';
+export const CHANNEL_SEMANTIC_PHASES = [
+  'submitting_channel_spend',
+  'unrolling',
+  'finding_state',
+  'preempting',
+  'finishing_waiting_timeout',
+  'finishing_spending',
+  'resolving',
+] as const;
+
+export type ChannelSemanticPhase = (typeof CHANNEL_SEMANTIC_PHASES)[number];
 
 export interface ProposalAcceptedPayload {
   id: bigint | number | string;

--- a/front-end/src/types/ChiaGaming.ts
+++ b/front-end/src/types/ChiaGaming.ts
@@ -133,6 +133,8 @@ export type GameStatusState =
   | 'replaying'
   | 'playing-move'
   | 'illegal-move-detected'
+  | 'finishing-waiting-timeout'
+  | 'finishing-spending'
   | 'ended-cancelled'
   | 'ended-error';
 

--- a/front-end/src/util/jsonSafe.ts
+++ b/front-end/src/util/jsonSafe.ts
@@ -7,6 +7,26 @@ export function jsonParse(text: string): any {
   });
 }
 
+/**
+ * Promote integer `number`s to `bigint` at an inbound JS boundary.
+ * Typed arrays stay bytes — they are the documented exception to the bigint rule.
+ */
+export function integersToBigInt<T>(value: T): T {
+  return convertIntegersToBigInt(value) as T;
+}
+
+function convertIntegersToBigInt(value: unknown): unknown {
+  if (typeof value === 'number' && Number.isInteger(value)) return BigInt(value);
+  if (value === null || typeof value !== 'object') return value;
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) return value;
+  if (Array.isArray(value)) return value.map(convertIntegersToBigInt);
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = convertIntegersToBigInt(entry);
+  }
+  return out;
+}
+
 const BYTES_TAG = '$bytes';
 
 function uint8ToBase64(bytes: Uint8Array): string {

--- a/src/channel_state/mod.rs
+++ b/src/channel_state/mod.rs
@@ -5,7 +5,6 @@ pub mod game_start_info;
 pub mod runner;
 pub mod types;
 
-use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
@@ -1591,74 +1590,37 @@ impl ChannelState {
         ))
     }
 
-    /// Ensure that we include the last state sequence number in a memo so we can
-    /// possibly supercede an earlier unroll.
+    /// Classify a parsed channel-coin spend from its CREATE_COIN conditions.
+    /// Who submitted the spend is not an input; the conditions are.
     ///
-    /// Look at the conditions:
-    ///
-    /// The current sequence number is always either
-    /// We have two sequence numbers:
-    ///  - unroll state number
-    ///  - channel coin spend state number
-    ///
-    /// Whenever the channel coin gets spent, either we'll want to make it hit
-    /// its timeout or supercede the state that's in it.
-    ///
-    /// If the sequence number in the unroll is equal to our current state number
-    /// then force the timeout.
-    ///
-    /// Otherwise
-    ///   Not equal, and parity equal - hard error
-    ///   Less than our current unroll number - either same parity (fucked) or
-    ///   opposite (return a spend to supercede the spend it gave)
-    ///   Equal to unroll, try to timeout
-    ///   Equal to state, not unroll, try to timeout (different)
-    ///   Greater than state number - hard error
-    ///
-    /// Conditions on spending the channel should have default_conditions_hash
-    /// and state number as rems.
-    ///
-    /// Happens because one of us decided to start spending it.
-    /// Play has not necessarily ended.
-    /// One way in which this is spent is the clean unroll.
-    ///   Clean unroll won't reach here.
-    /// One of the two sides, started unrolling.
-    ///   So we must unroll as well.
-    ///
-    /// Give a spend to do as well to start our part of the unroll given that
-    /// the channel coin is spent.
-    ///
-    /// Must have the option that games were outright canceled.
-    /// Need to make the result richer to communicate that.
+    /// - Unknown puzzle hash (never signed) fails in
+    ///   `resolve_unroll_from_conditions`. A state we have not reached cannot
+    ///   be in the map, so "future" is the same check.
+    /// - Equal to our current state number → timeout.
+    /// - Older, opposite parity, signed preemption source → preempt.
+    /// - Older, same parity (or no signed preemption source) → timeout using
+    ///   the compact historical record we signed.
+    /// - Conditions-hash mismatch vs the signed historical record → error.
     pub fn channel_coin_spent(
         &self,
         env: &mut ChannelEnv<'_>,
-        myself: bool,
+        _myself: bool,
         conditions: NodePtr,
     ) -> Result<ChannelCoinSpentResult, Error> {
         let (unrolling_state_number, conditions_hash) =
             self.resolve_unroll_from_conditions(env, conditions)?;
+        game_assert!(
+            unrolling_state_number <= self.state_number,
+            "signed unroll {unrolling_state_number} cannot exceed our state {}",
+            self.state_number
+        );
 
-        // Always let the retained full latest records determine whether an
-        // older state can be preempted. Their state-number parity, not
-        // `self.state_number`'s parity, controls whether the spend is valid.
-        // If neither latest record has the required parity and peer signature,
-        // the exact compact historical record still provides a valid timeout.
-        let mut result = match (myself, unrolling_state_number.cmp(&self.state_number)) {
-            (true, _) | (_, Ordering::Equal) => {
-                self.make_timeout_unroll_spend(env, unrolling_state_number, &conditions_hash)
-            }
-            // On-chain state is from the future relative to us - error.
-            (_, Ordering::Greater) => Err(Error::StrErr(format!(
-                "Reply from the future onchain {} (me {})",
-                unrolling_state_number, self.state_number,
-            ))),
-            (_, Ordering::Less) if self.preemption_source(unrolling_state_number).is_some() => {
-                self.make_preemption_unroll_spend(env, unrolling_state_number, &conditions_hash)
-            }
-            (_, Ordering::Less) => {
-                self.make_timeout_unroll_spend(env, unrolling_state_number, &conditions_hash)
-            }
+        let mut result = if unrolling_state_number == self.state_number {
+            self.make_timeout_unroll_spend(env, unrolling_state_number, &conditions_hash)
+        } else if self.preemption_source(unrolling_state_number).is_some() {
+            self.make_preemption_unroll_spend(env, unrolling_state_number, &conditions_hash)
+        } else {
+            self.make_timeout_unroll_spend(env, unrolling_state_number, &conditions_hash)
         };
         if let Ok(ref mut r) = result {
             r.unrolling_state_number = unrolling_state_number;

--- a/src/channel_state/mod.rs
+++ b/src/channel_state/mod.rs
@@ -174,16 +174,11 @@ impl ChannelState {
     /// Equal to `state_number()` when we hold the potato; one behind after we
     /// send, until the peer countersigns the new channel spend.
     pub fn unroll_target_state_number(&self) -> Option<usize> {
-        if let Some(info) = &self.latest_received_unroll {
-            return Some(info.coin.state_number);
-        }
-        // Never received: the only co-signed unroll is the handshake state (0).
-        // Holding the potato means we have not sent yet, so that is current.
-        if self.have_potato {
-            Some(self.state_number)
+        self.timeout_state_number().or(Some(if self.have_potato {
+            self.state_number
         } else {
-            Some(0)
-        }
+            0
+        }))
     }
 
     pub fn have_potato(&self) -> bool {
@@ -1604,7 +1599,6 @@ impl ChannelState {
     pub fn channel_coin_spent(
         &self,
         env: &mut ChannelEnv<'_>,
-        _myself: bool,
         conditions: NodePtr,
     ) -> Result<ChannelCoinSpentResult, Error> {
         let (unrolling_state_number, conditions_hash) =
@@ -1615,9 +1609,9 @@ impl ChannelState {
             self.state_number
         );
 
-        let mut result = if unrolling_state_number == self.state_number {
-            self.make_timeout_unroll_spend(env, unrolling_state_number, &conditions_hash)
-        } else if self.preemption_source(unrolling_state_number).is_some() {
+        let mut result = if unrolling_state_number < self.state_number
+            && self.preemption_source(unrolling_state_number).is_some()
+        {
             self.make_preemption_unroll_spend(env, unrolling_state_number, &conditions_hash)
         } else {
             self.make_timeout_unroll_spend(env, unrolling_state_number, &conditions_hash)

--- a/src/channel_state/mod.rs
+++ b/src/channel_state/mod.rs
@@ -171,6 +171,22 @@ impl ChannelState {
             .map(|t| t.coin.state_number)
     }
 
+    /// Last fully co-signed unroll we can spend the channel coin to.
+    /// Equal to `state_number()` when we hold the potato; one behind after we
+    /// send, until the peer countersigns the new channel spend.
+    pub fn unroll_target_state_number(&self) -> Option<usize> {
+        if let Some(info) = &self.latest_received_unroll {
+            return Some(info.coin.state_number);
+        }
+        // Never received: the only co-signed unroll is the handshake state (0).
+        // Holding the potato means we have not sent yet, so that is current.
+        if self.have_potato {
+            Some(self.state_number)
+        } else {
+            Some(0)
+        }
+    }
+
     pub fn have_potato(&self) -> bool {
         self.have_potato
     }
@@ -1685,11 +1701,15 @@ impl ChannelState {
         })
     }
 
-    /// Build a preemption (challenge-path) spend of the unroll coin.
-    /// The PUZZLE must match the on-chain coin (built from the state that
-    /// matches the on-chain unroll).  The SOLUTION and SIGNATURE come from
-    /// our latest state that satisfies the CLSP parity constraint:
-    ///   logand(1, logxor(our_state_number, OLD_SEQUENCE_NUMBER)) == 1
+    /// State number we would preempt `old_state_number` with, if any eligible
+    /// stored unroll record has the required parity and peer half-signature.
+    pub fn preempting_state_number_for(&self, old_state_number: usize) -> Option<usize> {
+        self.preemption_source(old_state_number)
+            .map(|info| info.coin.state_number)
+    }
+
+    /// Pick a stored unroll whose state number has opposite parity from
+    /// `old_state_number` and that carries the peer's preemption half-signature.
     fn preemption_source(&self, old_state_number: usize) -> Option<&ChannelUnrollSpendInfo> {
         let has_peer_sig = |info: &ChannelUnrollSpendInfo| {
             info.signatures.unroll_preempt_half_sig != Aggsig::default()
@@ -1707,6 +1727,11 @@ impl ChannelState {
         }
     }
 
+    /// Build a preemption (challenge-path) spend of the unroll coin.
+    /// The PUZZLE must match the on-chain coin (built from the state that
+    /// matches the on-chain unroll).  The SOLUTION and SIGNATURE come from
+    /// our latest state that satisfies the CLSP parity constraint:
+    ///   logand(1, logxor(our_state_number, OLD_SEQUENCE_NUMBER)) == 1
     fn make_preemption_unroll_spend(
         &self,
         env: &mut ChannelEnv<'_>,

--- a/src/game_session.rs
+++ b/src/game_session.rs
@@ -985,7 +985,8 @@ impl GameSession {
                     self.emit_channel_status_if_changed();
                 }
             }
-            TimeoutClaimSemantic::GameOpponentTurn { id } => {
+            TimeoutClaimSemantic::GameOpponentTurn { id }
+            | TimeoutClaimSemantic::GameFinishTimeout { id } => {
                 let notification = self
                     .peer
                     .as_any_mut()
@@ -1018,7 +1019,8 @@ impl GameSession {
                     self.emit_channel_status_if_changed();
                 }
             }
-            TimeoutClaimSemantic::GameOpponentTurn { id } => {
+            TimeoutClaimSemantic::GameOpponentTurn { id }
+            | TimeoutClaimSemantic::GameFinishTimeout { id } => {
                 let notification = self
                     .peer
                     .as_any_mut()

--- a/src/game_session.rs
+++ b/src/game_session.rs
@@ -914,26 +914,14 @@ impl GameSession {
         {
             return true;
         }
-        // In Active state, re-emit on balance changes (potato firings).
+        // In Active state, re-emit on balance / potato / state_number changes.
         // In other states, suppress same-state re-emissions (e.g. coin
         // changes within Unrolling).
         new_state == Some(&ChannelStatus::Active)
     }
 
     fn make_channel_status_notification(snap: &ChannelStatusSnapshot) -> GameNotification {
-        GameNotification::ChannelStatus {
-            state: snap.state.clone(),
-            session_disposition: snap.session_disposition.clone(),
-            advisory: snap.advisory.clone(),
-            coin: snap.coin.clone(),
-            our_balance: snap.our_balance.clone(),
-            their_balance: snap.their_balance.clone(),
-            game_allocated: snap.game_allocated.clone(),
-            have_potato: snap.have_potato,
-            zero_payout: snap.zero_payout,
-            unroll_initiator: snap.unroll_initiator,
-            semantic_phase: snap.semantic_phase,
-        }
+        GameNotification::ChannelStatus(snap.clone())
     }
 
     fn emit_channel_status_if_changed(&mut self) {
@@ -946,19 +934,7 @@ impl GameSession {
                 .peer
                 .channel_status_snapshot()
                 .or_else(|| self.last_channel_status.clone())
-                .unwrap_or(ChannelStatusSnapshot {
-                    state: ChannelStatus::Handshaking,
-                    session_disposition: None,
-                    advisory: None,
-                    coin: None,
-                    our_balance: None,
-                    their_balance: None,
-                    game_allocated: None,
-                    have_potato: None,
-                    zero_payout: None,
-                    unroll_initiator: None,
-                    semantic_phase: None,
-                });
+                .unwrap_or_else(|| ChannelStatusSnapshot::new(ChannelStatus::Handshaking));
             snapshot.session_disposition = Some(session_disposition);
             Some(snapshot)
         } else {
@@ -1079,17 +1055,8 @@ impl GameSession {
         self.state.channel_expired = true;
         self.state.is_failed = true;
         let snapshot = ChannelStatusSnapshot {
-            state: ChannelStatus::Failed,
-            session_disposition: None,
             advisory: Some("channel coin not confirmed in time".to_string()),
-            coin: None,
-            our_balance: None,
-            their_balance: None,
-            game_allocated: None,
-            have_potato: None,
-            zero_payout: None,
-            unroll_initiator: None,
-            semantic_phase: None,
+            ..ChannelStatusSnapshot::new(ChannelStatus::Failed)
         };
         self.state.events.push_back(GameSessionEvent::Notification(
             Self::make_channel_status_notification(&snapshot),
@@ -1769,17 +1736,9 @@ mod sequencing_tests {
         phase: Option<crate::session_phases::effects::ChannelSemanticPhase>,
     ) -> Option<ChannelStatusSnapshot> {
         Some(ChannelStatusSnapshot {
-            state: ChannelStatus::Unrolling,
-            session_disposition: None,
-            advisory: None,
-            coin: None,
-            our_balance: None,
-            their_balance: None,
-            game_allocated: None,
-            have_potato: None,
-            zero_payout: None,
             unroll_initiator: initiator,
             semantic_phase: phase,
+            ..ChannelStatusSnapshot::new(ChannelStatus::Unrolling)
         })
     }
 
@@ -1788,14 +1747,14 @@ mod sequencing_tests {
         use crate::session_phases::effects::{ChannelSemanticPhase, UnrollInitiator};
 
         assert!(GameSession::should_emit_status(
-            &unrolling_snapshot(None, Some(ChannelSemanticPhase::WaitingTimeout)),
-            &unrolling_snapshot(None, Some(ChannelSemanticPhase::SubmittingTimeoutFinish)),
+            &unrolling_snapshot(None, Some(ChannelSemanticPhase::FinishingWaitingTimeout),),
+            &unrolling_snapshot(None, Some(ChannelSemanticPhase::FinishingSpending)),
         ));
         assert!(GameSession::should_emit_status(
-            &unrolling_snapshot(None, Some(ChannelSemanticPhase::WaitingTimeout)),
+            &unrolling_snapshot(None, Some(ChannelSemanticPhase::FinishingWaitingTimeout),),
             &unrolling_snapshot(
                 Some(UnrollInitiator::Opponent),
-                Some(ChannelSemanticPhase::WaitingTimeout),
+                Some(ChannelSemanticPhase::FinishingWaitingTimeout),
             ),
         ));
     }

--- a/src/session_phases/effects.rs
+++ b/src/session_phases/effects.rs
@@ -127,6 +127,7 @@ pub enum ChannelSemanticPhase {
 pub enum TimeoutClaimSemantic {
     ChannelTimeoutFinish,
     GameOpponentTurn { id: GameID },
+    GameFinishTimeout { id: GameID },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -139,6 +140,8 @@ pub enum GameStatusKind {
     Replaying,
     PlayingMove,
     IllegalMoveDetected,
+    FinishingWaitingTimeout,
+    FinishingSpending,
     EndedCancelled,
     EndedError,
 }

--- a/src/session_phases/effects.rs
+++ b/src/session_phases/effects.rs
@@ -66,6 +66,37 @@ pub struct ChannelStatusSnapshot {
     pub unroll_initiator: Option<UnrollInitiator>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub semantic_phase: Option<ChannelSemanticPhase>,
+    /// Most recent channel state number this side is aware of.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_number: Option<usize>,
+    /// State number of the unroll we are publishing, or of the unroll coin
+    /// that landed on-chain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unrolling_state_number: Option<usize>,
+    /// State number we are (or were) preempting the landed unroll with.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preempting_state_number: Option<usize>,
+}
+
+impl ChannelStatusSnapshot {
+    pub fn new(state: ChannelStatus) -> Self {
+        Self {
+            state,
+            session_disposition: None,
+            advisory: None,
+            coin: None,
+            our_balance: None,
+            their_balance: None,
+            game_allocated: None,
+            have_potato: None,
+            zero_payout: None,
+            unroll_initiator: None,
+            semantic_phase: None,
+            state_number: None,
+            unrolling_state_number: None,
+            preempting_state_number: None,
+        }
+    }
 }
 
 /// Which party caused the observed channel-to-unroll transition.
@@ -77,14 +108,17 @@ pub enum UnrollInitiator {
 }
 
 /// Fine-grained progress within the existing on-chain channel lifecycle.
+/// Actor (us vs opponent) is `unroll_initiator`, not this enum.
+/// UI copy is an exhaustive map from this enum plus initiator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChannelSemanticPhase {
     SubmittingChannelSpend,
-    ResolvingOpponentChannelSpend,
+    Unrolling,
+    FindingState,
     Preempting,
-    WaitingTimeout,
-    SubmittingTimeoutFinish,
+    FinishingWaitingTimeout,
+    FinishingSpending,
     Resolving,
 }
 
@@ -239,24 +273,7 @@ pub enum GameNotification {
         tag: String,
         message: String,
     },
-    ChannelStatus {
-        state: ChannelStatus,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        session_disposition: Option<SessionDisposition>,
-        advisory: Option<String>,
-        coin: Option<CoinString>,
-        our_balance: Option<Amount>,
-        their_balance: Option<Amount>,
-        game_allocated: Option<Amount>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        have_potato: Option<bool>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        zero_payout: Option<bool>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        unroll_initiator: Option<UnrollInitiator>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        semantic_phase: Option<ChannelSemanticPhase>,
-    },
+    ChannelStatus(ChannelStatusSnapshot),
 }
 
 /// A coin id worth surfacing in the dashboard so the user can look it up in a
@@ -531,6 +548,9 @@ mod tests {
         assert_eq!(restored.zero_payout, None);
         assert_eq!(restored.unroll_initiator, None);
         assert_eq!(restored.semantic_phase, None);
+        assert_eq!(restored.state_number, None);
+        assert_eq!(restored.unrolling_state_number, None);
+        assert_eq!(restored.preempting_state_number, None);
     }
 
     #[test]

--- a/src/session_phases/handler_base.rs
+++ b/src/session_phases/handler_base.rs
@@ -20,8 +20,9 @@ pub enum UnrollOutcome {
     Unrecoverable(String),
 }
 
-/// Determine whether an unroll can be preempted, needs to wait for timeout, or
-/// is unrecoverable.  Used by SpendChannelCoinPhase.
+/// Map `channel_coin_spent`'s parse result to an unroll outcome.
+/// Parse errors (never signed, conditions mismatch) stay unrecoverable;
+/// they are not widened to a timeout just because some historical record exists.
 pub fn classify_unroll(
     ch: &ChannelState,
     env: &mut ChannelEnv<'_>,
@@ -43,16 +44,9 @@ pub fn classify_unroll(
             Ok(UnrollOutcome::Preempted(bundle))
         }
         Ok(_) => Ok(UnrollOutcome::WaitForTimeout),
-        Err(e) => {
-            let can_timeout = ch.get_historical_unroll_for_state(on_chain_state).is_ok();
-            if can_timeout {
-                Ok(UnrollOutcome::WaitForTimeout)
-            } else {
-                Ok(UnrollOutcome::Unrecoverable(format!(
-                    "cannot preempt ({e:?}) and no stored state for timeout at {on_chain_state}"
-                )))
-            }
-        }
+        Err(e) => Ok(UnrollOutcome::Unrecoverable(format!(
+            "channel coin spend at state {on_chain_state} is not a signed unroll we can finish or preempt: {e:?}"
+        ))),
     }
 }
 

--- a/src/session_phases/handler_base.rs
+++ b/src/session_phases/handler_base.rs
@@ -30,7 +30,7 @@ pub fn classify_unroll(
     unroll_coin: &CoinString,
     on_chain_state: usize,
 ) -> Result<UnrollOutcome, Error> {
-    let spend_result = ch.channel_coin_spent(env, false, conditions_nodeptr);
+    let spend_result = ch.channel_coin_spent(env, conditions_nodeptr);
 
     match spend_result {
         Ok(result) if !result.timeout => {

--- a/src/session_phases/handshake_initiator.rs
+++ b/src/session_phases/handshake_initiator.rs
@@ -815,8 +815,6 @@ impl PeerLifecyclePhase for HandshakeInitiatorPhase {
     fn channel_status_snapshot(&self) -> Option<ChannelStatusSnapshot> {
         if self.failed {
             return Some(ChannelStatusSnapshot {
-                state: ChannelStatus::Failed,
-                session_disposition: None,
                 advisory: self.failure_advisory.clone(),
                 coin: self
                     .channel_state
@@ -834,10 +832,7 @@ impl PeerLifecyclePhase for HandshakeInitiatorPhase {
                     .channel_state
                     .as_ref()
                     .map(|ch| ch.total_game_allocated()),
-                have_potato: None,
-                zero_payout: None,
-                unroll_initiator: None,
-                semantic_phase: None,
+                ..ChannelStatusSnapshot::new(ChannelStatus::Failed)
             });
         }
         // The channel-creation expiry -> Failed signal now lives in the
@@ -846,9 +841,6 @@ impl PeerLifecyclePhase for HandshakeInitiatorPhase {
         // value; it no longer drives a status branch.
         if self.pending_coin_spend {
             return Some(ChannelStatusSnapshot {
-                state: ChannelStatus::WaitingForHeightToOffer,
-                session_disposition: None,
-                advisory: None,
                 coin: self
                     .channel_state
                     .as_ref()
@@ -865,10 +857,7 @@ impl PeerLifecyclePhase for HandshakeInitiatorPhase {
                     .channel_state
                     .as_ref()
                     .map(|ch| ch.total_game_allocated()),
-                have_potato: None,
-                zero_payout: None,
-                unroll_initiator: None,
-                semantic_phase: None,
+                ..ChannelStatusSnapshot::new(ChannelStatus::WaitingForHeightToOffer)
             });
         }
         let state = match &self.state {
@@ -903,17 +892,11 @@ impl PeerLifecyclePhase for HandshakeInitiatorPhase {
                 (None, None, None)
             };
         Some(ChannelStatusSnapshot {
-            state,
-            session_disposition: None,
-            advisory: None,
             coin,
             our_balance,
             their_balance,
             game_allocated,
-            have_potato: None,
-            zero_payout: None,
-            unroll_initiator: None,
-            semantic_phase: None,
+            ..ChannelStatusSnapshot::new(state)
         })
     }
     fn coins_of_interest(&self) -> Vec<(CoinOfInterest, CoinString)> {

--- a/src/session_phases/handshake_receiver.rs
+++ b/src/session_phases/handshake_receiver.rs
@@ -770,8 +770,6 @@ impl PeerLifecyclePhase for HandshakeReceiverPhase {
     fn channel_status_snapshot(&self) -> Option<ChannelStatusSnapshot> {
         if self.failed {
             return Some(ChannelStatusSnapshot {
-                state: ChannelStatus::Failed,
-                session_disposition: None,
                 advisory: self.failure_advisory.clone(),
                 coin: self
                     .channel_state
@@ -789,10 +787,7 @@ impl PeerLifecyclePhase for HandshakeReceiverPhase {
                     .channel_state
                     .as_ref()
                     .map(|ch| ch.total_game_allocated()),
-                have_potato: None,
-                zero_payout: None,
-                unroll_initiator: None,
-                semantic_phase: None,
+                ..ChannelStatusSnapshot::new(ChannelStatus::Failed)
             });
         }
         // The channel-creation expiry -> Failed signal now lives in the
@@ -801,9 +796,6 @@ impl PeerLifecyclePhase for HandshakeReceiverPhase {
         // value; it no longer drives a status branch.
         if self.pending_coin_spend {
             return Some(ChannelStatusSnapshot {
-                state: ChannelStatus::WaitingForHeightToAccept,
-                session_disposition: None,
-                advisory: None,
                 coin: self
                     .channel_state
                     .as_ref()
@@ -820,10 +812,7 @@ impl PeerLifecyclePhase for HandshakeReceiverPhase {
                     .channel_state
                     .as_ref()
                     .map(|ch| ch.total_game_allocated()),
-                have_potato: None,
-                zero_payout: None,
-                unroll_initiator: None,
-                semantic_phase: None,
+                ..ChannelStatusSnapshot::new(ChannelStatus::WaitingForHeightToAccept)
             });
         }
         let state = match &self.state {
@@ -850,17 +839,11 @@ impl PeerLifecyclePhase for HandshakeReceiverPhase {
                 (None, None, None)
             };
         Some(ChannelStatusSnapshot {
-            state,
-            session_disposition: None,
-            advisory: None,
             coin,
             our_balance,
             their_balance,
             game_allocated,
-            have_potato: None,
-            zero_payout: None,
-            unroll_initiator: None,
-            semantic_phase: None,
+            ..ChannelStatusSnapshot::new(state)
         })
     }
     fn coins_of_interest(&self) -> Vec<(CoinOfInterest, CoinString)> {

--- a/src/session_phases/mod.rs
+++ b/src/session_phases/mod.rs
@@ -1884,21 +1884,18 @@ impl PeerLifecyclePhase for OffChainPhase {
                 .iter()
                 .any(|a| matches!(a, GameAction::CleanShutdown));
         Some(ChannelStatusSnapshot {
-            state: if shutting_down {
-                ChannelStatus::ShuttingDown
-            } else {
-                ChannelStatus::Active
-            },
-            session_disposition: None,
-            advisory: None,
             coin: Some(ch.channel_coin().clone()),
             our_balance: Some(ch.my_out_of_game_balance()),
             their_balance: Some(ch.their_out_of_game_balance()),
             game_allocated: Some(ch.total_game_allocated()),
             have_potato: Some(matches!(self.have_potato, PotatoState::Present)),
             zero_payout: shutting_down.then(|| ch.has_zero_payout()),
-            unroll_initiator: None,
-            semantic_phase: None,
+            state_number: Some(ch.state_number()),
+            ..ChannelStatusSnapshot::new(if shutting_down {
+                ChannelStatus::ShuttingDown
+            } else {
+                ChannelStatus::Active
+            })
         })
     }
     fn coins_of_interest(&self) -> Vec<(CoinOfInterest, CoinString)> {

--- a/src/session_phases/on_chain.rs
+++ b/src/session_phases/on_chain.rs
@@ -1936,17 +1936,11 @@ impl PeerLifecyclePhase for OnChainPhase {
             ChannelStatus::ResolvedUnrolled
         };
         Some(ChannelStatusSnapshot {
-            state,
-            session_disposition: None,
             advisory: self.advisory.clone(),
             coin: self.terminal_reward_coin.clone(),
             our_balance: Some(self.my_out_of_game_balance.clone()),
             their_balance: Some(self.their_out_of_game_balance.clone()),
-            game_allocated: None,
-            have_potato: None,
-            zero_payout: None,
-            unroll_initiator: None,
-            semantic_phase: None,
+            ..ChannelStatusSnapshot::new(state)
         })
     }
 

--- a/src/session_phases/on_chain.rs
+++ b/src/session_phases/on_chain.rs
@@ -605,13 +605,39 @@ impl OnChainPhase {
         }))
     }
 
-    fn opponent_timeout_claim_semantic(
+    fn timeout_claim_semantic(
         game_id: GameID,
         our_turn: bool,
         game_finished: bool,
+        has_claim: bool,
     ) -> Option<TimeoutClaimSemantic> {
-        (!our_turn && !game_finished)
-            .then_some(TimeoutClaimSemantic::GameOpponentTurn { id: game_id })
+        if !has_claim {
+            None
+        } else if game_finished {
+            Some(TimeoutClaimSemantic::GameFinishTimeout { id: game_id })
+        } else if !our_turn {
+            Some(TimeoutClaimSemantic::GameOpponentTurn { id: game_id })
+        } else {
+            None
+        }
+    }
+
+    fn on_chain_turn_status(our_turn: bool, game_finished: bool) -> GameStatusKind {
+        if game_finished {
+            GameStatusKind::FinishingWaitingTimeout
+        } else if our_turn {
+            GameStatusKind::OnChainMyTurn
+        } else {
+            GameStatusKind::OnChainTheirTurn
+        }
+    }
+
+    fn finishing_timeout_status(submitting: bool) -> GameStatusKind {
+        if submitting {
+            GameStatusKind::FinishingSpending
+        } else {
+            GameStatusKind::FinishingWaitingTimeout
+        }
     }
 
     pub fn timeout_claim_status(
@@ -623,7 +649,21 @@ impl OnChainPhase {
             .game_map
             .iter()
             .find(|(_, state)| state.game_id == game_id)?;
-        if state.our_turn || state.game_finished {
+        if state.game_finished {
+            return Some(GameNotification::GameStatus {
+                id: game_id,
+                status: Self::finishing_timeout_status(submitting_timeout_claim),
+                my_reward: None,
+                coin_id: Some(coin.clone()),
+                reason: None,
+                other_params: Some(GameStatusOtherParams {
+                    game_finished: Some(true),
+                    submitting_timeout_claim: Some(submitting_timeout_claim),
+                    ..Default::default()
+                }),
+            });
+        }
+        if state.our_turn {
             return None;
         }
         Some(GameNotification::GameStatus {
@@ -663,12 +703,14 @@ impl OnChainPhase {
         let mut effects = Vec::new();
         for (coin, game_id, gt, our_turn, game_finished) in coins {
             let claim = self.build_timeout_claim(env, &game_id, &coin)?;
+            let semantic =
+                Self::timeout_claim_semantic(game_id, our_turn, game_finished, claim.is_some());
             effects.push(Effect::RegisterCoin {
                 coin,
                 timeout: gt,
                 name: Some("game coin"),
                 spend: claim,
-                semantic: Self::opponent_timeout_claim_semantic(game_id, our_turn, game_finished),
+                semantic,
             });
         }
         Ok(effects)
@@ -747,7 +789,7 @@ impl OnChainPhase {
 
                     effects.push(Effect::Notify(GameNotification::GameStatus {
                         id: pending.game_id,
-                        status: GameStatusKind::OnChainTheirTurn,
+                        status: Self::on_chain_turn_status(false, game_over),
                         my_reward: None,
                         coin_id: Some(new_coin.clone()),
                         reason: None,
@@ -762,16 +804,18 @@ impl OnChainPhase {
                         }),
                     }));
                     let claim = self.build_timeout_claim(env, &pending.game_id, &new_coin)?;
+                    let semantic = Self::timeout_claim_semantic(
+                        pending.game_id,
+                        false,
+                        game_over,
+                        claim.is_some(),
+                    );
                     effects.push(Effect::RegisterCoin {
                         coin: new_coin,
                         timeout: gt,
                         name: Some("our on-chain move confirmed"),
                         spend: claim,
-                        semantic: Self::opponent_timeout_claim_semantic(
-                            pending.game_id,
-                            false,
-                            game_over,
-                        ),
+                        semantic,
                     });
                     effects.extend(self.process_queued_action(env)?);
                     return Ok(effects);
@@ -985,11 +1029,10 @@ impl OnChainPhase {
                         self.remember_current_game_coin(game_id, new_coin.clone());
                         effects.push(Effect::Notify(GameNotification::GameStatus {
                             id: old_definition.game_id,
-                            status: if !old_definition.our_turn {
-                                GameStatusKind::OnChainMyTurn
-                            } else {
-                                GameStatusKind::OnChainTheirTurn
-                            },
+                            status: Self::on_chain_turn_status(
+                                !old_definition.our_turn,
+                                old_definition.game_finished,
+                            ),
                             my_reward: None,
                             coin_id: Some(new_coin.clone()),
                             reason: None,
@@ -997,16 +1040,18 @@ impl OnChainPhase {
                         }));
                         let claim =
                             self.build_timeout_claim(env, &old_definition.game_id, &new_coin)?;
+                        let semantic = Self::timeout_claim_semantic(
+                            old_definition.game_id,
+                            !old_definition.our_turn,
+                            old_definition.game_finished,
+                            claim.is_some(),
+                        );
                         effects.push(Effect::RegisterCoin {
                             coin: new_coin,
                             timeout: gt,
                             name: Some("timeout-claim-armed game coin advanced by redo"),
                             spend: claim,
-                            semantic: Self::opponent_timeout_claim_semantic(
-                                old_definition.game_id,
-                                !old_definition.our_turn,
-                                old_definition.game_finished,
-                            ),
+                            semantic,
                         });
                     }
                 }
@@ -1146,11 +1191,7 @@ impl OnChainPhase {
 
                     effects.push(Effect::Notify(GameNotification::GameStatus {
                         id: old_definition.game_id,
-                        status: if is_my_turn {
-                            GameStatusKind::OnChainMyTurn
-                        } else {
-                            GameStatusKind::OnChainTheirTurn
-                        },
+                        status: Self::on_chain_turn_status(is_my_turn, terminal),
                         my_reward: None,
                         coin_id: Some(new_coin_id.clone()),
                         reason: None,
@@ -1160,6 +1201,12 @@ impl OnChainPhase {
                         }),
                     }));
                     let claim = self.build_timeout_claim(env, &game_id, &new_coin_id)?;
+                    let semantic = Self::timeout_claim_semantic(
+                        game_id,
+                        is_my_turn,
+                        terminal,
+                        claim.is_some(),
+                    );
                     effects.push(Effect::RegisterCoin {
                         coin: new_coin_id.clone(),
                         timeout: gt,
@@ -1169,9 +1216,7 @@ impl OnChainPhase {
                             "expected spend - their turn"
                         }),
                         spend: claim,
-                        semantic: Self::opponent_timeout_claim_semantic(
-                            game_id, is_my_turn, terminal,
-                        ),
+                        semantic,
                     });
                     if auto_settle {
                         self.game_action_queue
@@ -1299,7 +1344,7 @@ impl OnChainPhase {
 
                     effects.push(Effect::Notify(GameNotification::GameStatus {
                         id: old_definition.game_id,
-                        status: GameStatusKind::OnChainMyTurn,
+                        status: Self::on_chain_turn_status(true, terminal),
                         my_reward: None,
                         coin_id: Some(new_coin_string.clone()),
                         reason: None,
@@ -1331,12 +1376,14 @@ impl OnChainPhase {
                         }),
                     }));
                     let claim = self.build_timeout_claim(env, &game_id, &new_coin_string)?;
+                    let semantic =
+                        Self::timeout_claim_semantic(game_id, true, terminal, claim.is_some());
                     effects.push(Effect::RegisterCoin {
                         coin: new_coin_string.clone(),
                         timeout: gt,
                         name: Some("coin gives my turn"),
                         spend: claim,
-                        semantic: None,
+                        semantic,
                     });
                     if auto_settle {
                         self.game_action_queue
@@ -1676,13 +1723,14 @@ impl OnChainPhase {
                         ))
                     })?;
                 let mut effects = Vec::new();
-                if let Some(claim) = self.build_timeout_claim(env, &game_id, &current_coin)? {
+                let claim = self.build_timeout_claim(env, &game_id, &current_coin)?;
+                if let Some(claim) = claim {
                     effects.push(Effect::RegisterCoin {
                         coin: current_coin.clone(),
                         timeout: gt,
                         name: Some("timeout claim"),
                         spend: Some(claim),
-                        semantic: None,
+                        semantic: Some(TimeoutClaimSemantic::GameFinishTimeout { id: game_id }),
                     });
                 }
                 if let Some(def) = self.game_map.get_mut(&current_coin) {
@@ -1690,11 +1738,7 @@ impl OnChainPhase {
                 }
                 effects.push(Effect::Notify(GameNotification::GameStatus {
                     id: game_id,
-                    status: if my_turn == Some(true) {
-                        GameStatusKind::OnChainMyTurn
-                    } else {
-                        GameStatusKind::OnChainTheirTurn
-                    },
+                    status: GameStatusKind::FinishingWaitingTimeout,
                     my_reward: None,
                     coin_id: Some(current_coin),
                     reason: None,

--- a/src/session_phases/spend_channel_coin_phase.rs
+++ b/src/session_phases/spend_channel_coin_phase.rs
@@ -1012,6 +1012,8 @@ impl SpendChannelCoinPhase {
                 id: state.game_id,
                 status: if replaying_ids.contains(&state.game_id) {
                     GameStatusKind::Replaying
+                } else if state.game_finished {
+                    GameStatusKind::FinishingWaitingTimeout
                 } else if state.our_turn {
                     GameStatusKind::OnChainMyTurn
                 } else {

--- a/src/session_phases/spend_channel_coin_phase.rs
+++ b/src/session_phases/spend_channel_coin_phase.rs
@@ -43,11 +43,15 @@ enum SpendChannelCoinState {
     UnrollSpend {
         unroll_coin: CoinString,
         state_number: usize,
+        preempting: bool,
+        preempting_state_number: Option<usize>,
         reward_coin: Option<CoinString>,
     },
     UnrollConditions {
         unroll_coin: CoinString,
         state_number: usize,
+        preempting: bool,
+        preempting_state_number: Option<usize>,
     },
 }
 
@@ -109,7 +113,7 @@ impl SpendChannelCoinPhase {
             was_stale: false,
             terminal_reward_coin: None,
             channel_spend_started_locally: Some(true),
-            unroll_initiator: None,
+            unroll_initiator: Some(UnrollInitiator::Us),
             timeout_finish_submitted: false,
             expected_clean_shutdown_solution: None,
             last_channel_coin_spend_info,
@@ -143,7 +147,7 @@ impl SpendChannelCoinPhase {
             was_stale: false,
             terminal_reward_coin: None,
             channel_spend_started_locally: Some(false),
-            unroll_initiator: None,
+            unroll_initiator: Some(UnrollInitiator::Opponent),
             timeout_finish_submitted: false,
             expected_clean_shutdown_solution,
             last_channel_coin_spend_info: None,
@@ -235,6 +239,30 @@ impl SpendChannelCoinPhase {
             return true;
         }
         false
+    }
+
+    fn finishing_unroll_semantic_phase(&self, spending: bool) -> ChannelSemanticPhase {
+        if spending {
+            ChannelSemanticPhase::FinishingSpending
+        } else {
+            ChannelSemanticPhase::FinishingWaitingTimeout
+        }
+    }
+
+    fn channel_spend_semantic_phase(&self) -> ChannelSemanticPhase {
+        if self.expected_clean_shutdown_solution.is_some() {
+            ChannelSemanticPhase::SubmittingChannelSpend
+        } else {
+            ChannelSemanticPhase::Unrolling
+        }
+    }
+
+    fn channel_conditions_semantic_phase(&self) -> ChannelSemanticPhase {
+        if self.expected_clean_shutdown_solution.is_some() {
+            ChannelSemanticPhase::Resolving
+        } else {
+            ChannelSemanticPhase::FindingState
+        }
     }
 
     // --- Peer messages (delegated) ---
@@ -348,6 +376,11 @@ impl SpendChannelCoinPhase {
                 self.state = SpendChannelCoinState::ChannelConditions {
                     channel_coin: channel_coin.clone(),
                 };
+                // A local unroll spend is not proof it landed: the opponent can
+                // win the race. Attribution waits until the state number is known.
+                if self.channel_spend_started_locally == Some(true) {
+                    self.unroll_initiator = None;
+                }
                 effects.push(Effect::Log(format!(
                     "[spend-channel:channel-coin-spent] {}",
                     format_coin(coin_id)
@@ -358,11 +391,15 @@ impl SpendChannelCoinPhase {
             SpendChannelCoinState::UnrollSpend {
                 unroll_coin,
                 state_number,
+                preempting,
+                preempting_state_number,
                 ..
             } if coin_id == unroll_coin => {
                 self.state = SpendChannelCoinState::UnrollConditions {
                     unroll_coin: unroll_coin.clone(),
                     state_number: *state_number,
+                    preempting: *preempting,
+                    preempting_state_number: *preempting_state_number,
                 };
                 effects.push(Effect::Log(format!(
                     "[spend-channel:unroll-coin-spent] {}",
@@ -378,6 +415,8 @@ impl SpendChannelCoinPhase {
                 self.state = SpendChannelCoinState::UnrollConditions {
                     unroll_coin: unroll_coin.clone(),
                     state_number: *state_number,
+                    preempting: false,
+                    preempting_state_number: None,
                 };
                 effects.push(Effect::Log(format!(
                     "[spend-channel:unroll-coin-spent] {}",
@@ -453,6 +492,7 @@ impl SpendChannelCoinPhase {
             SpendChannelCoinState::UnrollConditions {
                 unroll_coin,
                 state_number,
+                ..
             } if *coin_id == *unroll_coin => {
                 let sn = *state_number;
                 match self.finish_on_chain_transition(env, coin_id, puzzle_and_solution, sn) {
@@ -641,12 +681,6 @@ impl SpendChannelCoinPhase {
             }
         };
 
-        // A locally queued spend is not proof that it landed: the opponent can
-        // win the race with a valid channel spend. Passive observation while we
-        // remained off-chain is the only attribution available in this model.
-        self.unroll_initiator = (self.channel_spend_started_locally == Some(false))
-            .then_some(UnrollInitiator::Opponent);
-
         {
             let ch = self.base.channel_state_mut()?;
             let cancelled_ids = ch.cancel_all_proposals();
@@ -693,6 +727,19 @@ impl SpendChannelCoinPhase {
             )?
         };
 
+        // Preemption means the landed unroll is the opponent's. Wait/finish
+        // keeps the local vs passively-observed attribution.
+        self.unroll_initiator = match &outcome {
+            UnrollOutcome::Preempted(_) => Some(UnrollInitiator::Opponent),
+            UnrollOutcome::WaitForTimeout | UnrollOutcome::Unrecoverable(_) => {
+                if self.channel_spend_started_locally == Some(false) {
+                    Some(UnrollInitiator::Opponent)
+                } else {
+                    Some(UnrollInitiator::Us)
+                }
+            }
+        };
+
         effects.push(Effect::Log(format!(
             "[unroll-started] {} state={on_chain_state}",
             format_coin(unroll_coin),
@@ -700,13 +747,20 @@ impl SpendChannelCoinPhase {
 
         match outcome {
             UnrollOutcome::Preempted(bundle) => {
+                let preempting_state_number = self
+                    .base
+                    .channel_state()
+                    .ok()
+                    .and_then(|ch| ch.preempting_state_number_for(on_chain_state));
                 effects.push(Effect::SpendTransaction(bundle, None));
                 effects.push(Effect::Log(format!(
-                    "[unroll-preempt] state={on_chain_state}",
+                    "[unroll-preempt] state={on_chain_state} preempting={preempting_state_number:?}"
                 )));
                 self.state = SpendChannelCoinState::UnrollSpend {
                     unroll_coin: unroll_coin.clone(),
                     state_number: on_chain_state,
+                    preempting: true,
+                    preempting_state_number,
                     reward_coin: None,
                 };
                 effects.push(Effect::RegisterCoin {
@@ -1178,51 +1232,90 @@ impl PeerLifecyclePhase for SpendChannelCoinPhase {
         SpendChannelCoinPhase::go_on_chain(self, env)
     }
     fn channel_status_snapshot(&self) -> Option<ChannelStatusSnapshot> {
-        let (state, coin, semantic_phase) = match &self.state {
+        struct SpendSnapshotView {
+            state: ChannelStatus,
+            coin: Option<CoinString>,
+            semantic_phase: Option<ChannelSemanticPhase>,
+            unrolling_state_number: Option<usize>,
+            preempting_state_number: Option<usize>,
+        }
+        let view = match &self.state {
             SpendChannelCoinState::ChannelSpend { channel_coin } => {
-                let s = if self.expected_clean_shutdown_solution.is_some() {
+                let state = if self.expected_clean_shutdown_solution.is_some() {
                     ChannelStatus::ShutdownTransactionPending
                 } else {
                     ChannelStatus::GoingOnChain
                 };
-                (
-                    s,
-                    Some(channel_coin.clone()),
-                    Some(ChannelSemanticPhase::SubmittingChannelSpend),
-                )
+                let unroll_target = if state == ChannelStatus::GoingOnChain {
+                    self.base
+                        .channel_state
+                        .as_ref()
+                        .and_then(|ch| ch.unroll_target_state_number())
+                } else {
+                    None
+                };
+                SpendSnapshotView {
+                    state,
+                    coin: Some(channel_coin.clone()),
+                    semantic_phase: Some(self.channel_spend_semantic_phase()),
+                    unrolling_state_number: unroll_target,
+                    preempting_state_number: None,
+                }
             }
             SpendChannelCoinState::ChannelConditions { channel_coin } => {
-                let s = if self.expected_clean_shutdown_solution.is_some() {
+                let state = if self.expected_clean_shutdown_solution.is_some() {
                     ChannelStatus::ShutdownTransactionPending
                 } else {
                     ChannelStatus::GoingOnChain
                 };
-                let phase = if self.channel_spend_started_locally == Some(false) {
-                    ChannelSemanticPhase::ResolvingOpponentChannelSpend
-                } else {
-                    ChannelSemanticPhase::Resolving
-                };
-                (s, Some(channel_coin.clone()), Some(phase))
+                SpendSnapshotView {
+                    state,
+                    coin: Some(channel_coin.clone()),
+                    semantic_phase: Some(self.channel_conditions_semantic_phase()),
+                    unrolling_state_number: None,
+                    preempting_state_number: None,
+                }
             }
-            SpendChannelCoinState::UnrollTimeoutOrSpend { unroll_coin, .. } => (
-                ChannelStatus::Unrolling,
-                Some(unroll_coin.clone()),
-                Some(if self.timeout_finish_submitted {
-                    ChannelSemanticPhase::SubmittingTimeoutFinish
+            SpendChannelCoinState::UnrollTimeoutOrSpend {
+                unroll_coin,
+                state_number,
+            } => SpendSnapshotView {
+                state: ChannelStatus::Unrolling,
+                coin: Some(unroll_coin.clone()),
+                semantic_phase: Some(
+                    self.finishing_unroll_semantic_phase(self.timeout_finish_submitted),
+                ),
+                unrolling_state_number: Some(*state_number),
+                preempting_state_number: None,
+            },
+            SpendChannelCoinState::UnrollSpend {
+                unroll_coin,
+                state_number,
+                preempting_state_number,
+                ..
+            } => SpendSnapshotView {
+                state: ChannelStatus::Unrolling,
+                coin: Some(unroll_coin.clone()),
+                semantic_phase: Some(ChannelSemanticPhase::Preempting),
+                unrolling_state_number: Some(*state_number),
+                preempting_state_number: *preempting_state_number,
+            },
+            SpendChannelCoinState::UnrollConditions {
+                unroll_coin,
+                state_number,
+                preempting,
+                preempting_state_number,
+            } => SpendSnapshotView {
+                state: ChannelStatus::Unrolling,
+                coin: Some(unroll_coin.clone()),
+                semantic_phase: Some(if *preempting {
+                    ChannelSemanticPhase::Preempting
                 } else {
-                    ChannelSemanticPhase::WaitingTimeout
+                    self.finishing_unroll_semantic_phase(true)
                 }),
-            ),
-            SpendChannelCoinState::UnrollSpend { unroll_coin, .. } => (
-                ChannelStatus::Unrolling,
-                Some(unroll_coin.clone()),
-                Some(ChannelSemanticPhase::Preempting),
-            ),
-            SpendChannelCoinState::UnrollConditions { unroll_coin, .. } => (
-                ChannelStatus::Unrolling,
-                Some(unroll_coin.clone()),
-                Some(ChannelSemanticPhase::Resolving),
-            ),
+                unrolling_state_number: Some(*state_number),
+                preempting_state_number: *preempting_state_number,
+            },
         };
         let (our_balance, their_balance, game_allocated) =
             if let Some(ch) = self.base.channel_state.as_ref() {
@@ -1234,24 +1327,25 @@ impl PeerLifecyclePhase for SpendChannelCoinPhase {
             } else {
                 (None, None, None)
             };
-        let zero_payout = (state == ChannelStatus::ShutdownTransactionPending).then(|| {
+        let zero_payout = (view.state == ChannelStatus::ShutdownTransactionPending).then(|| {
             self.base
                 .channel_state
                 .as_ref()
                 .is_some_and(|ch| ch.has_zero_payout())
         });
         Some(ChannelStatusSnapshot {
-            state,
-            session_disposition: None,
             advisory: self.advisory.clone(),
-            coin,
+            coin: view.coin,
             our_balance,
             their_balance,
             game_allocated,
-            have_potato: None,
             zero_payout,
             unroll_initiator: self.unroll_initiator,
-            semantic_phase,
+            semantic_phase: view.semantic_phase,
+            state_number: self.base.channel_state.as_ref().map(|ch| ch.state_number()),
+            unrolling_state_number: view.unrolling_state_number,
+            preempting_state_number: view.preempting_state_number,
+            ..ChannelStatusSnapshot::new(view.state)
         })
     }
     fn coins_of_interest(&self) -> Vec<(CoinOfInterest, CoinString)> {
@@ -1337,12 +1431,14 @@ mod tests {
         assert_eq!(snapshot.unroll_initiator, None);
         assert_eq!(
             snapshot.semantic_phase,
-            Some(ChannelSemanticPhase::WaitingTimeout)
+            Some(ChannelSemanticPhase::FinishingWaitingTimeout)
         );
+        assert_eq!(snapshot.unrolling_state_number, Some(1));
+        assert_eq!(snapshot.preempting_state_number, None);
     }
 
     #[test]
-    fn passive_channel_spend_snapshot_reports_resolution_without_attribution() {
+    fn passive_channel_spend_snapshot_attributes_the_opponent() {
         let phase = SpendChannelCoinPhase::new_at_channel_conditions(
             None,
             test_coin(),
@@ -1354,15 +1450,15 @@ mod tests {
         );
 
         let snapshot = phase.channel_status_snapshot().expect("snapshot");
-        assert_eq!(snapshot.unroll_initiator, None);
+        assert_eq!(snapshot.unroll_initiator, Some(UnrollInitiator::Opponent));
         assert_eq!(
             snapshot.semantic_phase,
-            Some(ChannelSemanticPhase::ResolvingOpponentChannelSpend)
+            Some(ChannelSemanticPhase::FindingState)
         );
     }
 
     #[test]
-    fn locally_started_or_clean_shutdown_channel_spends_remain_unattributed() {
+    fn local_unroll_is_attributed_to_us_and_clean_shutdown_stays_unattributed() {
         let locally_started = SpendChannelCoinPhase::new(
             None,
             test_coin(),
@@ -1377,7 +1473,7 @@ mod tests {
                 .channel_status_snapshot()
                 .unwrap()
                 .unroll_initiator,
-            None
+            Some(UnrollInitiator::Us)
         );
 
         let clean_shutdown = SpendChannelCoinPhase::new_for_clean_shutdown(
@@ -1390,12 +1486,11 @@ mod tests {
             Timeout::new(5),
             None,
         );
+        let clean_shutdown_snapshot = clean_shutdown.channel_status_snapshot().unwrap();
+        assert_eq!(clean_shutdown_snapshot.unroll_initiator, None);
         assert_eq!(
-            clean_shutdown
-                .channel_status_snapshot()
-                .unwrap()
-                .unroll_initiator,
-            None
+            clean_shutdown_snapshot.semantic_phase,
+            Some(ChannelSemanticPhase::SubmittingChannelSpend)
         );
     }
 
@@ -1412,7 +1507,11 @@ mod tests {
         );
         assert_eq!(
             phase.channel_status_snapshot().unwrap().semantic_phase,
-            Some(ChannelSemanticPhase::SubmittingChannelSpend)
+            Some(ChannelSemanticPhase::Unrolling)
+        );
+        assert_eq!(
+            phase.channel_status_snapshot().unwrap().unroll_initiator,
+            Some(UnrollInitiator::Us)
         );
 
         let mut allocator = AllocEncoder::new();
@@ -1420,10 +1519,12 @@ mod tests {
         phase
             .coin_spent(&mut env, &test_coin())
             .expect("observe channel spend");
+        let after_spend = phase.channel_status_snapshot().unwrap();
         assert_eq!(
-            phase.channel_status_snapshot().unwrap().semantic_phase,
-            Some(ChannelSemanticPhase::Resolving)
+            after_spend.semantic_phase,
+            Some(ChannelSemanticPhase::FindingState)
         );
+        assert_eq!(after_spend.unroll_initiator, None);
 
         phase.state = SpendChannelCoinState::UnrollTimeoutOrSpend {
             unroll_coin: test_coin(),
@@ -1431,7 +1532,7 @@ mod tests {
         };
         assert_eq!(
             phase.channel_status_snapshot().unwrap().semantic_phase,
-            Some(ChannelSemanticPhase::WaitingTimeout)
+            Some(ChannelSemanticPhase::FinishingWaitingTimeout)
         );
     }
 
@@ -1457,12 +1558,55 @@ mod tests {
         assert!(phase.timeout_claim_submitted(TimeoutClaimSemantic::ChannelTimeoutFinish));
         assert_eq!(
             phase.channel_status_snapshot().unwrap().semantic_phase,
-            Some(ChannelSemanticPhase::SubmittingTimeoutFinish)
+            Some(ChannelSemanticPhase::FinishingSpending)
         );
         assert!(phase.timeout_claim_rearmed(TimeoutClaimSemantic::ChannelTimeoutFinish));
         assert_eq!(
             phase.channel_status_snapshot().unwrap().semantic_phase,
-            Some(ChannelSemanticPhase::WaitingTimeout)
+            Some(ChannelSemanticPhase::FinishingWaitingTimeout)
+        );
+    }
+
+    #[test]
+    fn unroll_conditions_classify_preempt_versus_finish() {
+        let mut phase = SpendChannelCoinPhase {
+            state: SpendChannelCoinState::UnrollConditions {
+                unroll_coin: test_coin(),
+                state_number: 2,
+                preempting: true,
+                preempting_state_number: Some(5),
+            },
+            base: legacy_base(),
+            advisory: None,
+            was_stale: false,
+            terminal_reward_coin: None,
+            channel_spend_started_locally: Some(true),
+            unroll_initiator: Some(UnrollInitiator::Us),
+            timeout_finish_submitted: false,
+            expected_clean_shutdown_solution: None,
+            last_channel_coin_spend_info: None,
+            replacement: None,
+        };
+        assert_eq!(
+            phase.channel_status_snapshot().unwrap().semantic_phase,
+            Some(ChannelSemanticPhase::Preempting)
+        );
+
+        phase.state = SpendChannelCoinState::UnrollConditions {
+            unroll_coin: test_coin(),
+            state_number: 2,
+            preempting: false,
+            preempting_state_number: None,
+        };
+        assert_eq!(
+            phase.channel_status_snapshot().unwrap().semantic_phase,
+            Some(ChannelSemanticPhase::FinishingSpending)
+        );
+
+        phase.unroll_initiator = Some(UnrollInitiator::Opponent);
+        assert_eq!(
+            phase.channel_status_snapshot().unwrap().semantic_phase,
+            Some(ChannelSemanticPhase::FinishingSpending)
         );
     }
 }

--- a/src/session_phases/spend_channel_coin_phase.rs
+++ b/src/session_phases/spend_channel_coin_phase.rs
@@ -43,7 +43,6 @@ enum SpendChannelCoinState {
     UnrollSpend {
         unroll_coin: CoinString,
         state_number: usize,
-        preempting: bool,
         preempting_state_number: Option<usize>,
         reward_coin: Option<CoinString>,
     },
@@ -63,10 +62,6 @@ pub struct SpendChannelCoinPhase {
     advisory: Option<String>,
     was_stale: bool,
     terminal_reward_coin: Option<CoinString>,
-    /// The submitter is deliberately not exposed until the channel spend has
-    /// been observed and classified as an unroll.
-    #[serde(default)]
-    channel_spend_started_locally: Option<bool>,
     #[serde(default)]
     unroll_initiator: Option<UnrollInitiator>,
     #[serde(default)]
@@ -112,7 +107,6 @@ impl SpendChannelCoinPhase {
             advisory: None,
             was_stale: false,
             terminal_reward_coin: None,
-            channel_spend_started_locally: Some(true),
             unroll_initiator: Some(UnrollInitiator::Us),
             timeout_finish_submitted: false,
             expected_clean_shutdown_solution: None,
@@ -146,7 +140,6 @@ impl SpendChannelCoinPhase {
             advisory: None,
             was_stale: false,
             terminal_reward_coin: None,
-            channel_spend_started_locally: Some(false),
             unroll_initiator: Some(UnrollInitiator::Opponent),
             timeout_finish_submitted: false,
             expected_clean_shutdown_solution,
@@ -181,7 +174,6 @@ impl SpendChannelCoinPhase {
             advisory: None,
             was_stale: false,
             terminal_reward_coin: None,
-            channel_spend_started_locally: None,
             unroll_initiator: None,
             timeout_finish_submitted: false,
             expected_clean_shutdown_solution: Some(clean_shutdown_solution),
@@ -249,19 +241,20 @@ impl SpendChannelCoinPhase {
         }
     }
 
-    fn channel_spend_semantic_phase(&self) -> ChannelSemanticPhase {
+    fn channel_watch_status(&self) -> ChannelStatus {
         if self.expected_clean_shutdown_solution.is_some() {
-            ChannelSemanticPhase::SubmittingChannelSpend
+            ChannelStatus::ShutdownTransactionPending
         } else {
-            ChannelSemanticPhase::Unrolling
+            ChannelStatus::GoingOnChain
         }
     }
 
-    fn channel_conditions_semantic_phase(&self) -> ChannelSemanticPhase {
-        if self.expected_clean_shutdown_solution.is_some() {
-            ChannelSemanticPhase::Resolving
-        } else {
-            ChannelSemanticPhase::FindingState
+    fn channel_watch_phase(&self, finding: bool) -> ChannelSemanticPhase {
+        match (self.expected_clean_shutdown_solution.is_some(), finding) {
+            (true, false) => ChannelSemanticPhase::SubmittingChannelSpend,
+            (true, true) => ChannelSemanticPhase::Resolving,
+            (false, false) => ChannelSemanticPhase::Unrolling,
+            (false, true) => ChannelSemanticPhase::FindingState,
         }
     }
 
@@ -376,11 +369,6 @@ impl SpendChannelCoinPhase {
                 self.state = SpendChannelCoinState::ChannelConditions {
                     channel_coin: channel_coin.clone(),
                 };
-                // A local unroll spend is not proof it landed: the opponent can
-                // win the race. Attribution waits until the state number is known.
-                if self.channel_spend_started_locally == Some(true) {
-                    self.unroll_initiator = None;
-                }
                 effects.push(Effect::Log(format!(
                     "[spend-channel:channel-coin-spent] {}",
                     format_coin(coin_id)
@@ -391,14 +379,13 @@ impl SpendChannelCoinPhase {
             SpendChannelCoinState::UnrollSpend {
                 unroll_coin,
                 state_number,
-                preempting,
                 preempting_state_number,
                 ..
             } if coin_id == unroll_coin => {
                 self.state = SpendChannelCoinState::UnrollConditions {
                     unroll_coin: unroll_coin.clone(),
                     state_number: *state_number,
-                    preempting: *preempting,
+                    preempting: true,
                     preempting_state_number: *preempting_state_number,
                 };
                 effects.push(Effect::Log(format!(
@@ -727,18 +714,10 @@ impl SpendChannelCoinPhase {
             )?
         };
 
-        // Preemption means the landed unroll is the opponent's. Wait/finish
-        // keeps the local vs passively-observed attribution.
-        self.unroll_initiator = match &outcome {
-            UnrollOutcome::Preempted(_) => Some(UnrollInitiator::Opponent),
-            UnrollOutcome::WaitForTimeout | UnrollOutcome::Unrecoverable(_) => {
-                if self.channel_spend_started_locally == Some(false) {
-                    Some(UnrollInitiator::Opponent)
-                } else {
-                    Some(UnrollInitiator::Us)
-                }
-            }
-        };
+        // Preemption is the opponent's unroll. Other outcomes keep constructor attribution.
+        if matches!(outcome, UnrollOutcome::Preempted(_)) {
+            self.unroll_initiator = Some(UnrollInitiator::Opponent);
+        }
 
         effects.push(Effect::Log(format!(
             "[unroll-started] {} state={on_chain_state}",
@@ -759,7 +738,6 @@ impl SpendChannelCoinPhase {
                 self.state = SpendChannelCoinState::UnrollSpend {
                     unroll_coin: unroll_coin.clone(),
                     state_number: on_chain_state,
-                    preempting: true,
                     preempting_state_number,
                     reward_coin: None,
                 };
@@ -1243,41 +1221,30 @@ impl PeerLifecyclePhase for SpendChannelCoinPhase {
         }
         let view = match &self.state {
             SpendChannelCoinState::ChannelSpend { channel_coin } => {
-                let state = if self.expected_clean_shutdown_solution.is_some() {
-                    ChannelStatus::ShutdownTransactionPending
-                } else {
-                    ChannelStatus::GoingOnChain
-                };
-                let unroll_target = if state == ChannelStatus::GoingOnChain {
-                    self.base
-                        .channel_state
-                        .as_ref()
-                        .and_then(|ch| ch.unroll_target_state_number())
-                } else {
-                    None
-                };
+                let state = self.channel_watch_status();
+                let unrolling_state_number = (state == ChannelStatus::GoingOnChain)
+                    .then(|| {
+                        self.base
+                            .channel_state
+                            .as_ref()
+                            .and_then(|ch| ch.unroll_target_state_number())
+                    })
+                    .flatten();
                 SpendSnapshotView {
                     state,
                     coin: Some(channel_coin.clone()),
-                    semantic_phase: Some(self.channel_spend_semantic_phase()),
-                    unrolling_state_number: unroll_target,
+                    semantic_phase: Some(self.channel_watch_phase(false)),
+                    unrolling_state_number,
                     preempting_state_number: None,
                 }
             }
-            SpendChannelCoinState::ChannelConditions { channel_coin } => {
-                let state = if self.expected_clean_shutdown_solution.is_some() {
-                    ChannelStatus::ShutdownTransactionPending
-                } else {
-                    ChannelStatus::GoingOnChain
-                };
-                SpendSnapshotView {
-                    state,
-                    coin: Some(channel_coin.clone()),
-                    semantic_phase: Some(self.channel_conditions_semantic_phase()),
-                    unrolling_state_number: None,
-                    preempting_state_number: None,
-                }
-            }
+            SpendChannelCoinState::ChannelConditions { channel_coin } => SpendSnapshotView {
+                state: self.channel_watch_status(),
+                coin: Some(channel_coin.clone()),
+                semantic_phase: Some(self.channel_watch_phase(true)),
+                unrolling_state_number: None,
+                preempting_state_number: None,
+            },
             SpendChannelCoinState::UnrollTimeoutOrSpend {
                 unroll_coin,
                 state_number,
@@ -1526,7 +1493,7 @@ mod tests {
             after_spend.semantic_phase,
             Some(ChannelSemanticPhase::FindingState)
         );
-        assert_eq!(after_spend.unroll_initiator, None);
+        assert_eq!(after_spend.unroll_initiator, Some(UnrollInitiator::Us));
 
         phase.state = SpendChannelCoinState::UnrollTimeoutOrSpend {
             unroll_coin: test_coin(),
@@ -1549,7 +1516,6 @@ mod tests {
             advisory: None,
             was_stale: false,
             terminal_reward_coin: None,
-            channel_spend_started_locally: Some(false),
             unroll_initiator: Some(UnrollInitiator::Opponent),
             timeout_finish_submitted: false,
             expected_clean_shutdown_solution: None,
@@ -1582,7 +1548,6 @@ mod tests {
             advisory: None,
             was_stale: false,
             terminal_reward_coin: None,
-            channel_spend_started_locally: Some(true),
             unroll_initiator: Some(UnrollInitiator::Us),
             timeout_finish_submitted: false,
             expected_clean_shutdown_solution: None,

--- a/src/simulator/tests/session_phases_sim.rs
+++ b/src/simulator/tests/session_phases_sim.rs
@@ -5056,9 +5056,8 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             SimScriptAction::AcceptProposal(1, GameID(1)),
             // Let the handshake + empty potato exchanges settle.
             SimScriptAction::WaitBlocks(5, 0),
-            // Corrupt player 1: pretend we're at state 0.
-            // This wipes stored unroll/timeout so the real on-chain
-            // state number will be "from the future" AND unmatchable.
+            // Corrupt player 1: pretend we're at state 0 and wipe stored
+            // unroll records so the real on-chain unroll is one we never signed.
             SimScriptAction::CorruptStateNumber(1, 0),
             // Player 0 goes on chain normally (real state number).
             SimScriptAction::GoOnChain(0),
@@ -5088,7 +5087,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                     ..
                 })
             )),
-            "player 1 should get ChannelError for state-from-the-future, got: {p1_notifs:?}"
+            "player 1 should get ChannelError for an unroll they never signed, got: {p1_notifs:?}"
         );
         let channel_error_idx = p1_notifs
             .iter()

--- a/src/simulator/tests/session_phases_sim.rs
+++ b/src/simulator/tests/session_phases_sim.rs
@@ -17,8 +17,8 @@ use crate::common::types::{
 };
 use crate::game_session::{GameSession, GameSessionConfig, MessagePeerQueue, MessagePipe};
 use crate::session_phases::effects::{
-    CancelReason, ChannelStatus, GameNotification, GameSessionEvent, GameStatusKind,
-    SettlementOutcome, UnrollInitiator,
+    CancelReason, ChannelStatus, ChannelStatusSnapshot, GameNotification, GameSessionEvent,
+    GameStatusKind, SettlementOutcome, UnrollInitiator,
 };
 use crate::session_phases::game_collection;
 use crate::session_phases::handshake::CoinSpendRequest;
@@ -225,7 +225,7 @@ impl ToLocalUI for SimulatedPeer {
                 }
                 Ok(())
             }
-            GameNotification::ChannelStatus { state, .. } => {
+            GameNotification::ChannelStatus(ChannelStatusSnapshot { state, .. }) => {
                 use crate::session_phases::effects::ChannelStatus;
                 match state {
                     ChannelStatus::GoingOnChain
@@ -477,10 +477,10 @@ fn event_matches(actual: &TestEvent, expected: &ExpectedEvent) -> bool {
                     ExpectedNotification::InsufficientBalance,
                 ) => true,
                 (
-                    GameNotification::ChannelStatus {
+                    GameNotification::ChannelStatus(ChannelStatusSnapshot {
                         state: actual_state,
                         ..
-                    },
+                    }),
                     ExpectedNotification::ChannelStatus(expected_state),
                 ) => actual_state == expected_state,
                 _ => false,
@@ -515,7 +515,7 @@ fn event_shape(actual: &TestEvent) -> String {
             GameNotification::InsufficientBalance { id, our_balance_short, their_balance_short } => format!("Notif(InsufficientBalance(id={id:?},ours={our_balance_short},theirs={their_balance_short}))"),
             GameNotification::ActionFailed { reason, .. } => format!("Notif(ActionFailed(reason={reason}))"),
             GameNotification::MoveRejected { id, tag, message } => format!("Notif(MoveRejected(id={id:?},tag={tag},message={message}))"),
-            GameNotification::ChannelStatus { state, .. } => format!("Notif(ChannelStatus(state={state:?}))"),
+            GameNotification::ChannelStatus(ChannelStatusSnapshot { state, .. }) => format!("Notif(ChannelStatus(state={state:?}))"),
         },
     }
 }
@@ -700,10 +700,10 @@ impl LocalTestUIReceiver {
 impl ToLocalUI for LocalTestUIReceiver {
     fn notification(&mut self, notification: &GameNotification) -> Result<(), Error> {
         match notification {
-            GameNotification::ChannelStatus {
+            GameNotification::ChannelStatus(ChannelStatusSnapshot {
                 state: ChannelStatus::Active,
                 ..
-            } => {
+            }) => {
                 self.channel_created = true;
             }
             GameNotification::GameStatus {
@@ -802,7 +802,7 @@ impl ToLocalUI for LocalTestUIReceiver {
                 self.events
                     .push(TestEvent::Notification(notification.clone()));
             }
-            GameNotification::ChannelStatus { state, .. } => {
+            GameNotification::ChannelStatus(ChannelStatusSnapshot { state, .. }) => {
                 if matches!(state, ChannelStatus::Active) {
                     self.channel_created = true;
                 }
@@ -1008,10 +1008,10 @@ fn run_game_container_with_action_list_with_success_predicate(
         let channel_failed = lui.notifications.iter().any(|n| {
             matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Failed,
                     ..
-                }
+                })
             )
         });
         assert!(
@@ -1196,10 +1196,10 @@ fn run_game_container_with_action_list_with_success_predicate(
         let first_unrolling_idx = lui.notifications.iter().position(|n| {
             matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Unrolling,
                     ..
-                }
+                })
             )
         });
         let Some(unroll_idx) = first_unrolling_idx else {
@@ -1280,7 +1280,7 @@ fn run_game_container_with_action_list_with_success_predicate(
     for (i, lui) in local_uis.iter().enumerate() {
         let mut last_state: Option<ChannelStatus> = None;
         for n in &lui.notifications {
-            if let GameNotification::ChannelStatus { state, .. } = n {
+            if let GameNotification::ChannelStatus(ChannelStatusSnapshot { state, .. }) = n {
                 let ord = channel_state_ordinal(state);
                 if let Some(ref prev) = last_state {
                     let prev_ord = channel_state_ordinal(prev);
@@ -2059,10 +2059,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             let has_failed = outcome.local_uis[i].notifications.iter().any(|n| {
                 matches!(
                     n,
-                    GameNotification::ChannelStatus {
+                    GameNotification::ChannelStatus(ChannelStatusSnapshot {
                         state: ChannelStatus::Failed,
                         ..
-                    }
+                    })
                 )
             });
             assert!(
@@ -2095,10 +2095,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             let has_failed = outcome.local_uis[i].notifications.iter().any(|n| {
                 matches!(
                     n,
-                    GameNotification::ChannelStatus {
+                    GameNotification::ChannelStatus(ChannelStatusSnapshot {
                         state: ChannelStatus::Failed,
                         ..
-                    }
+                    })
                 )
             });
             assert!(
@@ -3306,20 +3306,20 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
         assert!(
             p1_notifs.iter().any(|n| matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Unrolling,
                     ..
-                }
+                })
             )),
             "player 1 should see Unrolling channel status, got: {p1_notifs:?}"
         );
         assert!(
             p0_notifs.iter().any(|n| matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Unrolling,
                     ..
-                }
+                })
             )),
             "player 0 should see Unrolling channel status, got: {p0_notifs:?}"
         );
@@ -3381,20 +3381,20 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
         assert!(
             p1_notifs.iter().any(|n| matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Unrolling,
                     ..
-                }
+                })
             )),
             "player 1 should see Unrolling channel status, got: {p1_notifs:?}"
         );
         assert!(
             p0_notifs.iter().any(|n| matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Unrolling,
                     ..
-                }
+                })
             )),
             "player 0 should see Unrolling channel status, got: {p0_notifs:?}"
         );
@@ -3560,10 +3560,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 .position(|event| {
                     matches!(
                         event,
-                        TestEvent::Notification(GameNotification::ChannelStatus {
+                        TestEvent::Notification(GameNotification::ChannelStatus(ChannelStatusSnapshot {
                             state: ChannelStatus::ResolvedUnrolled,
                             ..
-                        })
+                        }))
                     )
                 })
                 .expect("alice should observe the unroll resolution");
@@ -4748,7 +4748,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 p0_notifs
                     .iter()
                     .any(|n| has_status(n, GameStatusKind::EndedError))
-                || p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus { state: ChannelStatus::Failed, .. })),
+                || p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus(ChannelStatusSnapshot { state: ChannelStatus::Failed, .. }))),
                 "player 0 should get GameError or ChannelError when coin is force-destroyed, got: {p0_notifs:?}"
             );
 
@@ -4822,19 +4822,19 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             );
             assert!(outcome.local_uis[0].notifications.iter().any(|notification| matches!(
                 notification,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Unrolling,
                     unroll_initiator: Some(UnrollInitiator::Opponent),
                     ..
-                }
+                })
             )));
             assert!(outcome.local_uis[1].notifications.iter().any(|notification| matches!(
                 notification,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Unrolling,
-                    unroll_initiator: None,
+                    unroll_initiator: Some(UnrollInitiator::Us),
                     ..
-                }
+                })
             )));
 
             assert_event_sequence(&outcome.local_uis[0].events, &[
@@ -5069,10 +5069,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
         assert!(
             p1_notifs.iter().any(|n| matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Failed,
                     ..
-                }
+                })
             )),
             "player 1 should get ChannelError for state-from-the-future, got: {p1_notifs:?}"
         );
@@ -5081,10 +5081,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             .position(|n| {
                 matches!(
                     n,
-                    GameNotification::ChannelStatus {
+                    GameNotification::ChannelStatus(ChannelStatusSnapshot {
                         state: ChannelStatus::Failed,
                         ..
-                    }
+                    })
                 )
             })
             .unwrap();
@@ -5163,10 +5163,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
         assert!(
             p1_notifs.iter().any(|n| matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Failed,
                     ..
-                }
+                })
             )),
             "player 1 should get ChannelError for wrong-parity old state, got: {p1_notifs:?}"
         );
@@ -5175,10 +5175,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             .position(|n| {
                 matches!(
                     n,
-                    GameNotification::ChannelStatus {
+                    GameNotification::ChannelStatus(ChannelStatusSnapshot {
                         state: ChannelStatus::Failed,
                         ..
-                    }
+                    })
                 )
             })
             .unwrap();
@@ -5260,10 +5260,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 assert!(
                     !matches!(
                         n,
-                        GameNotification::ChannelStatus {
+                        GameNotification::ChannelStatus(ChannelStatusSnapshot {
                             state: ChannelStatus::Failed,
                             ..
-                        }
+                        })
                     ),
                     "player {i} should not get ChannelError, got: {n:?}"
                 );
@@ -5373,10 +5373,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             !p1_notifs.iter().any(|n| {
                 matches!(
                     n,
-                    GameNotification::ChannelStatus {
+                    GameNotification::ChannelStatus(ChannelStatusSnapshot {
                         state: ChannelStatus::Failed,
                         ..
-                    }
+                    })
                 )
             }),
             "Bob should not fail when proposal arrives before channel coin report, got: {p1_notifs:?}"
@@ -5860,7 +5860,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
 
         let p0_notifs = &outcome.local_uis[0].notifications;
         assert!(
-            p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus { state: ChannelStatus::ResolvedStale, .. })),
+            p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus(ChannelStatusSnapshot { state: ChannelStatus::ResolvedStale, .. }))),
             "player 0 should see ResolvedStale, got: {p0_notifs:?}"
         );
         // The accept round-tripped, so the second game is fully live (not a
@@ -5874,7 +5874,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             "player 0 should get exactly one GameError for the fully-live second game, got: {game_errors:?}, all: {p0_notifs:?}"
         );
         assert!(
-            !p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus { state: ChannelStatus::Failed, .. })),
+            !p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus(ChannelStatusSnapshot { state: ChannelStatus::Failed, .. }))),
             "player 0 should NOT get ChannelError, got: {p0_notifs:?}"
         );
     }));
@@ -5945,7 +5945,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
 
         let p0_notifs = &outcome.local_uis[0].notifications;
         assert!(
-            p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus { state: ChannelStatus::ResolvedStale, .. })),
+            p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus(ChannelStatusSnapshot { state: ChannelStatus::ResolvedStale, .. }))),
             "player 0 should see ResolvedStale, got: {p0_notifs:?}"
         );
         // The redo recovers the first game, but the second game's accept
@@ -5959,7 +5959,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             "player 0 should get exactly one GameError for the fully-live second game, got: {game_errors:?}, all: {p0_notifs:?}"
         );
         assert!(
-            !p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus { state: ChannelStatus::Failed, .. })),
+            !p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus(ChannelStatusSnapshot { state: ChannelStatus::Failed, .. }))),
             "player 0 should NOT get ChannelError, got: {p0_notifs:?}"
         );
     }));
@@ -6043,10 +6043,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
         assert!(
             p0_notifs.iter().any(|n| matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::ResolvedStale,
                     ..
-                }
+                })
             )),
             "player 0 should see ResolvedStale, got: {p0_notifs:?}"
         );
@@ -6063,10 +6063,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
         assert!(
             !p0_notifs.iter().any(|n| matches!(
                 n,
-                GameNotification::ChannelStatus {
+                GameNotification::ChannelStatus(ChannelStatusSnapshot {
                     state: ChannelStatus::Failed,
                     ..
-                }
+                })
             )),
             "player 0 should NOT get ChannelError, got: {p0_notifs:?}"
         );
@@ -6134,7 +6134,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
 
         let p0_notifs = &outcome.local_uis[0].notifications;
         assert!(
-            p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus { state: ChannelStatus::ResolvedStale, .. })),
+            p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus(ChannelStatusSnapshot { state: ChannelStatus::ResolvedStale, .. }))),
             "player 0 should see ResolvedStale, got: {p0_notifs:?}"
         );
         // The second game (fully live, round-tripped) is absent → GameError.
@@ -6156,7 +6156,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             "player 0 should get exactly one EndedCancelled for the in-flight accept, got: {game_cancels:?}, all: {p0_notifs:?}"
         );
         assert!(
-            !p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus { state: ChannelStatus::Failed, .. })),
+            !p0_notifs.iter().any(|n| matches!(n, GameNotification::ChannelStatus(ChannelStatusSnapshot { state: ChannelStatus::Failed, .. }))),
             "player 0 should NOT get ChannelError, got: {p0_notifs:?}"
         );
     }));
@@ -6693,10 +6693,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             let has_failed = outcome.local_uis[i].notifications.iter().any(|n| {
                 matches!(
                     n,
-                    GameNotification::ChannelStatus {
+                    GameNotification::ChannelStatus(ChannelStatusSnapshot {
                         state: ChannelStatus::Failed,
                         ..
-                    }
+                    })
                 )
             });
             assert!(
@@ -6733,10 +6733,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 let has_failed = outcome.local_uis[i].notifications.iter().any(|n| {
                     matches!(
                         n,
-                        GameNotification::ChannelStatus {
+                        GameNotification::ChannelStatus(ChannelStatusSnapshot {
                             state: ChannelStatus::Failed,
                             ..
-                        }
+                        })
                     )
                 });
                 assert!(
@@ -6774,10 +6774,10 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
                 let has_failed = outcome.local_uis[i].notifications.iter().any(|n| {
                     matches!(
                         n,
-                        GameNotification::ChannelStatus {
+                        GameNotification::ChannelStatus(ChannelStatusSnapshot {
                             state: ChannelStatus::Failed,
                             ..
-                        }
+                        })
                     )
                 });
                 assert!(

--- a/src/simulator/tests/session_phases_sim.rs
+++ b/src/simulator/tests/session_phases_sim.rs
@@ -425,7 +425,8 @@ fn event_matches(actual: &TestEvent, expected: &ExpectedEvent) -> bool {
                 ) => true,
                 (
                     GameNotification::GameStatus {
-                        status: GameStatusKind::OnChainTheirTurn,
+                        status:
+                            GameStatusKind::OnChainTheirTurn | GameStatusKind::FinishingWaitingTimeout,
                         other_params: Some(params),
                         ..
                     },
@@ -443,7 +444,9 @@ fn event_matches(actual: &TestEvent, expected: &ExpectedEvent) -> bool {
                         status:
                             GameStatusKind::OnChainMyTurn
                             | GameStatusKind::OnChainTheirTurn
-                            | GameStatusKind::Replaying,
+                            | GameStatusKind::Replaying
+                            | GameStatusKind::FinishingWaitingTimeout
+                            | GameStatusKind::FinishingSpending,
                         ..
                     },
                     ExpectedNotification::GameStatusOnChainTurn,
@@ -496,7 +499,10 @@ fn event_shape(actual: &TestEvent) -> String {
         TestEvent::GameMessage { .. } => "GameMessage".to_string(),
         TestEvent::Notification(n) => match n {
             GameNotification::GameStatus { id, status, other_params, .. } => {
-                if matches!(status, GameStatusKind::OnChainTheirTurn)
+                if matches!(
+                    status,
+                    GameStatusKind::OnChainTheirTurn | GameStatusKind::FinishingWaitingTimeout
+                )
                     && other_params
                         .as_ref()
                         .and_then(|p| p.moved_by_us)
@@ -757,15 +763,19 @@ impl ToLocalUI for LocalTestUIReceiver {
                         | GameStatusKind::Replaying
                         | GameStatusKind::PlayingMove
                         | GameStatusKind::IllegalMoveDetected
+                        | GameStatusKind::FinishingWaitingTimeout
+                        | GameStatusKind::FinishingSpending
                 ) {
                     self.events
                         .push(TestEvent::Notification(notification.clone()));
                 }
-                if matches!(status, GameStatusKind::OnChainTheirTurn)
-                    && other_params
-                        .as_ref()
-                        .and_then(|p| p.moved_by_us)
-                        .unwrap_or(false)
+                if matches!(
+                    status,
+                    GameStatusKind::OnChainTheirTurn | GameStatusKind::FinishingWaitingTimeout
+                ) && other_params
+                    .as_ref()
+                    .and_then(|p| p.moved_by_us)
+                    .unwrap_or(false)
                 {
                     // Preserve event-count parity for tests expecting a separate GameStatusMovedByUs signal.
                     self.events
@@ -1166,6 +1176,8 @@ fn run_game_container_with_action_list_with_success_predicate(
                     GameStatusKind::OnChainMyTurn
                         | GameStatusKind::OnChainTheirTurn
                         | GameStatusKind::Replaying
+                        | GameStatusKind::FinishingWaitingTimeout
+                        | GameStatusKind::FinishingSpending
                 ) {
                     continue;
                 }
@@ -1188,6 +1200,8 @@ fn run_game_container_with_action_list_with_success_predicate(
             GameStatusKind::OnChainMyTurn
                 | GameStatusKind::OnChainTheirTurn
                 | GameStatusKind::Replaying
+                | GameStatusKind::FinishingWaitingTimeout
+                | GameStatusKind::FinishingSpending
                 | GameStatusKind::EndedCancelled
                 | GameStatusKind::EndedError
         )
@@ -6478,7 +6492,7 @@ pub fn test_funs() -> Vec<(&'static str, &'static (dyn Fn() + Send + Sync))> {
             p0_notifs.iter().any(|n| matches!(
                 n,
                 GameNotification::GameStatus {
-                    status: GameStatusKind::OnChainTheirTurn,
+                    status: GameStatusKind::FinishingWaitingTimeout,
                     other_params: Some(params),
                     ..
                 } if params.moved_by_us == Some(true)

--- a/src/simulator/tests/session_phases_sim/harness.rs
+++ b/src/simulator/tests/session_phases_sim/harness.rs
@@ -777,19 +777,12 @@ impl SimulationHarness {
                     }
                     GameSessionEvent::ReceiveError(error) => {
                         eprintln!("SIM receive error p{player_index}: {error}");
-                        deferred_notifications.push(GameNotification::ChannelStatus {
-                            state: ChannelStatus::Failed,
-                            session_disposition: None,
-                            advisory: Some(format!("error receiving peer message: {error}")),
-                            coin: None,
-                            our_balance: None,
-                            their_balance: None,
-                            game_allocated: None,
-                            have_potato: None,
-                            zero_payout: None,
-                            unroll_initiator: None,
-                            semantic_phase: None,
-                        });
+                        deferred_notifications.push(GameNotification::ChannelStatus(
+                            ChannelStatusSnapshot {
+                                advisory: Some(format!("error receiving peer message: {error}")),
+                                ..ChannelStatusSnapshot::new(ChannelStatus::Failed)
+                            },
+                        ));
                     }
                     GameSessionEvent::CoinSolutionRequest(coin) => {
                         coin_requests.push(coin.clone());

--- a/src/test_support/krunk_sim.rs
+++ b/src/test_support/krunk_sim.rs
@@ -84,7 +84,7 @@ mod sim_tests {
     use crate::channel_state::types::{ChannelEnv, OnChainGameState, TimeoutClaimState};
     use crate::common::types::{Amount, CoinString, Hash, PuzzleHash, Timeout};
     use crate::session_phases::effects::{
-        ChannelStatus, GameNotification, GameStatusKind, SettlementOutcome,
+        ChannelStatus, ChannelStatusSnapshot, GameNotification, GameStatusKind, SettlementOutcome,
     };
     use crate::session_phases::on_chain::{OnChainPhase, OnChainPhaseArgs};
     use crate::session_phases::types::{GameAction, PotatoState};
@@ -257,10 +257,12 @@ mod sim_tests {
             .position(|event| {
                 matches!(
                     event,
-                    TestEvent::Notification(GameNotification::ChannelStatus {
-                        state: ChannelStatus::ResolvedUnrolled,
-                        ..
-                    })
+                    TestEvent::Notification(GameNotification::ChannelStatus(
+                        ChannelStatusSnapshot {
+                            state: ChannelStatus::ResolvedUnrolled,
+                            ..
+                        }
+                    ))
                 )
             })
             .expect("picker must observe unroll resolution");
@@ -540,10 +542,10 @@ mod sim_tests {
                 assert!(
                     ui.notifications.iter().any(|notification| matches!(
                         notification,
-                        GameNotification::ChannelStatus {
+                        GameNotification::ChannelStatus(ChannelStatusSnapshot {
                             state: ChannelStatus::ResolvedUnrolled,
                             ..
-                        }
+                        })
                     )),
                     "player {who} should resolve through the known unroll: {:?}",
                     ui.notifications
@@ -551,10 +553,10 @@ mod sim_tests {
                 assert!(
                     !ui.notifications.iter().any(|notification| matches!(
                         notification,
-                        GameNotification::ChannelStatus {
+                        GameNotification::ChannelStatus(ChannelStatusSnapshot {
                             state: ChannelStatus::Failed,
                             ..
-                        }
+                        })
                     )),
                     "player {who} should not fail unroll recognition: {:?}",
                     ui.notifications

--- a/src/test_support/krunk_sim.rs
+++ b/src/test_support/krunk_sim.rs
@@ -732,7 +732,7 @@ mod sim_tests {
                     notification,
                     GameNotification::GameStatus {
                         id,
-                        status: GameStatusKind::OnChainTheirTurn,
+                        status: GameStatusKind::FinishingWaitingTimeout,
                         other_params: Some(params),
                         ..
                     } if *id == GameID(1) && params.game_finished == Some(true)
@@ -744,7 +744,7 @@ mod sim_tests {
                     notification,
                     GameNotification::GameStatus {
                         id,
-                        status: GameStatusKind::OnChainMyTurn,
+                        status: GameStatusKind::FinishingWaitingTimeout,
                         other_params: Some(params),
                         ..
                     } if *id == GameID(1) && params.game_finished == Some(true)

--- a/src/test_support/peer/peer_harness.rs
+++ b/src/test_support/peer/peer_harness.rs
@@ -17,7 +17,9 @@ use crate::common::types::{GameID, PrivateKey, Program, Timeout};
 #[cfg(test)]
 use crate::game_session::{MessagePeerQueue, MessagePipe, PeerLifecyclePhase};
 #[cfg(test)]
-use crate::session_phases::effects::{apply_effects, Effect, GameNotification};
+use crate::session_phases::effects::{
+    apply_effects, ChannelStatusSnapshot, Effect, GameNotification,
+};
 #[cfg(test)]
 use crate::session_phases::game_collection;
 #[cfg(test)]
@@ -165,9 +167,9 @@ impl ToLocalUI for Pipe {
                     }
                 }
             }
-            GameNotification::ChannelStatus {
+            GameNotification::ChannelStatus(ChannelStatusSnapshot {
                 state, advisory, ..
-            } => {
+            }) => {
                 use crate::session_phases::effects::ChannelStatus;
                 if matches!(
                     state,

--- a/src/test_support/spacepoker_sim.rs
+++ b/src/test_support/spacepoker_sim.rs
@@ -159,7 +159,7 @@ mod sim_tests {
                             notification,
                             GameNotification::GameStatus {
                                 id: GameID(1),
-                                status: GameStatusKind::OnChainMyTurn,
+                                status: GameStatusKind::FinishingWaitingTimeout,
                                 other_params: Some(params),
                                 ..
                             } if params.game_finished == Some(true)

--- a/src/tests/channel_state.rs
+++ b/src/tests/channel_state.rs
@@ -98,6 +98,98 @@ pub(crate) mod sim_tests {
             .expect("should build conditions")
     }
 
+    #[test]
+    fn unroll_target_is_one_behind_after_sending_the_potato() {
+        let mut allocator = AllocEncoder::new();
+        let mut rng = ChaCha8Rng::from_seed([0; 32]);
+        let unroll_puzzle = read_unroll_puzzle(&mut allocator).unwrap();
+        let nil = allocator.allocator().nil();
+        let ref_coin_puz = Puzzle::from_nodeptr(&mut allocator, nil).expect("should work");
+        let ref_coin_ph = ref_coin_puz.sha256tree(&mut allocator);
+        let standard_puzzle = get_standard_coin_puzzle(&mut allocator).expect("should load");
+        let mut env = ChannelEnv {
+            allocator: &mut allocator,
+            referee_coin_puzzle: ref_coin_puz,
+            referee_coin_puzzle_hash: ref_coin_ph,
+            unroll_puzzle,
+            standard_puzzle,
+            agg_sig_me_additional_data: Hash::from_bytes(AGG_SIG_ME_ADDITIONAL_DATA),
+        };
+
+        let mut game = setup_handshake(&mut rng, &mut env);
+        let first_sender = if game.player(0).ch.have_potato() {
+            0
+        } else {
+            1
+        };
+        empty_potato_round_trip(&mut game, &mut env, first_sender);
+
+        let sender = if game.player(0).ch.have_potato() {
+            0
+        } else {
+            1
+        };
+        let receiver = sender ^ 1;
+
+        let before = game.player(sender).ch.state_number();
+        assert!(before > 0);
+        assert_eq!(
+            game.player(sender).ch.unroll_target_state_number(),
+            Some(before),
+            "holding the potato, unroll target is the current state"
+        );
+
+        let sigs = game
+            .player(sender)
+            .ch
+            .send_empty_potato(&mut env)
+            .expect("send_empty_potato");
+        assert!(!game.player(sender).ch.have_potato());
+        assert_eq!(game.player(sender).ch.state_number(), before + 1);
+        assert_eq!(
+            game.player(sender).ch.unroll_target_state_number(),
+            Some(before),
+            "after sending, unroll target stays on the last co-signed state"
+        );
+
+        game.player(receiver)
+            .ch
+            .received_empty_potato(&mut env, &sigs)
+            .expect("received_empty_potato");
+        assert_eq!(
+            game.player(receiver).ch.unroll_target_state_number(),
+            Some(game.player(receiver).ch.state_number()),
+            "receiver's unroll target matches the state they just co-signed"
+        );
+
+        let mut handshake_only = setup_handshake(&mut rng, &mut env);
+        let handshake_sender = if handshake_only.player(0).ch.have_potato() {
+            0
+        } else {
+            1
+        };
+        assert_eq!(
+            handshake_only
+                .player(handshake_sender)
+                .ch
+                .unroll_target_state_number(),
+            Some(handshake_only.player(handshake_sender).ch.state_number())
+        );
+        handshake_only
+            .player(handshake_sender)
+            .ch
+            .send_empty_potato(&mut env)
+            .expect("send from handshake");
+        assert_eq!(
+            handshake_only
+                .player(handshake_sender)
+                .ch
+                .unroll_target_state_number(),
+            Some(0),
+            "first send from handshake unrolls to state 0, not the bumped current state"
+        );
+    }
+
     /// Test the parity constraint in preemption unroll spends.
     ///
     /// After 3 round-trips of empty potato exchanges, player 0 has:

--- a/src/tests/channel_state.rs
+++ b/src/tests/channel_state.rs
@@ -237,7 +237,7 @@ pub(crate) mod sim_tests {
         {
             let p0 = &game.player(0).ch;
             let conditions = make_conditions_for_state(&mut env, p0, 4);
-            let result = p0.channel_coin_spent(&mut env, false, conditions);
+            let result = p0.channel_coin_spent(&mut env, conditions);
             assert!(
                 result.is_ok(),
                 "same-parity historical state should time out, got: {result:?}"
@@ -252,7 +252,7 @@ pub(crate) mod sim_tests {
         {
             let p0 = &game.player(0).ch;
             let conditions = make_conditions_for_state(&mut env, p0, 3);
-            let result = p0.channel_coin_spent(&mut env, false, conditions);
+            let result = p0.channel_coin_spent(&mut env, conditions);
             assert!(
                 result.is_ok(),
                 "preemption with different-parity on-chain state should succeed, got: {result:?}"
@@ -266,7 +266,7 @@ pub(crate) mod sim_tests {
             let p0 = &game.player(0).ch;
             let conditions = make_conditions_for_state(&mut env, p0, 6);
             let result = p0
-                .channel_coin_spent(&mut env, false, conditions)
+                .channel_coin_spent(&mut env, conditions)
                 .expect("current state should resolve");
             assert!(result.timeout, "current state must use timeout");
         }
@@ -284,7 +284,7 @@ pub(crate) mod sim_tests {
                 assert_eq!(p0.state_number(), 7);
                 let conditions = make_conditions_for_state(&mut env, p0, 5);
                 let result = p0
-                    .channel_coin_spent(&mut env, false, conditions)
+                    .channel_coin_spent(&mut env, conditions)
                     .expect("co-signed adjacent state should preempt");
                 assert!(
                     !result.timeout,
@@ -387,7 +387,7 @@ pub(crate) mod sim_tests {
                 .to_clvm(env.allocator)
                 .expect("conditions");
             let p0 = &game.player(0).ch;
-            let result = p0.channel_coin_spent(&mut env, false, conditions);
+            let result = p0.channel_coin_spent(&mut env, conditions);
             assert!(
                 result.is_err(),
                 "unrecognized unroll puzzle hash should always fail, got: {result:?}"

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -498,7 +498,9 @@ impl<C: ManagedGameSession> TransactionManager<C> {
     /// Report a trusted chain height when the watched-coin snapshot is not
     /// available or is known partial. This advances handshake protocol clocks
     /// through the manager without inventing coin creations/deletions or
-    /// evaluating channel-creation expiry from absent coin data.
+    /// evaluating channel-creation expiry from absent coin data. Timeout claims
+    /// wait for `report_coin_states`: a height-only observation cannot tell
+    /// whether the coin is still unspent.
     pub fn report_height(
         &mut self,
         allocator: &mut AllocEncoder,
@@ -515,7 +517,6 @@ impl<C: ManagedGameSession> TransactionManager<C> {
             self.report_timeout_claim_rearms(rearmed)?;
         }
         self.reconcile_timeout_claim_status()?;
-        self.evaluate_mature_timeout_claims(height)?;
         self.cradle.session_observe(allocator, height, None)
     }
 
@@ -587,11 +588,18 @@ impl<C: ManagedGameSession> TransactionManager<C> {
         Ok(())
     }
 
+    /// Queue eager timeout spends whose relative lock is ripe. Called only from
+    /// `report_coin_states`, after spend reconciliation, so a coin that was
+    /// spent at or before this height is not claimed.
     fn evaluate_mature_timeout_claims(&mut self, height: u64) -> Result<(), Error> {
         let mut to_submit: Vec<(SpendBundle, Option<TimeoutClaimSemantic>)> = Vec::new();
-        for watched in self.watched_coins.values_mut() {
+        for (coin, watched) in self.watched_coins.iter_mut() {
             let ripe = matches!(watched.birthday, Some(b) if b + watched.timeout_blocks.to_u64() <= height);
-            if ripe && !watched.claim_submitted && watched.spent_confirmed_at.is_none() {
+            if ripe
+                && !watched.claim_submitted
+                && watched.spent_confirmed_at.is_none()
+                && self.present_coins.contains(coin)
+            {
                 if let Some(spend) = &watched.timeout_spend {
                     to_submit.push((spend.clone(), watched.timeout_claim_semantic));
                     watched.claim_submitted = true;
@@ -1375,7 +1383,7 @@ mod tests {
     }
 
     #[test]
-    fn height_only_report_matures_known_timeout_claim() {
+    fn height_only_report_does_not_submit_timeout_before_snapshot() {
         let mut allocator = AllocEncoder::new();
         let coin = test_coin(14);
         let mut mock = MockGameSession::default();
@@ -1384,6 +1392,45 @@ mod tests {
             coin_string: coin.clone(),
             timeout: Timeout::new(5),
             spend: Some(test_bundle("height-only-timeout")),
+            semantic: Some(TimeoutClaimSemantic::ChannelTimeoutFinish),
+        }]);
+        let mut mgr = TransactionManager::new(mock);
+        mgr.flush_and_collect(&mut allocator).expect("register");
+        let live = [CoinStateRecord {
+            coin: coin.clone(),
+            created_height: Some(10),
+            spent_height: None,
+        }];
+        mgr.report_coin_states(&mut allocator, 10, &live)
+            .expect("observe birthday");
+
+        mgr.report_height(&mut allocator, 15)
+            .expect("height-only at maturity");
+        assert!(
+            mgr.drain_submissions().unwrap().is_empty(),
+            "height-only cannot know the coin is still unspent"
+        );
+        assert!(mgr.cradle().submitted_timeout_claims.is_empty());
+
+        mgr.report_coin_states(&mut allocator, 15, &live)
+            .expect("live snapshot at maturity");
+        assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
+        assert_eq!(
+            mgr.cradle().submitted_timeout_claims,
+            vec![TimeoutClaimSemantic::ChannelTimeoutFinish]
+        );
+    }
+
+    #[test]
+    fn timeout_claim_skipped_when_coin_spent_at_maturity() {
+        let mut allocator = AllocEncoder::new();
+        let coin = test_coin(19);
+        let mut mock = MockGameSession::default();
+        mock.queue_drain(vec![GameSessionEvent::WatchCoin {
+            coin_name: coin.to_coin_id(),
+            coin_string: coin.clone(),
+            timeout: Timeout::new(5),
+            spend: Some(test_bundle("spent-at-maturity")),
             semantic: Some(TimeoutClaimSemantic::ChannelTimeoutFinish),
         }]);
         let mut mgr = TransactionManager::new(mock);
@@ -1400,12 +1447,24 @@ mod tests {
         .expect("observe birthday");
 
         mgr.report_height(&mut allocator, 15)
-            .expect("height-only maturity");
-        assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
-        assert_eq!(
-            mgr.cradle().submitted_timeout_claims,
-            vec![TimeoutClaimSemantic::ChannelTimeoutFinish]
+            .expect("height-only at maturity");
+        assert!(mgr.drain_submissions().unwrap().is_empty());
+
+        mgr.report_coin_states(
+            &mut allocator,
+            15,
+            &[CoinStateRecord {
+                coin: coin.clone(),
+                created_height: Some(10),
+                spent_height: Some(15),
+            }],
+        )
+        .expect("spent at maturity");
+        assert!(
+            mgr.drain_submissions().unwrap().is_empty(),
+            "do not timeout-spend a coin already spent when the claim matures"
         );
+        assert!(mgr.cradle().submitted_timeout_claims.is_empty());
     }
 
     #[test]
@@ -1429,7 +1488,8 @@ mod tests {
         }];
         mgr.report_coin_states(&mut allocator, 10, &live)
             .expect("observe birthday");
-        mgr.report_height(&mut allocator, 15).expect("mature");
+        mgr.report_coin_states(&mut allocator, 15, &live)
+            .expect("mature");
         assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
 
         mgr.report_height(&mut allocator, 14)
@@ -1440,7 +1500,7 @@ mod tests {
         );
         assert!(mgr.drain_submissions().unwrap().is_empty());
 
-        mgr.report_height(&mut allocator, 15)
+        mgr.report_coin_states(&mut allocator, 15, &live)
             .expect("recover maturity");
         assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
     }
@@ -1469,14 +1529,14 @@ mod tests {
         assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
 
         // Production first observes the lower trusted tip, then reconciles the
-        // same tip from the complete coin snapshot. Height 14 is still mature,
-        // so the first report re-arms and requeues exactly one claim.
+        // same tip from the complete coin snapshot. Height-only re-arms; the
+        // snapshot is what requeues the still-live claim.
         mgr.report_height(&mut allocator, 14)
             .expect("lowered height");
-        assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
+        assert!(mgr.drain_submissions().unwrap().is_empty());
         mgr.report_coin_states(&mut allocator, 14, &live)
             .expect("same-tip snapshot");
-        assert!(mgr.drain_submissions().unwrap().is_empty());
+        assert_eq!(mgr.drain_submissions().unwrap().len(), 1);
         assert_eq!(
             mgr.cradle().rearmed_timeout_claims,
             vec![TimeoutClaimSemantic::ChannelTimeoutFinish]


### PR DESCRIPTION
## Summary
- Classify unroll and terminal-game timeout situations in WASM (`semanticPhase` + `unrollInitiator`) and render them with exhaustive JS copy maps, including the potato after the channel state number.
- Show session mode on a banner rail and pipe health as tab link marks; warn before leaving a live session and drop this tab's lease on close.
- Submit timeout claims only after an authoritative coin snapshot, and treat unsigned or mismatched channel-coin spends as parse errors instead of timeouts.

## Test plan
- [ ] `./ct.sh`
- [ ] Start a session, confirm the banner rail, potato/state number, and tab pipe marks.
- [ ] Force an unroll (self and opponent) and check wait vs spend / preempt copy.
- [ ] Reload and close a live tab: leave warning and lease drop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span on-chain unroll classification, timeout-claim registration, and session persistence (v13); UI is mostly display but incorrect spend handling could affect channel resolution.
> 
> **Overview**
> **Connectivity UX** moves session *mode* off the tabs: Wallet/Hub/Game show link vs broken-chain emojis for pipe health only; degraded peer pings show on the game dashboard banner (yellow rail + “Peer pings look stuck”), not on tab colors. The session dashboard adds a left **banner rail** (`idle` / `playing` / `pings-bad` / `on-chain` / `ended`).
> 
> **WASM → UI contract** expands `ChannelStatus` with `state_number`, unroll state numbers, and renamed semantic phases (`unrolling`, `finding_state`, `finishing_waiting_timeout`, `finishing_spending`, etc.). Dashboard copy maps those phases plus `unroll_initiator` to labels like “Finishing opponent unroll” and preempt detail strings. Terminal finished games get distinct on-chain statuses (`finishing-waiting-timeout` / `finishing-spending`) and `GameFinishTimeout` timeout-claim semantics.
> 
> **On-chain safety:** `channel_coin_spent` no longer branches on “who spent”; unsigned or conditions-mismatch spends error at parse time instead of falling back to timeout. `classify_unroll` no longer widens parse failures to “wait for timeout.”
> 
> **Persistence** bumps envelope schema to **v13** (v12 deleted per alpha policy). Shared `integersToBigInt` normalizes WASM/RPC integer boundaries.
> 
> **Tab lifecycle:** `beforeunload` warns on live off-chain/on-chain sessions; hub disconnect and lease release run on `pagehide` so staying on the page after a warning does not drop the hub. `releaseLeaseIfOwner` clears the active-tab lease when the owning tab actually closes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96964b43917d16fe93db401dd49fef6afe1ec795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->