### PR TITLE
Add a toggle on WalletConnection screen for testnet or mainnet

### DIFF
--- a/CONNECTIVITY.md
+++ b/CONNECTIVITY.md
@@ -366,12 +366,18 @@ The hub does not create a session. It can only advise and relay:
    it **ignores** the advisory (no `session_reject`).
 4. If the target consents, it marks itself busy, generates a random hex
    `game_session_id`, sends a bencodex `session_proposal` app message (including
-   the `game_session_id`) to the challenger through the addressed relay, starts
+   the `game_session_id` and its selected `network`) to the challenger through
+   the addressed relay, starts
    WASM as initiator, and sends binary handshake frames. Persist of that start
    is async; `session_reject` / local cancel must abort any in-flight start so
    it cannot resurrect an orphan handshake.
 5. The challenger app checks local availability before showing the proposal
-   prompt. While the prompt is open it reserves that peer id so early
+   prompt. The hub is network-blind, so cross-network challenges can reach this
+   point; the challenger rejects a proposal whose `network` is missing,
+   malformed, or not equal to its own network preference with `session_reject`
+   and no consent UI (a mainnet and a testnet client bind different genesis
+   challenges, so a session between them could never verify signatures). While
+   the prompt is open it reserves that peer id so early
    `HandshakeA` bytes can buffer. If unavailable or declined, it sends
    `session_reject` and discards buffered handshake bytes. Receiving
    `session_reject` during pre-active matchmaking cancels the attempt

--- a/CONNECTIVITY.md
+++ b/CONNECTIVITY.md
@@ -422,7 +422,10 @@ The hub does not create a session. It can only advise and relay:
   (`shouldReportHubBusy(phase, false)` forces busy regardless of phase) and
   cancels any pending pre-Active matchmaking attempt; wallet reconnect
   recomputes presence from the session phase and any in-progress non-terminal
-  restore cradle (phase alone is often still `none` mid-resume). (`Shell.tsx`)
+  restore cradle (phase alone is often still `none` mid-resume). The Choose
+  Connection network toggle is locked while a session binds a genesis
+  challenge (`sessionLocksNetwork`) so reconnect cannot pair a different
+  chain id than the existing WASM cradle. (`Shell.tsx`)
 
 - **Session state surfaced to Shell**: `GameSession` reports coarse session
   phase (`off-chain | on-chain | resolved`) and an error flag to Shell via

--- a/FRONTEND_ARCHITECTURE.md
+++ b/FRONTEND_ARCHITECTURE.md
@@ -191,17 +191,23 @@ while WASM protocol frames remain raw bytes with the existing reliability tags.
    `session_reject`).
 6. If the accepter consents, that app becomes the channel initiator. It marks
    itself busy, generates a random hex `game_session_id`, sends a bencodex
-   `session_proposal` app message (including the `game_session_id`) to the peer,
+   `session_proposal` app message (including the `game_session_id` and its
+   selected `network`) to the peer,
    starts the WASM session as initiator, and then sends the binary handshake
    frames through the same addressed pipe. Starting persists session state
    asynchronously; a later `session_reject` (or local cancel) must abort that
    in-flight start so it cannot resurrect an orphan handshake.
 7. The peer receives the `session_proposal`, checks local availability and
-   validates amounts/timeouts at the trust boundary, stores the
+   validates amounts/timeouts and `network` at the trust boundary, stores the
    `game_session_id` in its PeerSession, reserves that peer id so early
    handshake bytes can buffer, and shows its own consent prompt. Invalid
-   amounts or out-of-range timeouts are rejected with `session_reject` only —
-   they must not clear a finished freeze or IndexedDB checkpoint. If unavailable
+   amounts, out-of-range timeouts, or a `network` that is missing, malformed, or
+   not equal to the local network preference are rejected with `session_reject`
+   only —
+   they must not clear a finished freeze or IndexedDB checkpoint. The hub is
+   network-blind, so a cross-network match reaches this check and is rejected
+   here before any consent UI (differing genesis challenges would break every
+   signature). If unavailable
    or declined, it sends `session_reject` and discards any buffered handshake
    bytes. Receiving `session_reject` or `delivery_failure` during an Accept
    transition aborts that attempt with the same freeze-safe disposition as

--- a/front-end/src/components/AmountInput.tsx
+++ b/front-end/src/components/AmountInput.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { getCurrencyLabels } from '../constants/currency';
 
 function mojosToXchStr(mojos: bigint): string {
   const s = mojos.toString().padStart(13, '0');
@@ -57,6 +58,7 @@ export function AmountInput({
   exceedsLabel = 'Exceeds available balance.',
   onKeyDown,
 }: AmountInputProps) {
+  const labels = getCurrencyLabels();
   const [unit, setUnit] = useState<AmountUnit>('mojo');
   const [rawInput, setRawInput] = useState(() => valueMojos.toString());
   const lastExternalMojos = useRef(valueMojos);
@@ -119,14 +121,14 @@ export function AmountInput({
             onClick={() => handleUnitChange('mojo')}
             className={`px-2 py-0.5 transition-colors ${unit === 'mojo' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
           >
-            mojo
+            {labels.mojo}
           </button>
           <button
             type="button"
             onClick={() => handleUnitChange('xch')}
             className={`px-2 py-0.5 transition-colors border-l border-canvas-border ${unit === 'xch' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
           >
-            XCH
+            {labels.xch}
           </button>
         </div>
       </div>
@@ -151,7 +153,9 @@ export function AmountInput({
               className="underline font-medium hover:text-alert-text-contrast transition-colors"
             >
               Use max (
-              {unit === 'xch' ? `${mojosToXchStr(maxMojos!)} XCH` : `${maxMojos!.toString()} mojos`}
+              {unit === 'xch'
+                ? `${mojosToXchStr(maxMojos!)} ${labels.xch}`
+                : `${maxMojos!.toString()} ${labels.mojos}`}
               )
             </button>
           )}

--- a/front-end/src/components/GameProposalDialogs.tsx
+++ b/front-end/src/components/GameProposalDialogs.tsx
@@ -3,6 +3,7 @@ import { isValidKrunkStake } from '../features/krunk/adapter';
 import { gameDisplayName, REGISTERED_GAMES } from '../lib/gameRegistry';
 import { composeDraftCanSubmit, composeDraftTerms } from '../lib/session/model';
 import { formatMojos } from '../util';
+import { getCurrencyLabels } from '../constants/currency';
 import { AmountInput } from './AmountInput';
 import { Button } from './button';
 
@@ -118,7 +119,9 @@ export function ComposeProposalDialog({
           />
         )}
         {isKrunk && perHandAmount > 0n && !krunkStakeValid && (
-          <p className="text-xs text-alert-text">Krunk stakes must be multiples of 100 mojos.</p>
+          <p className="text-xs text-alert-text">
+            Krunk stakes must be multiples of 100 {getCurrencyLabels().mojos}.
+          </p>
         )}
         <div className="flex w-full flex-col items-center gap-1">
           <label className="text-xs font-medium text-canvas-text">Timeout (blocks)</label>

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -62,6 +62,8 @@ import {
   setDefaultFee as saveDefaultFee,
   getFeeUnit,
   setFeeUnit as saveFeeUnit,
+  getNetwork,
+  setNetwork as saveNetwork,
   getActiveTab as getSavedTab,
   setActiveTab as saveActiveTab,
   getUnreadGame as getSavedUnreadGame,
@@ -79,6 +81,8 @@ import {
   peekAlias,
   setAlias,
 } from '../hooks/save';
+import type { ChiaNetwork } from '../lib/session/saveEnvelope';
+import { getCurrencyLabels } from '../constants/currency';
 import {
   sessionController,
   destroySessionController,
@@ -244,6 +248,7 @@ function SessionBuyIn({
   channelTimeout?: string;
   unrollTimeout?: string;
 }) {
+  const labels = getCurrencyLabels();
   const effectiveChannelTimeout =
     parseOptionalBigInt(channelTimeout) ?? DEFAULT_CHANNEL_TIMEOUT_BLOCKS;
   const effectiveUnrollTimeout =
@@ -252,7 +257,7 @@ function SessionBuyIn({
     return (
       <>
         <br />
-        Buy-in: <strong>{myAmount}</strong> mojos
+        Buy-in: <strong>{myAmount}</strong> {labels.mojos}
         <br />
         Channel timeout: <strong>{effectiveChannelTimeout.toString()}</strong> blocks
         <br />
@@ -264,9 +269,9 @@ function SessionBuyIn({
   return (
     <>
       <br />
-      Your buy-in: <strong>{myAmount}</strong> mojos
+      Your buy-in: <strong>{myAmount}</strong> {labels.mojos}
       <br />
-      Their buy-in: <strong>{theirAmount}</strong> mojos
+      Their buy-in: <strong>{theirAmount}</strong> {labels.mojos}
       <br />
       Channel timeout: <strong>{effectiveChannelTimeout.toString()}</strong> blocks
       <br />
@@ -1040,6 +1045,7 @@ const Shell = () => {
   const wcAbortRef = useRef(false);
   const [defaultFee, setDefaultFee] = useState<bigint>(() => getDefaultFee());
   const [feeUnit, setFeeUnit] = useState<'mojo' | 'xch'>(() => getFeeUnit());
+  const [network, setNetwork] = useState<ChiaNetwork>(() => getNetwork());
   const [feeEditing, setFeeEditing] = useState(false);
   const [feeInput, setFeeInput] = useState('');
   const feeInputRef = useRef<HTMLInputElement>(null);
@@ -1117,6 +1123,13 @@ const Shell = () => {
     },
     [feeEditing, feeInput, parseFeeInput],
   );
+
+  const handleNetworkChange = useCallback((next: ChiaNetwork) => {
+    setNetwork(next);
+    saveNetwork(next);
+  }, []);
+
+  const currency = useMemo(() => getCurrencyLabels(), [network]);
 
   // Theme state
   const [isDark, setIsDark] = useState<boolean>(() => {
@@ -3652,7 +3665,7 @@ const Shell = () => {
                 </div>
                 {balance !== undefined && (
                   <p className="text-2xl font-bold text-canvas-text-contrast">
-                    {balance.toLocaleString()} mojos
+                    {balance.toLocaleString()} {currency.mojos}
                   </p>
                 )}
                 <div className="w-full max-w-xs text-sm text-canvas-text">
@@ -3663,13 +3676,13 @@ const Shell = () => {
                         onClick={() => handleFeeUnitChange('mojo')}
                         className={`px-2 py-0.5 transition-colors ${feeUnit === 'mojo' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
                       >
-                        mojo
+                        {currency.mojo}
                       </button>
                       <button
                         onClick={() => handleFeeUnitChange('xch')}
                         className={`px-2 py-0.5 transition-colors border-l border-canvas-border ${feeUnit === 'xch' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
                       >
-                        XCH
+                        {currency.xch}
                       </button>
                     </div>
                   </div>
@@ -3706,7 +3719,7 @@ const Shell = () => {
                       onClick={startEditingFee}
                       className="w-full text-left px-3 py-2 rounded-md bg-canvas-bg-subtle text-canvas-text border border-canvas-border hover:bg-canvas-bg-hover transition-colors cursor-pointer"
                     >
-                      {feeDisplayText()} {feeUnit === 'xch' ? 'XCH' : 'mojos'}
+                      {feeDisplayText()} {feeUnit === 'xch' ? currency.xch : currency.mojos}
                     </button>
                   )}
                 </div>
@@ -3783,13 +3796,13 @@ const Shell = () => {
                         onClick={() => handleFeeUnitChange('mojo')}
                         className={`px-2 py-0.5 transition-colors ${feeUnit === 'mojo' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
                       >
-                        mojo
+                        {currency.mojo}
                       </button>
                       <button
                         onClick={() => handleFeeUnitChange('xch')}
                         className={`px-2 py-0.5 transition-colors border-l border-canvas-border ${feeUnit === 'xch' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
                       >
-                        XCH
+                        {currency.xch}
                       </button>
                     </div>
                   </div>
@@ -3826,7 +3839,7 @@ const Shell = () => {
                       onClick={startEditingFee}
                       className="w-full text-left px-3 py-2 rounded-md bg-canvas-bg-subtle text-canvas-text border border-canvas-border hover:bg-canvas-bg-hover transition-colors cursor-pointer"
                     >
-                      {feeDisplayText()} {feeUnit === 'xch' ? 'XCH' : 'mojos'}
+                      {feeDisplayText()} {feeUnit === 'xch' ? currency.xch : currency.mojos}
                     </button>
                   )}
                 </div>
@@ -3864,6 +3877,23 @@ const Shell = () => {
             ) : (
               <div className="flex flex-col justify-center items-center w-full px-4 py-6 gap-4">
                 <p className="text-lg font-semibold text-canvas-text-contrast">Choose Connection</p>
+                <div className="w-full max-w-sm flex flex-col items-center gap-1">
+                  <span className="text-sm text-canvas-text">Network</span>
+                  <div className="flex rounded-md border border-canvas-border overflow-hidden text-xs">
+                    <button
+                      onClick={() => handleNetworkChange('mainnet')}
+                      className={`px-3 py-1 transition-colors ${network === 'mainnet' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
+                    >
+                      Mainnet
+                    </button>
+                    <button
+                      onClick={() => handleNetworkChange('testnet')}
+                      className={`px-3 py-1 transition-colors border-l border-canvas-border ${network === 'testnet' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
+                    >
+                      Testnet
+                    </button>
+                  </div>
+                </div>
                 <div className="w-full max-w-sm flex flex-col gap-3">
                   <Button
                     variant="solid"

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -103,6 +103,7 @@ import { useThemeSyncToIframe } from '../hooks/useThemeSyncToIframe';
 import {
   isRestoreBlocked,
   restoreGateAfterTerminalFinalization,
+  sessionLocksNetwork,
   shouldCancelAttemptOnDisconnect,
   shouldCancelOnPeerUnreachable,
   shouldMountGameSession,
@@ -1124,11 +1125,6 @@ const Shell = () => {
     [feeEditing, feeInput, parseFeeInput],
   );
 
-  const handleNetworkChange = useCallback((next: ChiaNetwork) => {
-    setNetwork(next);
-    saveNetwork(next);
-  }, []);
-
   const currency = getCurrencyLabels();
 
   // Theme state
@@ -1163,6 +1159,26 @@ const Shell = () => {
   const sessionFinishedCleanupRef = useRef(false);
   const sessionPhaseRef = useRef<SessionPhase>('none');
   sessionPhaseRef.current = sessionPhase;
+
+  const networkLocked = sessionLocksNetwork(
+    sessionPhase,
+    sessionSaveRef.current?.phase,
+    sessionConfig?.pairingToken,
+  );
+
+  const handleNetworkChange = useCallback((next: ChiaNetwork) => {
+    if (
+      sessionLocksNetwork(
+        sessionPhaseRef.current,
+        sessionSaveRef.current?.phase,
+        sessionConfigRef.current?.pairingToken,
+      )
+    ) {
+      return;
+    }
+    setNetwork(next);
+    saveNetwork(next);
+  }, []);
 
   const deferStateUpdate = useCallback((fn: () => void) => {
     if (typeof queueMicrotask === 'function') {
@@ -3881,18 +3897,27 @@ const Shell = () => {
                   <span className="text-sm text-canvas-text">Network</span>
                   <div className="flex rounded-md border border-canvas-border overflow-hidden text-xs">
                     <button
+                      type="button"
+                      disabled={networkLocked}
                       onClick={() => handleNetworkChange('mainnet')}
-                      className={`px-3 py-1 transition-colors ${network === 'mainnet' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
+                      className={`px-3 py-1 transition-colors ${network === 'mainnet' ? 'bg-canvas-bg-active font-semibold' : networkLocked ? '' : 'hover:bg-canvas-bg-hover'} ${networkLocked ? 'opacity-40 cursor-default' : ''}`}
                     >
                       Mainnet
                     </button>
                     <button
+                      type="button"
+                      disabled={networkLocked}
                       onClick={() => handleNetworkChange('testnet')}
-                      className={`px-3 py-1 transition-colors border-l border-canvas-border ${network === 'testnet' ? 'bg-canvas-bg-active font-semibold' : 'hover:bg-canvas-bg-hover'}`}
+                      className={`px-3 py-1 transition-colors border-l border-canvas-border ${network === 'testnet' ? 'bg-canvas-bg-active font-semibold' : networkLocked ? '' : 'hover:bg-canvas-bg-hover'} ${networkLocked ? 'opacity-40 cursor-default' : ''}`}
                     >
                       Testnet
                     </button>
                   </div>
+                  {networkLocked && (
+                    <p className="text-xs text-canvas-text text-center">
+                      Network is locked for this session
+                    </p>
+                  )}
                 </div>
                 <div className="w-full max-w-sm flex flex-col gap-3">
                   <Button

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -1129,7 +1129,7 @@ const Shell = () => {
     saveNetwork(next);
   }, []);
 
-  const currency = useMemo(() => getCurrencyLabels(), [network]);
+  const currency = getCurrencyLabels();
 
   // Theme state
   const [isDark, setIsDark] = useState<boolean>(() => {

--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -136,6 +136,7 @@ import {
   isValidTimeoutString,
   parseOptionalBigInt,
   parseSessionAmount,
+  sessionProposalNetworkMatches,
 } from '../lib/session/peerSessionParams';
 import { sessionModelForReactProps } from '../lib/session/finishedSessionDisplay';
 import { finalizeTerminalSession } from '../lib/session/terminalFinalization';
@@ -1587,6 +1588,7 @@ const Shell = () => {
             channel_timeout: advisory.channel_timeout,
             unroll_timeout: advisory.unroll_timeout,
             game_session_id: gameSessionId,
+            network: getNetwork(),
           });
           await startFreshSessionWithPeer({
             peerId: advisory.peer_id,
@@ -1888,6 +1890,13 @@ const Shell = () => {
                 !isValidSessionAmountString(msg.responder_amount)
               ) {
                 log(`[Shell] session_reject to=${fromId}: proposal invalid amounts`);
+                sendSessionReject(fromId);
+                return;
+              }
+              if (!sessionProposalNetworkMatches(msg.network, getNetwork())) {
+                log(
+                  `[Shell] session_reject to=${fromId}: proposal network mismatch theirs=${msg.network ?? 'none'} mine=${getNetwork()}`,
+                );
                 sendSessionReject(fromId);
                 return;
               }

--- a/front-end/src/constants/currency.ts
+++ b/front-end/src/constants/currency.ts
@@ -1,0 +1,48 @@
+import { PREFERENCES_KEY } from '../hooks/savePreferences';
+
+/**
+ * User-visible currency labels for the selected Chia network. Testnet uses the
+ * T-prefixed nomenclature (TXCH / TMojo); mainnet keeps the standard names.
+ *
+ * The network preference is read from the persisted `appPreferences` blob so
+ * this stays a side-effect-free leaf module (no dependency on the save graph,
+ * which imports `util` and would otherwise form an import cycle).
+ */
+export interface CurrencyLabels {
+  /** Uppercase ticker: XCH / TXCH. */
+  xch: string;
+  /** Lowercase word for the coin: chia / TXCH. */
+  chia: string;
+  /** Singular sub-unit, lowercase: mojo / TMojo. */
+  mojo: string;
+  /** Plural sub-unit, lowercase: mojos / TMojos. */
+  mojos: string;
+  /** Uppercase sub-unit: MOJO / TMOJO. */
+  MOJO: string;
+}
+
+function readNetworkIsTestnet(): boolean {
+  try {
+    const raw = localStorage.getItem(PREFERENCES_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as { network?: unknown };
+    return parsed.network === 'testnet';
+  } catch {
+    return false;
+  }
+}
+
+export function isTestnet(): boolean {
+  return readNetworkIsTestnet();
+}
+
+export function getCurrencyLabels(): CurrencyLabels {
+  const t = readNetworkIsTestnet();
+  return {
+    xch: t ? 'TXCH' : 'XCH',
+    chia: t ? 'TXCH' : 'chia',
+    mojo: t ? 'TMojo' : 'mojo',
+    mojos: t ? 'TMojos' : 'mojos',
+    MOJO: t ? 'TMOJO' : 'MOJO',
+  };
+}

--- a/front-end/src/constants/env.ts
+++ b/front-end/src/constants/env.ts
@@ -1,3 +1,16 @@
 export const PROJECT_ID = 'b919da6c796177dc819d12110ce22cc4';
 export const RELAY_URL = 'wss://relay.walletconnect.com';
-export const CHAIN_ID = 'chia:mainnet';
+
+const _win = typeof window !== 'undefined' ? (window as any) : {};
+const _env = typeof process !== 'undefined' ? process.env : {};
+
+/** WalletConnect CAIP-2 chain ids for each supported Chia network. */
+export const MAINNET_CHAIN_ID = 'chia:mainnet';
+export const TESTNET_CHAIN_ID = 'chia:testnet';
+
+/**
+ * Optional hard override for the WalletConnect chain id, for CI / testing.
+ * When set it wins over the user-selected network preference.
+ */
+export const CHAIN_ID_OVERRIDE: string | undefined =
+  _win.__CHIA_GAMING_CHAIN_ID__ || _env.CHIA_GAMING_CHAIN_ID || undefined;

--- a/front-end/src/constants/env.ts
+++ b/front-end/src/constants/env.ts
@@ -14,3 +14,21 @@ export const TESTNET_CHAIN_ID = 'chia:testnet';
  */
 export const CHAIN_ID_OVERRIDE: string | undefined =
   _win.__CHIA_GAMING_CHAIN_ID__ || _env.CHIA_GAMING_CHAIN_ID || undefined;
+
+/**
+ * Genesis challenge (AGG_SIG_ME additional data) for each supported Chia
+ * network, as 32-byte hex. This value is folded into every AGG_SIG_ME
+ * signature, so it must match the network the connected wallet is on or the
+ * node will reject the spend. Testnet target is testnet11.
+ */
+export const MAINNET_GENESIS_CHALLENGE =
+  'ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb';
+export const TESTNET_GENESIS_CHALLENGE =
+  '37a90eb5185a9c4439a91ddc98bbadce7b4feba060d50116a067de66bf236615';
+
+/**
+ * Optional hard override for the genesis challenge, for CI / testing.
+ * When set it wins over the user-selected network preference.
+ */
+export const GENESIS_CHALLENGE_OVERRIDE: string | undefined =
+  _win.__CHIA_GAMING_GENESIS_CHALLENGE__ || _env.CHIA_GAMING_GENESIS_CHALLENGE || undefined;

--- a/front-end/src/constants/wallet-connect.ts
+++ b/front-end/src/constants/wallet-connect.ts
@@ -1,6 +1,7 @@
 import { ProposalTypes } from '@walletconnect/types';
 
-import { CHAIN_ID } from './env';
+import { CHAIN_ID_OVERRIDE, MAINNET_CHAIN_ID, TESTNET_CHAIN_ID } from './env';
+import { getNetwork } from '../hooks/save';
 
 export enum ChiaMethod {
   GetWallets = 'chia_getWallets',
@@ -16,10 +17,21 @@ export enum ChiaMethod {
   GetPuzzleAndSolution = 'chia_getPuzzleAndSolution',
 }
 
-export const REQUIRED_NAMESPACES: ProposalTypes.RequiredNamespaces = {
-  chia: {
-    methods: Object.values(ChiaMethod),
-    chains: [CHAIN_ID],
-    events: [],
-  },
-};
+/**
+ * WalletConnect CAIP-2 chain id for the currently-selected Chia network.
+ * A build-time/window override wins over the persisted network preference.
+ */
+export function getChainId(): string {
+  if (CHAIN_ID_OVERRIDE) return CHAIN_ID_OVERRIDE;
+  return getNetwork() === 'testnet' ? TESTNET_CHAIN_ID : MAINNET_CHAIN_ID;
+}
+
+export function getRequiredNamespaces(): ProposalTypes.RequiredNamespaces {
+  return {
+    chia: {
+      methods: Object.values(ChiaMethod),
+      chains: [getChainId()],
+      events: [],
+    },
+  };
+}

--- a/front-end/src/constants/wallet-connect.ts
+++ b/front-end/src/constants/wallet-connect.ts
@@ -1,6 +1,14 @@
 import { ProposalTypes } from '@walletconnect/types';
 
-import { CHAIN_ID_OVERRIDE, MAINNET_CHAIN_ID, TESTNET_CHAIN_ID } from './env';
+import {
+  CHAIN_ID_OVERRIDE,
+  MAINNET_CHAIN_ID,
+  TESTNET_CHAIN_ID,
+  GENESIS_CHALLENGE_OVERRIDE,
+  MAINNET_GENESIS_CHALLENGE,
+  TESTNET_GENESIS_CHALLENGE,
+} from './env';
+import { isTestnet } from './currency';
 import { getNetwork } from '../hooks/save';
 
 export enum ChiaMethod {
@@ -24,6 +32,22 @@ export enum ChiaMethod {
 export function getChainId(): string {
   if (CHAIN_ID_OVERRIDE) return CHAIN_ID_OVERRIDE;
   return getNetwork() === 'testnet' ? TESTNET_CHAIN_ID : MAINNET_CHAIN_ID;
+}
+
+/**
+ * Genesis challenge (AGG_SIG_ME additional data) hex for the currently-selected
+ * Chia network. A build-time/window override wins over the persisted network
+ * preference. This is threaded into the WASM game session so on-chain signatures
+ * (channel funding, unroll, clean-shutdown payouts) match the connected network.
+ *
+ * Reads the preference via `isTestnet()` (a direct, read-only lookup) rather
+ * than `getNetwork()`, which would seed the session-save cache with a
+ * non-durable `preferences` record as a side effect — that seeding trips the
+ * durability guard when this runs inside session creation.
+ */
+export function getGenesisChallenge(): string {
+  if (GENESIS_CHALLENGE_OVERRIDE) return GENESIS_CHALLENGE_OVERRIDE;
+  return isTestnet() ? TESTNET_GENESIS_CHALLENGE : MAINNET_GENESIS_CHALLENGE;
 }
 
 export function getRequiredNamespaces(): ProposalTypes.RequiredNamespaces {

--- a/front-end/src/constants/wallet-connect.ts
+++ b/front-end/src/constants/wallet-connect.ts
@@ -9,6 +9,7 @@ import {
   TESTNET_GENESIS_CHALLENGE,
 } from './env';
 import { isTestnet } from './currency';
+import { PREFERENCES_KEY } from '../hooks/savePreferences';
 import { getNetwork } from '../hooks/save';
 
 export enum ChiaMethod {
@@ -35,18 +36,39 @@ export function getChainId(): string {
 }
 
 /**
- * Genesis challenge (AGG_SIG_ME additional data) hex for the currently-selected
- * Chia network. A build-time/window override wins over the persisted network
- * preference. This is threaded into the WASM game session so on-chain signatures
- * (channel funding, unroll, clean-shutdown payouts) match the connected network.
+ * True when the persisted connection preference is the local simulator.
+ * Direct localStorage read: `getBlockchainType()` would seed the session-save
+ * cache the same way `getNetwork()` would.
+ */
+function readBlockchainIsSimulator(): boolean {
+  try {
+    const raw = localStorage.getItem(PREFERENCES_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as { blockchainType?: unknown };
+    return parsed.blockchainType === 'simulator';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Genesis challenge (AGG_SIG_ME additional data) hex for the chain this session
+ * will actually talk to. A build-time/window override wins.
  *
- * Reads the preference via `isTestnet()` (a direct, read-only lookup) rather
- * than `getNetwork()`, which would seed the session-save cache with a
+ * The local simulator always verifies spends against the hardcoded mainnet
+ * `AGG_SIG_ME_ADDITIONAL_DATA` constant, so simulator sessions use the mainnet
+ * challenge even if the UI network toggle is Testnet. That toggle still drives
+ * WalletConnect chain id and currency labels; it is not a simulated network.
+ *
+ * Reads preferences via direct localStorage lookups (`isTestnet()`,
+ * `readBlockchainIsSimulator()`) rather than `getNetwork()` /
+ * `getBlockchainType()`, which would seed the session-save cache with a
  * non-durable `preferences` record as a side effect — that seeding trips the
  * durability guard when this runs inside session creation.
  */
 export function getGenesisChallenge(): string {
   if (GENESIS_CHALLENGE_OVERRIDE) return GENESIS_CHALLENGE_OVERRIDE;
+  if (readBlockchainIsSimulator()) return MAINNET_GENESIS_CHALLENGE;
   return isTestnet() ? TESTNET_GENESIS_CHALLENGE : MAINNET_GENESIS_CHALLENGE;
 }
 

--- a/front-end/src/features/krunk/useKrunkHand.ts
+++ b/front-end/src/features/krunk/useKrunkHand.ts
@@ -3,6 +3,7 @@ import { Program } from 'clvm-lib';
 import { Observable } from 'rxjs';
 import { GameplayEvent } from '../../hooks/useGameSession';
 import { requireLiveGameHandSource, type GameHandSource } from '../../lib/gameMount';
+import { getCurrencyLabels } from '../../constants/currency';
 import { krunkSettlementStatus } from '../../lib/settlement';
 import type { GameTerminalModel } from '../../lib/session/types';
 import { krunkOutcomeFromPlay, reduceKrunkFeatureState } from './adapter';
@@ -224,14 +225,15 @@ export function krunkWinMessage(moverShare: string): string {
 }
 
 function krunkAmountLabel(amount: string): string {
+  const labels = getCurrencyLabels();
   const mojos = BigInt(amount);
-  if (mojos < 1_000_000n) return `${mojos} mojo`;
+  if (mojos < 1_000_000n) return `${mojos} ${labels.mojo}`;
   const TRILLION = 1_000_000_000_000n;
   const whole = mojos / TRILLION;
   const frac = mojos % TRILLION;
-  if (frac === 0n) return `${whole} chia`;
+  if (frac === 0n) return `${whole} ${labels.chia}`;
   const fracStr = frac.toString().padStart(12, '0').replace(/0+$/, '');
-  return `${whole}.${fracStr} chia`;
+  return `${whole}.${fracStr} ${labels.chia}`;
 }
 
 export function krunkWinnerMessage(winner: string, amount: string): string {

--- a/front-end/src/features/spacePoker/SpacePoker.tsx
+++ b/front-end/src/features/spacePoker/SpacePoker.tsx
@@ -8,6 +8,7 @@ import {
 import type { GameTerminalModel } from '../../lib/session/types';
 import { useCheatNerfKeys } from '../../hooks/useCheatNerfKeys';
 import type { GameplayEvent } from '../../hooks/useGameSession';
+import { getCurrencyLabels } from '../../constants/currency';
 import { describeSpacePokerHand, formatSpacepokerHandLog } from './handPresentation';
 import { SpacePokerActionControls } from './SpacePokerActionControls';
 import { SpacePokerHandHistory, SpacePokerTable } from './SpacePokerTable';
@@ -68,6 +69,7 @@ export default function SpacePoker({
     initialPersistedState ?? undefined,
   );
   const { handler, myTurn, N } = sp.gameState;
+  const spCurrency = getCurrencyLabels();
 
   const handleNerf = useCallback(() => {
     requireLiveGameHandSource(handSource).nerf();
@@ -164,7 +166,7 @@ export default function SpacePoker({
             className={`rounded px-2 py-0.5 ${sp.displayMode === mode ? 'bg-canvas-solid text-canvas-bg' : 'border border-canvas-line text-canvas-text-contrast'}`}
             onClick={() => sp.setDisplayMode(mode)}
           >
-            {mode === 'xch' ? 'XCH' : mode}
+            {mode === 'xch' ? spCurrency.xch : mode === 'mojos' ? spCurrency.mojos : mode}
           </button>
         ))}
       </div>

--- a/front-end/src/features/spacePoker/useSpacepokerHand.ts
+++ b/front-end/src/features/spacePoker/useSpacepokerHand.ts
@@ -3,6 +3,7 @@ import { Program } from 'clvm-lib';
 import { Observable } from 'rxjs';
 import { GameplayEvent } from '../../hooks/useGameSession';
 import { requireLiveGameHandSource, type GameHandSource } from '../../lib/gameMount';
+import { getCurrencyLabels } from '../../constants/currency';
 import type { PersistedGameState } from '../../lib/session/gameStateCodec';
 import type { GameTerminalModel } from '../../lib/session/types';
 import type { StateUpdate } from '../../lib/gameAdapter';
@@ -180,7 +181,7 @@ function formatXch(mojos: bigint): string {
   const s = abs.toString().padStart(13, '0');
   const whole = s.slice(0, -12).replace(/^0+/, '') || '0';
   const frac = s.slice(-12).replace(/0+$/, '');
-  return `${sign}${frac ? `${whole}.${frac}` : whole} XCH`;
+  return `${sign}${frac ? `${whole}.${frac}` : whole} ${getCurrencyLabels().xch}`;
 }
 
 export function rollbackOptimisticTerminalHistory(
@@ -857,7 +858,7 @@ export function useSpacepokerHand(
     (units: bigint): string => {
       if (displayMode === 'units') return String(units);
       const mojos = units * betUnit;
-      if (displayMode === 'mojos') return `${mojos.toLocaleString()} mojos`;
+      if (displayMode === 'mojos') return `${mojos.toLocaleString()} ${getCurrencyLabels().mojos}`;
       return formatXch(mojos);
     },
     [betUnit, displayMode],

--- a/front-end/src/hooks/FakeBlockchainInterface.ts
+++ b/front-end/src/hooks/FakeBlockchainInterface.ts
@@ -1,4 +1,5 @@
 import { encodeU64AsClvmHex, normalizeCoinStringHex } from '../util';
+import { getCurrencyLabels } from '../constants/currency';
 import { CoinRecord } from '../types/rpc/CoinRecord';
 import { jsonParse, jsonStringify } from '../util/jsonSafe';
 
@@ -369,7 +370,10 @@ export class FakeBlockchainInterface implements InternalBlockchainInterface {
     return {
       qrUri: `sim://${this.wsUrl.replace('ws://', '')}/${uniqueId}`,
       fields: {
-        balance: { label: 'Starting balance (mojos)', default: 1_000_000n },
+        balance: {
+          label: `Starting balance (${getCurrencyLabels().mojos})`,
+          default: 1_000_000n,
+        },
       },
       finalize: async (values?: { balance?: bigint }) => {
         log('[sim-blockchain] finalize: start');

--- a/front-end/src/hooks/WasmStateInit.ts
+++ b/front-end/src/hooks/WasmStateInit.ts
@@ -163,6 +163,7 @@ export class WasmStateInit {
     my_contribution: bigint,
     their_contribution: bigint,
     rewardPuzzleHash: string,
+    genesisChallenge: string,
     channelTimeout = 15,
     unrollTimeout = 15,
   ): { game: ChiaGame; puzzleHash: string } {
@@ -174,6 +175,7 @@ export class WasmStateInit {
       channel_timeout: channelTimeout,
       unroll_timeout: unrollTimeout,
       reward_puzzle_hash: rewardPuzzleHash,
+      genesis_challenge: genesisChallenge,
     });
 
     return {

--- a/front-end/src/hooks/blobSingleton.ts
+++ b/front-end/src/hooks/blobSingleton.ts
@@ -11,6 +11,7 @@ import {
   SessionSave,
 } from './save';
 import { coerceToBytes } from '../util';
+import { getGenesisChallenge } from '../constants/wallet-connect';
 import { log } from '../services/log';
 import {
   DIAGNOSTIC_LOG_LIMIT,
@@ -121,6 +122,7 @@ export async function configSessionController(
     sc.myContribution,
     theirContribution,
     sc.rewardPuzzleHash,
+    getGenesisChallenge(),
     channelTimeout,
     unrollTimeout,
   );

--- a/front-end/src/hooks/save.ts
+++ b/front-end/src/hooks/save.ts
@@ -15,6 +15,7 @@ import {
   SESSION_SAVE_SCHEMA,
   SESSION_SAVE_VERSION,
   type BlockchainType,
+  type ChiaNetwork,
   type LiveSessionSave,
   type PreHandshakeSessionSave,
   type SessionHistorySave,
@@ -552,6 +553,16 @@ export function clearSessionId(): void {
 
 export function getBlockchainType(): BlockchainType | undefined {
   return loadState().preferences.blockchainType;
+}
+
+export function getNetwork(): ChiaNetwork {
+  return loadState().preferences.network ?? 'mainnet';
+}
+
+export function setNetwork(network: ChiaNetwork): void {
+  mutate((s) => {
+    s.preferences.network = network;
+  });
 }
 
 export type SessionCacheUpdate =

--- a/front-end/src/hooks/savePreferences.ts
+++ b/front-end/src/hooks/savePreferences.ts
@@ -2,12 +2,13 @@ import {
   SESSION_SAVE_SCHEMA,
   SESSION_SAVE_VERSION,
   type BlockchainType,
+  type ChiaNetwork,
   type SessionSave,
 } from '../lib/session/saveEnvelope';
 import { randomHex } from './saveCoordination';
 
 const STATE_KEY = 'appState';
-const PREFERENCES_KEY = 'appPreferences';
+export const PREFERENCES_KEY = 'appPreferences';
 
 interface StoredPreferences {
   playerId: string;
@@ -23,6 +24,7 @@ interface StoredPreferences {
   walletAlert?: boolean;
   hubAlert?: boolean;
   blockchainType?: BlockchainType;
+  network?: ChiaNetwork;
 }
 
 export function savePreferences(state: SessionSave): void {
@@ -40,6 +42,7 @@ export function savePreferences(state: SessionSave): void {
     walletAlert: state.preferences.walletAlert,
     hubAlert: state.preferences.hubAlert,
     blockchainType: state.preferences.blockchainType,
+    network: state.preferences.network,
   };
   try {
     localStorage.setItem(PREFERENCES_KEY, JSON.stringify(preferences));
@@ -77,6 +80,7 @@ export function loadPreferences(): SessionSave {
             walletAlert: preferences.walletAlert,
             hubAlert: preferences.hubAlert,
             blockchainType: preferences.blockchainType,
+            network: preferences.network,
           },
           history: {},
         };

--- a/front-end/src/hooks/useWalletConnect.ts
+++ b/front-end/src/hooks/useWalletConnect.ts
@@ -2,8 +2,8 @@ import Client from '@walletconnect/sign-client';
 import { SessionTypes } from '@walletconnect/types';
 import { Subject } from 'rxjs';
 
-import { PROJECT_ID, RELAY_URL, CHAIN_ID } from '../constants/env';
-import { REQUIRED_NAMESPACES } from '../constants/wallet-connect';
+import { PROJECT_ID, RELAY_URL } from '../constants/env';
+import { getChainId, getRequiredNamespaces } from '../constants/wallet-connect';
 import { log } from '../services/log';
 
 export interface StartConnectResult {
@@ -51,7 +51,7 @@ class WalletState {
   }
 
   getChainId() {
-    return this.chainId ?? CHAIN_ID;
+    return this.chainId ?? getChainId();
   }
 
   getAddress() {
@@ -71,11 +71,11 @@ class WalletState {
     const accounts = namespace.accounts ?? [];
     const methods = namespace.methods ?? [];
     const chains = namespace.chains ?? [];
-    const account = accounts.find((candidate) => candidate.startsWith(`${CHAIN_ID}:`)) ?? null;
-    const chainGranted = chains.includes(CHAIN_ID) || !!account;
-    const methodsGranted = REQUIRED_NAMESPACES.chia.methods.every((method) =>
-      methods.includes(method),
-    );
+    const chainId = getChainId();
+    const account = accounts.find((candidate) => candidate.startsWith(`${chainId}:`)) ?? null;
+    const chainGranted = chains.includes(chainId) || !!account;
+    const requiredMethods = getRequiredNamespaces().chia.methods ?? [];
+    const methodsGranted = requiredMethods.every((method) => methods.includes(method));
 
     return account && chainGranted && methodsGranted ? account : null;
   }
@@ -240,7 +240,7 @@ class WalletState {
 
     try {
       const { uri, approval } = await this.client.connect({
-        requiredNamespaces: REQUIRED_NAMESPACES,
+        requiredNamespaces: getRequiredNamespaces(),
       });
 
       this.observable.next({

--- a/front-end/src/lib/restoreLifecycle.ts
+++ b/front-end/src/lib/restoreLifecycle.ts
@@ -1,5 +1,6 @@
 import type { SessionPhase } from '../types/ChiaGaming';
 import type { RestoreStatus } from '../hooks/SessionController';
+import type { SessionSave } from './session/saveEnvelope';
 import {
   createSessionModel,
   isPreActiveChannelStatus,
@@ -70,6 +71,27 @@ export function shouldAdvertiseAvailable(
 export function shouldReportHubBusy(sessionPhase: SessionPhase, walletConnected = true): boolean {
   if (!walletConnected) return true;
   return sessionPhase !== 'none' && sessionPhase !== 'resolved';
+}
+
+/**
+ * True when a WASM cradle already exists — or is about to be created — with a
+ * baked-in genesis challenge. Changing the network preference would let
+ * WalletConnect pair a different chain id than that challenge, so signatures
+ * would not verify on the connected chain.
+ *
+ * A resolved freeze does not lock: the next match may choose a new network.
+ * Mid-resume still locks while phase is `none` if a live or pre-handshake
+ * save (or pairing token) is present.
+ */
+export function sessionLocksNetwork(
+  sessionPhase: SessionPhase,
+  savePhase?: SessionSave['phase'],
+  pairingToken?: string,
+): boolean {
+  if (sessionPhase === 'off-chain' || sessionPhase === 'on-chain') return true;
+  if (sessionPhase === 'resolved') return false;
+  if (savePhase === 'live' || savePhase === 'pre-handshake') return true;
+  return !!pairingToken;
 }
 
 /**

--- a/front-end/src/lib/session/peerSessionParams.ts
+++ b/front-end/src/lib/session/peerSessionParams.ts
@@ -52,3 +52,19 @@ export function isValidTimeoutString(v: string | undefined): boolean {
   const n = parseOptionalBigInt(v);
   return n !== undefined && n >= BigInt(MIN_TIMEOUT_BLOCKS) && n <= BigInt(MAX_TIMEOUT_BLOCKS);
 }
+
+/**
+ * Trust-boundary check for the network advertised in a peer `session_proposal`.
+ *
+ * The advertised value must be a well-formed network id (`mainnet`/`testnet`)
+ * and equal to our local network preference. A missing, malformed, or opposite
+ * network is rejected: a mainnet client and a testnet client bind different
+ * genesis challenges, so their signatures would never verify on the same chain.
+ */
+export function sessionProposalNetworkMatches(
+  advertised: string | undefined,
+  local: string,
+): boolean {
+  if (advertised !== 'mainnet' && advertised !== 'testnet') return false;
+  return advertised === local;
+}

--- a/front-end/src/lib/session/persistence.ts
+++ b/front-end/src/lib/session/persistence.ts
@@ -103,6 +103,14 @@ function parsePreferences(value: unknown): SessionPreferencesSave {
           new Set(['simulator', 'walletconnect']),
           'preferences.blockchainType',
         );
+  const network =
+    fields.network === undefined
+      ? undefined
+      : parseDiscriminant<'mainnet' | 'testnet'>(
+          fields.network,
+          new Set(['mainnet', 'testnet']),
+          'preferences.network',
+        );
   return {
     alias: optionalString(fields.alias, 'preferences.alias', true),
     theme,
@@ -126,6 +134,7 @@ function parsePreferences(value: unknown): SessionPreferencesSave {
         ? undefined
         : requireBoolean(fields.hubAlert, 'preferences.hubAlert'),
     blockchainType,
+    network,
   };
 }
 

--- a/front-end/src/lib/session/persistencePayloads.ts
+++ b/front-end/src/lib/session/persistencePayloads.ts
@@ -245,6 +245,13 @@ export function validateCommonFields(save: SessionSave): void {
   ) {
     throw new Error('Garbled save: invalid blockchainType');
   }
+  if (
+    save.preferences.network !== undefined &&
+    save.preferences.network !== 'mainnet' &&
+    save.preferences.network !== 'testnet'
+  ) {
+    throw new Error('Garbled save: invalid network');
+  }
   if (save.preferences.defaultFee !== undefined) {
     requireBigint(save.preferences.defaultFee, 'preferences.defaultFee');
   }

--- a/front-end/src/lib/session/saveEnvelope.ts
+++ b/front-end/src/lib/session/saveEnvelope.ts
@@ -14,6 +14,8 @@ export const SESSION_SAVE_VERSION = 12n;
 
 export type BlockchainType = 'simulator' | 'walletconnect';
 
+export type ChiaNetwork = 'mainnet' | 'testnet';
+
 export interface SessionIdentitySave {
   playerId: string;
   sessionId?: string;
@@ -31,6 +33,7 @@ export interface SessionPreferencesSave {
   walletAlert?: boolean;
   hubAlert?: boolean;
   blockchainType?: BlockchainType;
+  network?: ChiaNetwork;
 }
 
 export interface SessionHistorySave {

--- a/front-end/src/lib/tests/currency_labels.test.ts
+++ b/front-end/src/lib/tests/currency_labels.test.ts
@@ -1,0 +1,64 @@
+import { getCurrencyLabels, isTestnet } from '../../constants/currency';
+import { formatAmount, formatMojos } from '../../util';
+
+const PREFERENCES_KEY = 'appPreferences';
+
+function selectNetwork(network: 'mainnet' | 'testnet' | undefined) {
+  if (network === undefined) {
+    localStorage.removeItem(PREFERENCES_KEY);
+    return;
+  }
+  localStorage.setItem(PREFERENCES_KEY, JSON.stringify({ playerId: 'test', network }));
+}
+
+describe('currency labels follow the network preference', () => {
+  afterEach(() => {
+    localStorage.removeItem(PREFERENCES_KEY);
+  });
+
+  it('defaults to mainnet nomenclature when no preference is stored', () => {
+    selectNetwork(undefined);
+    expect(isTestnet()).toBe(false);
+    expect(getCurrencyLabels()).toEqual({
+      xch: 'XCH',
+      chia: 'chia',
+      mojo: 'mojo',
+      mojos: 'mojos',
+      MOJO: 'MOJO',
+    });
+  });
+
+  it('uses T-prefixed nomenclature on testnet', () => {
+    selectNetwork('testnet');
+    expect(isTestnet()).toBe(true);
+    expect(getCurrencyLabels()).toEqual({
+      xch: 'TXCH',
+      chia: 'TXCH',
+      mojo: 'TMojo',
+      mojos: 'TMojos',
+      MOJO: 'TMOJO',
+    });
+  });
+});
+
+describe('formatAmount / formatMojos honor the network labels', () => {
+  afterEach(() => {
+    localStorage.removeItem(PREFERENCES_KEY);
+  });
+
+  it('formats mainnet amounts with XCH / MOJO / mojos', () => {
+    selectNetwork('mainnet');
+    expect(formatAmount(999_999n)).toBe('999999 MOJO');
+    expect(formatAmount(1_000_000_000_000n)).toBe('1 XCH');
+    expect(formatMojos(100_000_000n)).toBe('0.0001 XCH');
+    expect(formatMojos(999n)).toBe('999 mojos');
+  });
+
+  it('formats testnet amounts with TXCH / TMOJO / TMojos', () => {
+    selectNetwork('testnet');
+    expect(formatAmount(999_999n)).toBe('999999 TMOJO');
+    expect(formatAmount(1_000_000_000_000n)).toBe('1 TXCH');
+    expect(formatMojos(100_000_000n)).toBe('0.0001 TXCH');
+    expect(formatMojos(999n)).toBe('999 TMojos');
+  });
+});

--- a/front-end/src/lib/tests/hub_connection.test.ts
+++ b/front-end/src/lib/tests/hub_connection.test.ts
@@ -323,6 +323,26 @@ describe('binary message relay', () => {
     expect(cb.onPeerAppMessage).toHaveBeenCalledWith('p_sender', 'p_sender', appMessage);
   });
 
+  it('decodes the network field on a session_proposal', async () => {
+    const cb = makeCallbacks();
+    makeConnection('http://t', 's1', cb);
+    await Promise.resolve();
+
+    const appMessage = {
+      type: 'session_proposal',
+      proposer_amount: '500',
+      responder_amount: '500',
+      network: 'testnet',
+    };
+    const payload = encodeBencodex(appMessage);
+    MockWebSocket.instance!._fireBinaryInbound('p_sender', payload);
+    expect(cb.onPeerAppMessage).toHaveBeenCalledWith(
+      'p_sender',
+      'p_sender',
+      expect.objectContaining({ type: 'session_proposal', network: 'testnet' }),
+    );
+  });
+
   it('passes distinct alias from binary frame header', async () => {
     const cb = makeCallbacks();
     makeConnection('http://t', 's1', cb);

--- a/front-end/src/lib/tests/peer_session_params.test.ts
+++ b/front-end/src/lib/tests/peer_session_params.test.ts
@@ -2,6 +2,7 @@ import {
   isValidSessionAmountString,
   isValidTimeoutString,
   parseSessionAmount,
+  sessionProposalNetworkMatches,
 } from '../session/peerSessionParams';
 
 describe('peerSessionParams', () => {
@@ -53,6 +54,25 @@ describe('peerSessionParams', () => {
       expect(() => parseSessionAmount('0')).toThrow(/positive/);
       expect(() => parseSessionAmount('bad')).toThrow(/invalid session amount/);
       expect(() => parseSessionAmount('08')).toThrow(/invalid session amount/);
+    });
+  });
+
+  describe('sessionProposalNetworkMatches', () => {
+    it('accepts a well-formed network that equals the local preference', () => {
+      expect(sessionProposalNetworkMatches('mainnet', 'mainnet')).toBe(true);
+      expect(sessionProposalNetworkMatches('testnet', 'testnet')).toBe(true);
+    });
+
+    it('rejects the opposite network', () => {
+      expect(sessionProposalNetworkMatches('mainnet', 'testnet')).toBe(false);
+      expect(sessionProposalNetworkMatches('testnet', 'mainnet')).toBe(false);
+    });
+
+    it('rejects a missing or malformed advertised network', () => {
+      expect(sessionProposalNetworkMatches(undefined, 'mainnet')).toBe(false);
+      expect(sessionProposalNetworkMatches('', 'mainnet')).toBe(false);
+      expect(sessionProposalNetworkMatches('Mainnet', 'mainnet')).toBe(false);
+      expect(sessionProposalNetworkMatches('chia:mainnet', 'mainnet')).toBe(false);
     });
   });
 });

--- a/front-end/src/lib/tests/restore_lifecycle.test.ts
+++ b/front-end/src/lib/tests/restore_lifecycle.test.ts
@@ -1,6 +1,7 @@
 import {
   isRestoreBlocked,
   restoreGateAfterTerminalFinalization,
+  sessionLocksNetwork,
   shouldAdvertiseAvailable,
   shouldAwaitShutdownOnPeerUnreachable,
   shouldCancelAttemptOnDisconnect,
@@ -76,6 +77,21 @@ describe('restore lifecycle gates', () => {
     // Explicit walletConnected=true matches the default behavior.
     expect(shouldReportHubBusy('none', true)).toBe(false);
     expect(shouldReportHubBusy('off-chain', true)).toBe(true);
+  });
+
+  it('locks the network while a session binds a genesis challenge', () => {
+    expect(sessionLocksNetwork('none')).toBe(false);
+    expect(sessionLocksNetwork('resolved')).toBe(false);
+    expect(sessionLocksNetwork('resolved', 'live', 'pair')).toBe(false);
+    expect(sessionLocksNetwork('resolved', 'terminal')).toBe(false);
+
+    expect(sessionLocksNetwork('off-chain')).toBe(true);
+    expect(sessionLocksNetwork('on-chain')).toBe(true);
+    expect(sessionLocksNetwork('none', 'live')).toBe(true);
+    expect(sessionLocksNetwork('none', 'pre-handshake')).toBe(true);
+    expect(sessionLocksNetwork('none', 'preferences', 'pair')).toBe(true);
+    expect(sessionLocksNetwork('none', 'preferences')).toBe(false);
+    expect(sessionLocksNetwork('none', 'terminal')).toBe(false);
   });
 
   it('keeps hub presence busy for a non-terminal restore cradle even when phase is still none', () => {

--- a/front-end/src/lib/tests/wallet_connect_chain.test.ts
+++ b/front-end/src/lib/tests/wallet_connect_chain.test.ts
@@ -1,0 +1,62 @@
+import 'fake-indexeddb/auto';
+import { getChainId, getRequiredNamespaces, ChiaMethod } from '../../constants/wallet-connect';
+import { setNetwork, _resetForTests } from '../../hooks/save';
+
+function makeStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (i: number) => [...store.keys()][i] ?? null,
+  };
+}
+
+function setGlobal(key: string, value: unknown) {
+  Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+}
+
+describe('WalletConnect chain id follows the network preference', () => {
+  beforeEach(() => {
+    _resetForTests();
+    setGlobal('localStorage', makeStorage());
+    setGlobal('sessionStorage', makeStorage());
+  });
+
+  afterEach(() => {
+    _resetForTests();
+    Reflect.deleteProperty(globalThis, 'localStorage');
+    Reflect.deleteProperty(globalThis, 'sessionStorage');
+  });
+
+  it('defaults to mainnet', () => {
+    expect(getChainId()).toBe('chia:mainnet');
+    expect(getRequiredNamespaces().chia.chains).toEqual(['chia:mainnet']);
+  });
+
+  it('uses the testnet chain id when the preference is testnet', () => {
+    setNetwork('testnet');
+    expect(getChainId()).toBe('chia:testnet');
+    expect(getRequiredNamespaces().chia.chains).toEqual(['chia:testnet']);
+  });
+
+  it('switches back to mainnet when the preference changes', () => {
+    setNetwork('testnet');
+    expect(getChainId()).toBe('chia:testnet');
+    setNetwork('mainnet');
+    expect(getChainId()).toBe('chia:mainnet');
+  });
+
+  it('always requests the full Chia method set', () => {
+    const methods = getRequiredNamespaces().chia.methods;
+    expect(methods).toEqual(Object.values(ChiaMethod));
+  });
+});

--- a/front-end/src/lib/tests/wallet_connect_chain.test.ts
+++ b/front-end/src/lib/tests/wallet_connect_chain.test.ts
@@ -6,7 +6,7 @@ import {
   ChiaMethod,
 } from '../../constants/wallet-connect';
 import { MAINNET_GENESIS_CHALLENGE, TESTNET_GENESIS_CHALLENGE } from '../../constants/env';
-import { setNetwork, _resetForTests } from '../../hooks/save';
+import { setNetwork, saveSession, _resetForTests } from '../../hooks/save';
 
 function makeStorage(): Storage {
   const store = new Map<string, string>();
@@ -94,5 +94,17 @@ describe('genesis challenge follows the network preference', () => {
     expect(getGenesisChallenge()).toBe(TESTNET_GENESIS_CHALLENGE);
     setNetwork('mainnet');
     expect(getGenesisChallenge()).toBe(MAINNET_GENESIS_CHALLENGE);
+  });
+
+  it('uses the mainnet challenge for the simulator even when testnet is selected', async () => {
+    setNetwork('testnet');
+    await saveSession({ scope: 'common', preferences: { blockchainType: 'simulator' } });
+    expect(getGenesisChallenge()).toBe(MAINNET_GENESIS_CHALLENGE);
+  });
+
+  it('still uses the testnet challenge for WalletConnect when testnet is selected', async () => {
+    setNetwork('testnet');
+    await saveSession({ scope: 'common', preferences: { blockchainType: 'walletconnect' } });
+    expect(getGenesisChallenge()).toBe(TESTNET_GENESIS_CHALLENGE);
   });
 });

--- a/front-end/src/lib/tests/wallet_connect_chain.test.ts
+++ b/front-end/src/lib/tests/wallet_connect_chain.test.ts
@@ -5,10 +5,7 @@ import {
   getRequiredNamespaces,
   ChiaMethod,
 } from '../../constants/wallet-connect';
-import {
-  MAINNET_GENESIS_CHALLENGE,
-  TESTNET_GENESIS_CHALLENGE,
-} from '../../constants/env';
+import { MAINNET_GENESIS_CHALLENGE, TESTNET_GENESIS_CHALLENGE } from '../../constants/env';
 import { setNetwork, _resetForTests } from '../../hooks/save';
 
 function makeStorage(): Storage {

--- a/front-end/src/lib/tests/wallet_connect_chain.test.ts
+++ b/front-end/src/lib/tests/wallet_connect_chain.test.ts
@@ -1,5 +1,14 @@
 import 'fake-indexeddb/auto';
-import { getChainId, getRequiredNamespaces, ChiaMethod } from '../../constants/wallet-connect';
+import {
+  getChainId,
+  getGenesisChallenge,
+  getRequiredNamespaces,
+  ChiaMethod,
+} from '../../constants/wallet-connect';
+import {
+  MAINNET_GENESIS_CHALLENGE,
+  TESTNET_GENESIS_CHALLENGE,
+} from '../../constants/env';
 import { setNetwork, _resetForTests } from '../../hooks/save';
 
 function makeStorage(): Storage {
@@ -58,5 +67,35 @@ describe('WalletConnect chain id follows the network preference', () => {
   it('always requests the full Chia method set', () => {
     const methods = getRequiredNamespaces().chia.methods;
     expect(methods).toEqual(Object.values(ChiaMethod));
+  });
+});
+
+describe('genesis challenge follows the network preference', () => {
+  beforeEach(() => {
+    _resetForTests();
+    setGlobal('localStorage', makeStorage());
+    setGlobal('sessionStorage', makeStorage());
+  });
+
+  afterEach(() => {
+    _resetForTests();
+    Reflect.deleteProperty(globalThis, 'localStorage');
+    Reflect.deleteProperty(globalThis, 'sessionStorage');
+  });
+
+  it('defaults to the mainnet genesis challenge', () => {
+    expect(getGenesisChallenge()).toBe(MAINNET_GENESIS_CHALLENGE);
+  });
+
+  it('uses the testnet11 genesis challenge when the preference is testnet', () => {
+    setNetwork('testnet');
+    expect(getGenesisChallenge()).toBe(TESTNET_GENESIS_CHALLENGE);
+  });
+
+  it('switches back to mainnet when the preference changes', () => {
+    setNetwork('testnet');
+    expect(getGenesisChallenge()).toBe(TESTNET_GENESIS_CHALLENGE);
+    setNetwork('mainnet');
+    expect(getGenesisChallenge()).toBe(MAINNET_GENESIS_CHALLENGE);
   });
 });

--- a/front-end/src/services/HubConnection.ts
+++ b/front-end/src/services/HubConnection.ts
@@ -57,6 +57,7 @@ export type PeerAppMessage =
       channel_timeout?: string;
       unroll_timeout?: string;
       game_session_id?: string;
+      network?: string;
     }
   | { type: 'session_reject' };
 
@@ -127,6 +128,7 @@ function decodePeerAppMessage(payload: Uint8Array): PeerAppMessage | null {
         channel_timeout: optionalText(decoded, 'channel_timeout'),
         unroll_timeout: optionalText(decoded, 'unroll_timeout'),
         game_session_id: optionalText(decoded, 'game_session_id'),
+        network: optionalText(decoded, 'network'),
       };
     case 'session_reject':
       return { type };

--- a/front-end/src/types/ChiaGaming.ts
+++ b/front-end/src/types/ChiaGaming.ts
@@ -254,6 +254,7 @@ interface GameSessionCreateConfig {
   channel_timeout: number;
   unroll_timeout: number;
   reward_puzzle_hash: string;
+  genesis_challenge: string;
 }
 
 /// A labeled coin id (hex) surfaced in the dashboard for explorer lookup.

--- a/front-end/src/util.ts
+++ b/front-end/src/util.ts
@@ -1,4 +1,5 @@
 import { Spend, CoinSpend, SpendBundle } from './types/ChiaGaming';
+import { getCurrencyLabels } from './constants/currency';
 
 export function toUint8(s: string) {
   if (s.length % 2 != 0) {
@@ -117,18 +118,20 @@ export function spend_bundle_to_clvm(sbundle: SpendBundle): string {
 }
 
 export function formatAmount(mojos: bigint): string {
+  const labels = getCurrencyLabels();
   if (mojos < 1_000_000n) {
-    return `${mojos} MOJO`;
+    return `${mojos} ${labels.MOJO}`;
   }
   const TRILLION = 1_000_000_000_000n;
   const whole = mojos / TRILLION;
   const frac = mojos % TRILLION;
-  if (frac === 0n) return `${whole} XCH`;
+  if (frac === 0n) return `${whole} ${labels.xch}`;
   const fracStr = frac.toString().padStart(12, '0').replace(/0+$/, '');
-  return `${whole}.${fracStr} XCH`;
+  return `${whole}.${fracStr} ${labels.xch}`;
 }
 
 export function formatMojos(mojos: bigint): string {
+  const labels = getCurrencyLabels();
   const TRILLION = 1_000_000_000_000n;
   const absMojos = mojos < 0n ? -mojos : mojos;
   if (absMojos >= 100_000_000n) {
@@ -136,9 +139,9 @@ export function formatMojos(mojos: bigint): string {
     const whole = absMojos / TRILLION;
     const frac = absMojos % TRILLION;
     const fracStr = frac.toString().padStart(12, '0').slice(0, 4);
-    return `${sign}${whole.toLocaleString()}.${fracStr} XCH`;
+    return `${sign}${whole.toLocaleString()}.${fracStr} ${labels.xch}`;
   }
-  return `${mojos.toLocaleString()} mojos`;
+  return `${mojos.toLocaleString()} ${labels.mojos}`;
 }
 
 /** Encode a non-negative integer as CLVM atom hex (big-endian, minimal). */

--- a/src/channel_state/types/channel_state.rs
+++ b/src/channel_state/types/channel_state.rs
@@ -71,7 +71,21 @@ pub struct ChannelEnv<'a> {
 }
 
 impl<'a> ChannelEnv<'a> {
+    /// Construct a channel environment using the mainnet genesis challenge.
+    /// Prefer `new_with_genesis` in production so signatures match the network
+    /// the session is bound to; this default is retained for tests and the
+    /// simulator, which operate against the mainnet constant.
     pub fn new(allocator: &'a mut AllocEncoder) -> Result<ChannelEnv<'a>, Error> {
+        ChannelEnv::new_with_genesis(allocator, &Hash::from_bytes(AGG_SIG_ME_ADDITIONAL_DATA))
+    }
+
+    /// Construct a channel environment bound to a specific network's genesis
+    /// challenge (AGG_SIG_ME additional data). This value is folded into every
+    /// AGG_SIG_ME signature, so it must match the connected network.
+    pub fn new_with_genesis(
+        allocator: &'a mut AllocEncoder,
+        agg_sig_me_additional_data: &Hash,
+    ) -> Result<ChannelEnv<'a>, Error> {
         let referee_coin_puzzle = read_hex_puzzle(allocator, "clsp/referee/onchain/referee.hex")?;
         let unroll_puzzle = read_hex_puzzle(
             allocator,
@@ -85,7 +99,7 @@ impl<'a> ChannelEnv<'a> {
             referee_coin_puzzle_hash,
             unroll_puzzle,
             standard_puzzle,
-            agg_sig_me_additional_data: Hash::from_bytes(AGG_SIG_ME_ADDITIONAL_DATA),
+            agg_sig_me_additional_data: agg_sig_me_additional_data.clone(),
         })
     }
 }

--- a/src/game_session.rs
+++ b/src/game_session.rs
@@ -340,6 +340,12 @@ struct GameSessionState {
     #[serde(default)]
     channel_expired: bool,
 
+    /// Genesis challenge (AGG_SIG_ME additional data) for the network this
+    /// session is bound to. Threaded in at creation so all on-chain signing
+    /// (channel funding, unroll, clean-shutdown payout) matches the connected
+    /// network. Persisted so restored sessions keep signing correctly.
+    agg_sig_me_additional_data: Hash,
+
     #[serde(skip)]
     events: GameSessionEventQueue,
 }
@@ -419,6 +425,8 @@ pub struct GameSessionConfig {
     pub channel_timeout: Timeout,
     pub unroll_timeout: Timeout,
     pub reward_puzzle_hash: PuzzleHash,
+    /// Genesis challenge (AGG_SIG_ME additional data) for the target network.
+    pub agg_sig_me_additional_data: Hash,
 }
 
 /// Scan a wallet `SpendBundle` for settlement-payment outputs created by
@@ -501,6 +509,7 @@ impl GameSession {
                 channel_creation_expiry: None,
                 channel_established: false,
                 channel_expired: false,
+                agg_sig_me_additional_data: config.agg_sig_me_additional_data.clone(),
                 events: GameSessionEventQueue::default(),
                 inbound_messages: VecDeque::default(),
             },
@@ -605,7 +614,8 @@ impl GameSession {
 
     #[cfg(test)]
     pub fn force_unroll_spend(&self, allocator: &mut AllocEncoder) -> Result<SpendBundle, Error> {
-        let mut env = ChannelEnv::new(allocator)?;
+        let mut env =
+            ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
         if let Some(ph) = self.peer.as_any().downcast_ref::<OffChainPhase>() {
             return ph.force_unroll_spend(&mut env);
         }
@@ -632,7 +642,8 @@ impl GameSession {
         let saved = self.saved_unroll_snapshot.as_ref().ok_or_else(|| {
             Error::StrErr("force_stale_unroll_spend: no snapshot saved".to_string())
         })?;
-        let mut env = ChannelEnv::new(allocator)?;
+        let mut env =
+            ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
         let ph = self
             .peer
             .as_any()
@@ -740,7 +751,8 @@ impl GameSession {
         launcher_coin: CoinString,
     ) -> Result<(), Error> {
         let effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.provide_launcher_coin(&mut env, launcher_coin)?
         };
         self.process_effects(effects, allocator)?;
@@ -754,7 +766,8 @@ impl GameSession {
     ) -> Result<(), Error> {
         let bundle = claim_settlement_coins(allocator, bundle);
         let effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.provide_coin_spend_bundle(&mut env, bundle)?
         };
         self.process_effects(effects, allocator)?;
@@ -828,7 +841,10 @@ impl GameSession {
         }
         while let Some(msg) = self.state.inbound_messages.pop_front() {
             let recv_result = {
-                let mut env = ChannelEnv::new(allocator)?;
+                let mut env = ChannelEnv::new_with_genesis(
+                    allocator,
+                    &self.state.agg_sig_me_additional_data,
+                )?;
                 self.peer.received_message(&mut env, msg)
             };
             match recv_result {
@@ -847,7 +863,8 @@ impl GameSession {
         let res = if self.state.session_disposition.is_some() {
             None
         } else {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             Some(self.peer.flush_pending_actions(&mut env))
         };
         match res {
@@ -1179,7 +1196,10 @@ impl GameSession {
         if self.peer.handshake_finished() {
             while self.peer.has_queued_message() {
                 let recv_result = {
-                    let mut env = ChannelEnv::new(allocator)?;
+                    let mut env = ChannelEnv::new_with_genesis(
+                        allocator,
+                        &self.state.agg_sig_me_additional_data,
+                    )?;
                     self.peer.process_queued_message(&mut env)
                 };
                 match recv_result {
@@ -1198,7 +1218,10 @@ impl GameSession {
             }
             while self.peer.has_queued_action() {
                 let action_result = {
-                    let mut env = ChannelEnv::new(allocator)?;
+                    let mut env = ChannelEnv::new_with_genesis(
+                        allocator,
+                        &self.state.agg_sig_me_additional_data,
+                    )?;
                     self.peer.process_queued_action(&mut env)
                 };
                 match action_result {
@@ -1270,7 +1293,8 @@ impl GameSession {
         .into_gen()?;
 
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             let spend = standard_solution_partial(
                 env.allocator,
                 &self.state.identity.synthetic_private_key,
@@ -1316,7 +1340,8 @@ impl GameSession {
         self.state.unfunded_offer = None;
 
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             let empty_conditions = ().to_clvm(env.allocator).into_gen()?;
             let quoted_empty_conditions = empty_conditions.to_quoted_program(env.allocator)?;
             let solution = solution_for_conditions(env.allocator, empty_conditions)?;
@@ -1366,7 +1391,8 @@ impl GameSession {
     #[cfg(test)]
     pub fn flush_pending(&mut self, allocator: &mut AllocEncoder) -> Result<(), Error> {
         let effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.flush_pending_actions(&mut env)?
         };
         self.process_effects(effects, allocator)?;
@@ -1407,7 +1433,8 @@ impl GameSession {
         game_id: &GameID,
     ) -> Result<(), Error> {
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.self_accept_proposal(&mut env, game_id)?
         };
         self.process_effects(reported_effects, allocator)?;
@@ -1422,7 +1449,8 @@ impl GameSession {
     ) -> Result<(), Error> {
         let entropy: Hash = Hash::default();
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer
                 .cheat_game(&mut env, game_id, mover_share, entropy)?
         };
@@ -1442,7 +1470,8 @@ impl GameSession {
         &mut self,
         allocator: &mut AllocEncoder,
     ) -> Result<PuzzleHash, Error> {
-        let mut env = ChannelEnv::new(allocator)?;
+        let mut env =
+            ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
         self.peer.channel_state()?.get_reward_puzzle_hash(&mut env)
     }
 
@@ -1450,7 +1479,8 @@ impl GameSession {
         &mut self,
         allocator: &mut AllocEncoder,
     ) -> Result<Option<Hash>, Error> {
-        let mut env = ChannelEnv::new(allocator)?;
+        let mut env =
+            ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
         match self.peer.channel_state() {
             Ok(ch) => ch.get_game_state_id(&mut env).map(Some),
             Err(_) => Ok(None),
@@ -1469,7 +1499,8 @@ impl GameSession {
         }
 
         let start_effect = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             if let Some(hh) = self
                 .peer
                 .as_any_mut()
@@ -1493,7 +1524,8 @@ impl GameSession {
         }
 
         let start_effect = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             if let Some(hh) = self
                 .peer
                 .as_any_mut()
@@ -1521,7 +1553,8 @@ impl GameSession {
         games: &[GameProposal],
     ) -> Result<Vec<GameID>, Error> {
         let (result, reported_effects) = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.propose_games(&mut env, games)?
         };
         self.process_effects(reported_effects, allocator)?;
@@ -1534,7 +1567,8 @@ impl GameSession {
         game_id: &GameID,
     ) -> Result<(), Error> {
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.accept_proposal(&mut env, game_id)?
         };
         self.process_effects(reported_effects, allocator)?;
@@ -1547,7 +1581,8 @@ impl GameSession {
         game_id: &GameID,
     ) -> Result<(), Error> {
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.cancel_proposal(&mut env, game_id)?
         };
         self.process_effects(reported_effects, allocator)?;
@@ -1567,7 +1602,8 @@ impl GameSession {
         new_entropy: Hash,
     ) -> Result<(), Error> {
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.make_move(&mut env, id, &readable, new_entropy)?
         };
         self.process_effects(reported_effects, allocator)?;
@@ -1582,7 +1618,8 @@ impl GameSession {
         new_entropy: Hash,
     ) -> Result<(), Error> {
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             let mut effects = self.peer.accept_proposal(&mut env, id)?;
             effects.extend(self.peer.make_move(&mut env, id, &readable, new_entropy)?);
             effects
@@ -1598,7 +1635,8 @@ impl GameSession {
         id: &GameID,
     ) -> Result<(), Error> {
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.accept_settlement(&mut env, id)?
         };
         self.process_effects(reported_effects, allocator)?;
@@ -1608,7 +1646,8 @@ impl GameSession {
     /// Signal shutdown.  Forwards to FromLocalUI::shut_down.
     pub fn shut_down(&mut self, allocator: &mut AllocEncoder) -> Result<(), Error> {
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.shut_down(&mut env)?
         };
         self.process_effects(reported_effects, allocator)?;
@@ -1628,7 +1667,10 @@ impl GameSession {
         self.state.current_height = height;
         for observation in observations {
             let effects = {
-                let mut env = ChannelEnv::new(allocator)?;
+                let mut env = ChannelEnv::new_with_genesis(
+                    allocator,
+                    &self.state.agg_sig_me_additional_data,
+                )?;
                 match observation {
                     CoinObservation::Created(coin) => {
                         self.peer.coin_created(&mut env, coin)?.unwrap_or_default()
@@ -1711,7 +1753,8 @@ impl GameSession {
         }
         self.state.peer_disconnected = true;
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer.go_on_chain(&mut env, got_error)?
         };
         if !reported_effects.is_empty() {
@@ -1735,7 +1778,8 @@ impl GameSession {
             return Ok(());
         }
         let reported_effects = {
-            let mut env = ChannelEnv::new(allocator)?;
+            let mut env =
+                ChannelEnv::new_with_genesis(allocator, &self.state.agg_sig_me_additional_data)?;
             self.peer
                 .coin_puzzle_and_solution(&mut env, coin_id, puzzle_and_solution)?
         };
@@ -1935,6 +1979,61 @@ mod sequencing_tests {
         assert!(
             replacement_rec.borrow().created.is_empty(),
             "coin_created went to the handshake handler, not the replacement"
+        );
+    }
+}
+
+#[cfg(test)]
+mod genesis_challenge_tests {
+    use super::*;
+    use crate::common::constants::AGG_SIG_ME_ADDITIONAL_DATA;
+    use crate::common::types::PrivateKey;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn channel_env_new_with_genesis_uses_provided_challenge() {
+        let mut allocator = AllocEncoder::new();
+        let testnet = Hash::from_bytes([0x11; 32]);
+        let env = ChannelEnv::new_with_genesis(&mut allocator, &testnet).expect("env");
+        assert_eq!(env.agg_sig_me_additional_data, testnet);
+
+        let mut mainnet_allocator = AllocEncoder::new();
+        let env_default = ChannelEnv::new(&mut mainnet_allocator).expect("env");
+        assert_eq!(
+            env_default.agg_sig_me_additional_data,
+            Hash::from_bytes(AGG_SIG_ME_ADDITIONAL_DATA)
+        );
+    }
+
+    #[test]
+    fn game_session_persists_genesis_challenge_across_serialize() {
+        let mut allocator = AllocEncoder::new();
+        let mut rng = ChaCha8Rng::from_seed([1u8; 32]);
+        let private_key: PrivateKey = rng.random();
+        let identity = ChiaIdentity::new(&mut allocator, private_key).expect("identity");
+        let testnet = Hash::from_bytes([0x11; 32]);
+        let config = GameSessionConfig {
+            game_types: BTreeMap::new(),
+            have_potato: true,
+            identity,
+            my_contribution: Amount::new(100),
+            their_contribution: Amount::new(100),
+            channel_timeout: Timeout::new(5),
+            unroll_timeout: Timeout::new(15),
+            reward_puzzle_hash: PuzzleHash::from_bytes([2; 32]),
+            agg_sig_me_additional_data: testnet.clone(),
+        };
+        let private_keys: ChannelPrivateKeys = rng.random();
+        let session = GameSession::new_with_keys(config, private_keys);
+        assert_eq!(session.state.agg_sig_me_additional_data, testnet);
+
+        let bytes = bencodex::to_vec(&session).expect("serialize");
+        let restored: GameSession = bencodex::from_slice(&bytes).expect("deserialize");
+        assert_eq!(restored.state.agg_sig_me_additional_data, testnet);
+        assert_ne!(
+            restored.state.agg_sig_me_additional_data,
+            Hash::from_bytes(AGG_SIG_ME_ADDITIONAL_DATA)
         );
     }
 }

--- a/src/simulator/tests/session_phases_sim.rs
+++ b/src/simulator/tests/session_phases_sim.rs
@@ -8,11 +8,11 @@ use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 
 use crate::channel_state::types::{ChannelEnv, ChannelPrivateKeys, ReadableMove};
-use crate::common::constants::{CREATE_COIN, SINGLETON_LAUNCHER_HASH};
+use crate::common::constants::{AGG_SIG_ME_ADDITIONAL_DATA, CREATE_COIN, SINGLETON_LAUNCHER_HASH};
 use crate::common::standard_coin::{standard_solution_partial, ChiaIdentity};
 use crate::common::types::{atom_from_clvm, i64_from_atom, usize_from_atom};
 use crate::common::types::{
-    AllocEncoder, Amount, CoinID, CoinSpend, CoinString, Error, GameID, GameType, IntoErr,
+    AllocEncoder, Amount, CoinID, CoinSpend, CoinString, Error, GameID, GameType, Hash, IntoErr,
     PrivateKey, Program, PuzzleHash, Spend, SpendBundle, Timeout,
 };
 use crate::game_session::{GameSession, GameSessionConfig, MessagePeerQueue, MessagePipe};
@@ -962,6 +962,7 @@ fn run_game_container_with_action_list_with_success_predicate(
             channel_timeout: Timeout::new(5),
             unroll_timeout: Timeout::new(15),
             reward_puzzle_hash: identities[0].puzzle_hash.clone(),
+            agg_sig_me_additional_data: Hash::from_bytes(AGG_SIG_ME_ADDITIONAL_DATA),
         },
         private_keys[0].clone(),
     );
@@ -975,6 +976,7 @@ fn run_game_container_with_action_list_with_success_predicate(
             channel_timeout: Timeout::new(5),
             unroll_timeout: Timeout::new(15),
             reward_puzzle_hash: identities[1].puzzle_hash.clone(),
+            agg_sig_me_additional_data: Hash::from_bytes(AGG_SIG_ME_ADDITIONAL_DATA),
         },
         private_keys[1].clone(),
     );

--- a/wasm/src/mod.rs
+++ b/wasm/src/mod.rs
@@ -138,7 +138,7 @@ mod gaming_wasm {
 
     /// Increment for every incompatible change to the persisted `JsGameSession`
     /// shape, including incompatible shapes owned by nested Rust types.
-    const GAME_SESSION_SERIALIZATION_SCHEMA: u32 = 4;
+    const GAME_SESSION_SERIALIZATION_SCHEMA: u32 = 5;
 
     #[derive(Serialize)]
     struct JsWatchCoinEntry {
@@ -204,6 +204,7 @@ mod gaming_wasm {
         channel_timeout: i32,
         unroll_timeout: i32,
         reward_puzzle_hash: String,
+        genesis_challenge: String,
     }
 
     struct GameConfigPartial {
@@ -214,6 +215,7 @@ mod gaming_wasm {
         my_contribution: Amount,
         their_contribution: Amount,
         reward_puzzle_hash: PuzzleHash,
+        agg_sig_me_additional_data: Hash,
         rng_id: i32,
     }
 
@@ -227,6 +229,12 @@ mod gaming_wasm {
                 jsconfig.reward_puzzle_hash.len(),
             ))
         })?;
+        let genesis_challenge_bytes = hex::decode(&jsconfig.genesis_challenge).map_err(|e| {
+            js_error(&format!(
+                "genesis_challenge hex decode: {e:?} (length={})",
+                jsconfig.genesis_challenge.len(),
+            ))
+        })?;
 
         Ok(GameConfigPartial {
             game_types,
@@ -238,6 +246,7 @@ mod gaming_wasm {
             reward_puzzle_hash: PuzzleHash::from_hash(
                 Hash::from_slice(&reward_puzzle_hash_bytes).into_js()?,
             ),
+            agg_sig_me_additional_data: Hash::from_slice(&genesis_challenge_bytes).into_js()?,
             rng_id: jsconfig.rng_id,
         })
     }
@@ -330,6 +339,7 @@ mod gaming_wasm {
                 my_contribution: partial.my_contribution,
                 their_contribution: partial.their_contribution,
                 reward_puzzle_hash: partial.reward_puzzle_hash,
+                agg_sig_me_additional_data: partial.agg_sig_me_additional_data,
             };
 
             let game_cradle = GameSession::new(rng, config);


### PR DESCRIPTION
This PR also includes the change to support signing spends on testnet as previously the genesis challenge was not passed in and only supported mainnet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect WalletConnect pairing, persisted session/WASM serialization (schema bump), and all on-chain signing paths via genesis challenge binding; mismatch or restore across networks could reject spends or proposals.
> 
> **Overview**
> Adds a **Mainnet / Testnet** choice on the wallet connection screen, persisted in app preferences and wired through WalletConnect chain IDs, UI currency labels (TXCH/TMojo on testnet), and WASM session creation.
> 
> **Signing:** The WASM/Rust stack now takes a per-network **genesis challenge** (`AGG_SIG_ME` additional data) at session creation, stores it on the game session, and builds `ChannelEnv` from it everywhere channel spends are signed. The local simulator still uses the mainnet challenge even when testnet is selected in the UI.
> 
> **Matchmaking:** `session_proposal` includes the proposer’s `network`. The challenger rejects proposals that are missing, invalid, or mismatched via `session_reject` before consent UI—the hub does not enforce network. While a session (or restore/pairing) binds a genesis challenge, the network toggle is locked (`sessionLocksNetwork`).
> 
> Docs (`CONNECTIVITY.md`, `FRONTEND_ARCHITECTURE.md`) describe the network-blind hub and client-side rejection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6907fabfcc055112c7488e064ebd149287415af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->