### PR TITLE
Give GitHub Bugbot exhaustive-review instructions

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,8 @@
+# Bugbot review instructions
+
+Do an exhaustive review of the entire PR diff. Do not stop, truncate, or
+report after the first few findings. Continue until every changed file, every
+control-flow path, and every related test/docs delta has been inspected. A
+short list of early hits is not acceptable. Enumerate all issues you find; if
+you find none after a full pass, say so explicitly. Do not skip later commits
+or files because earlier ones already produced results.


### PR DESCRIPTION
## Summary
- Add `.cursor/BUGBOT.md` so high-effort PR Bugbot gets the same exhaustive-search instructions already used in local `/review-bugbot` runs.
- GitHub Bugbot does not receive the local `Custom Instructions` prompt; this file is the checked-in equivalent it always loads.

## Test plan
- [ ] Confirm this PR's `Cursor Bugbot` check includes the new rule (`bugbot run verbose=true` if needed).
- [ ] After merge, open a follow-up PR and check that Bugbot still loads `.cursor/BUGBOT.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds **`.cursor/BUGBOT.md`** so GitHub’s Cursor Bugbot gets checked-in instructions to review the **entire PR diff** without stopping after early findings—matching behavior intended for local `/review-bugbot` runs, since GitHub Bugbot does not use local Custom Instructions.
> 
> The file tells Bugbot to inspect every changed file, control-flow path, and related test/docs delta, enumerate all issues (or state explicitly if none), and not skip later commits or files after early results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ebea3e9b67e08d8c0e616dbf956dc788f414c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->