### PR TITLE
add standard root workspace scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,18 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
+    "build": "./tools/build-deploy.sh",
+    "build:check": "./cb.sh",
+    "check": "pnpm run format:check && pnpm run lint && pnpm run typecheck",
+    "dev": "./run-local-demo.sh",
     "format": "prettier --write 'front-end/src/**/*.{ts,tsx,js,jsx,mjs,json,css}' 'front-end/scripts/**/*.{ts,js,mjs}' 'front-end/*.{ts,js,mjs,json}' 'front-end/public/**/*.html' 'hub/*/src/**/*.{ts,tsx,js,jsx,mjs,json}' 'hub/*/*.{ts,js,mjs,json}' '*.{ts,js,mjs,json}'",
     "format:check": "prettier --check 'front-end/src/**/*.{ts,tsx,js,jsx,mjs,json,css}' 'front-end/scripts/**/*.{ts,js,mjs}' 'front-end/*.{ts,js,mjs,json}' 'front-end/public/**/*.html' 'hub/*/src/**/*.{ts,tsx,js,jsx,mjs,json}' 'hub/*/*.{ts,js,mjs,json}' '*.{ts,js,mjs,json}'",
     "lint": "eslint . --max-warnings 0",
-    "lint:fix": "pnpm run lint --fix"
+    "lint:fix": "pnpm run lint --fix",
+    "start": "./run-local-demo.sh --skip-build",
+    "test": "./ct.sh",
+    "test:js": "./tools/local-wasm-tests.sh",
+    "typecheck": "pnpm --filter chia-gaming-fe exec tsc --project tsconfig.json --noEmit && pnpm --filter chia-gaming-hub-frontend exec tsc --project tsconfig.json --noEmit && pnpm --filter chia-gaming-hub-service exec tsc --project tsconfig.json --noEmit"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",


### PR DESCRIPTION
add standard root workspace scripts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds script aliases and a typecheck aggregator; no application or build logic changes.
> 
> **Overview**
> Adds **root `package.json` scripts** so common workflows run through `pnpm` instead of invoking shell scripts directly.
> 
> **Build & dev:** `build` → `tools/build-deploy.sh`, `build:check` → `cb.sh`, `dev` and `start` → `run-local-demo.sh` (`start` skips build).
> 
> **Quality:** `check` chains `format:check`, `lint`, and a new `typecheck` that runs `tsc --noEmit` on the three workspace packages (`chia-gaming-fe`, `chia-gaming-hub-frontend`, `chia-gaming-hub-service`).
> 
> **Tests:** `test` → `ct.sh`, `test:js` → `tools/local-wasm-tests.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151db874f1adea7b7c3ac1b9e899b8dbf3373b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->