### PR TITLE
Attach fees to all transactions

### DIFF
--- a/front-end/src/constants/wallet-connect.ts
+++ b/front-end/src/constants/wallet-connect.ts
@@ -19,6 +19,7 @@ export enum ChiaMethod {
   GetHeightInfo = 'chia_getHeightInfo',
   SelectCoins = 'chia_selectCoins',
   CreateOfferForIds = 'chia_createOfferForIds',
+  SendTransaction = 'chia_sendTransaction',
   PushTransactions = 'chia_pushTransactions',
   CreateNewRemoteWallet = 'chia_createNewRemoteWallet',
   RegisterRemoteCoins = 'chia_registerRemoteCoins',

--- a/front-end/src/hooks/BlockchainPoller.ts
+++ b/front-end/src/hooks/BlockchainPoller.ts
@@ -123,11 +123,11 @@ export class BlockchainPoller {
           () => adapter.spend(blob, spendBundle, changePuzzleHash, source, fee),
           true,
         ),
-      rememberLocalRemovals: adapter.rememberLocalRemovals
-        ? (spendBundle) =>
+      createFeeSpend: adapter.createFeeSpend
+        ? (fee, concurrentSpendCoinId) =>
             this.enqueueRpc(
-              'rememberLocalRemovals',
-              () => adapter.rememberLocalRemovals!(spendBundle),
+              'createFeeSpend',
+              () => adapter.createFeeSpend!(fee, concurrentSpendCoinId),
               true,
             )
         : undefined,

--- a/front-end/src/hooks/RealBlockchainInterface.ts
+++ b/front-end/src/hooks/RealBlockchainInterface.ts
@@ -16,7 +16,12 @@ import {
   toHexString,
 } from '../util';
 import { decodeBech32mPuzzleHash, encodePuzzleHashToBech32m } from '../util/bech32m';
-import { CoinsetCoin, TransactionRecord, WalletSpendBundle } from '../types/rpc/PushTransactions';
+import {
+  CoinsetCoin,
+  CoinsetCoinSpend,
+  TransactionRecord,
+  WalletSpendBundle,
+} from '../types/rpc/PushTransactions';
 import { walletConnectState } from './useWalletConnect';
 import { clearWalletConnectStorage } from './save';
 import { jsonStringify } from '../util/jsonSafe';
@@ -210,6 +215,63 @@ async function rootRemovalsFromSpendBundle(spendBundle: WalletSpendBundle): Prom
   );
 }
 
+function firstDefined<T>(source: Record<string, unknown>, ...keys: string[]): T | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (value !== undefined && value !== null) return value as T;
+  }
+  return undefined;
+}
+
+// The wallet returns spend bundles over WalletConnect in camelCase
+// (`spendBundle`, `coinSpends`, `coin.parentCoinInfo`, `aggregatedSignature`),
+// but the WASM aggregator and our removal derivation both consume the coinset
+// snake_case shape. Normalize the wallet's bundle into that canonical shape once
+// here, accepting either casing, so nothing downstream has to care.
+function normalizeWalletSpendBundle(raw: unknown): WalletSpendBundle | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const bundle = raw as Record<string, unknown>;
+  const coinSpendsRaw = firstDefined<unknown[]>(bundle, 'coin_spends', 'coinSpends');
+  const aggregatedSignature = firstDefined<string>(
+    bundle,
+    'aggregated_signature',
+    'aggregatedSignature',
+  );
+  if (!Array.isArray(coinSpendsRaw) || typeof aggregatedSignature !== 'string') return null;
+
+  const coinSpends: CoinsetCoinSpend[] = [];
+  for (const entry of coinSpendsRaw) {
+    if (entry === null || typeof entry !== 'object') return null;
+    const cs = entry as Record<string, unknown>;
+    const coinRaw = cs.coin as Record<string, unknown> | undefined;
+    if (coinRaw === null || typeof coinRaw !== 'object') return null;
+    const parentCoinInfo = firstDefined<string>(coinRaw!, 'parent_coin_info', 'parentCoinInfo');
+    const puzzleHash = firstDefined<string>(coinRaw!, 'puzzle_hash', 'puzzleHash');
+    const amount = coinRaw!.amount;
+    const puzzleReveal = firstDefined<string>(cs, 'puzzle_reveal', 'puzzleReveal');
+    const solution = cs.solution as string | undefined;
+    if (
+      typeof parentCoinInfo !== 'string' ||
+      typeof puzzleHash !== 'string' ||
+      (typeof amount !== 'bigint' && typeof amount !== 'number') ||
+      typeof puzzleReveal !== 'string' ||
+      typeof solution !== 'string'
+    ) {
+      return null;
+    }
+    coinSpends.push({
+      coin: {
+        parent_coin_info: parentCoinInfo,
+        puzzle_hash: puzzleHash,
+        amount: typeof amount === 'bigint' ? amount : BigInt(amount),
+      },
+      puzzle_reveal: puzzleReveal,
+      solution,
+    });
+  }
+  return { coin_spends: coinSpends, aggregated_signature: aggregatedSignature };
+}
+
 export class RealBlockchainInterface implements InternalBlockchainInterface {
   readonly requestGapMs = WC_INTER_REQUEST_MS;
   blockchainAddressData: BlockchainInboundAddressResult;
@@ -225,7 +287,6 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
   private peerPollTimer: ReturnType<typeof setTimeout> | null = null;
   private peerPollEpoch = 0;
   private wcSubscription: { unsubscribe: () => void } | null = null;
-  private pendingLocalRemovalsForNextPush: CoinsetCoin[] = [];
   private monitoringReady = false;
   private monitoringPromise: Promise<void> | null = null;
   private monitoringEpoch = 0;
@@ -346,25 +407,13 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
     log(`[wc-blockchain] pushTransactions submitting #${seq} from=${src} fee=${feeValue}`);
 
     try {
-      const submittedRootRemovals = await rootRemovalsFromSpendBundle(
-        spendBundle as WalletSpendBundle,
-      );
-      const submittedRootIds = new Set<string>();
-      for (const coin of submittedRootRemovals) {
-        submittedRootIds.add(await coinIdFromBytes(toUint8(coinStringFromCoinsetCoin(coin))));
-      }
-      const removals: CoinsetCoin[] = [];
-      for (const coin of this.pendingLocalRemovalsForNextPush) {
-        const coinId = await coinIdFromBytes(toUint8(coinStringFromCoinsetCoin(coin)));
-        if (submittedRootIds.has(coinId)) {
-          removals.push(coin);
-        }
-      }
-      if (feeValue !== 0n && removals.length === 0) {
-        throw new Error(
-          'nonzero wallet fee requires local removal metadata for chia_pushTransactions',
-        );
-      }
+      // Removals are the non-ephemeral coins this (possibly fee-aggregated)
+      // bundle spends. The wallet persists them on the pending TransactionRecord
+      // and excludes them from coin selection, which stops the next submission
+      // from reusing an as-yet-unconfirmed fee coin. The fee-paying spend is
+      // already aggregated into spendBundle, so chia_pushTransactions must NOT
+      // add its own fee; `fee` here only populates fee_amount for wallet display.
+      const removals = await rootRemovalsFromSpendBundle(spendBundle as WalletSpendBundle);
       const txRecord = await this.buildTransactionRecord(
         spendBundle as WalletSpendBundle,
         feeValue,
@@ -375,10 +424,8 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
         transactions: [txRecord],
         push: true,
         sign: false,
-        fee: feeValue || undefined,
         allowUnsynced: true,
       });
-      this.pendingLocalRemovalsForNextPush = [];
       log(
         `[wc-blockchain] pushTransactions submitted #${seq} removals=${removals.length} result=${jsonStringify(result)}`,
       );
@@ -399,11 +446,51 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
     }
   }
 
-  async rememberLocalRemovals(spendBundle: unknown): Promise<void> {
-    const removals = await rootRemovalsFromSpendBundle(spendBundle as WalletSpendBundle);
-    if (removals.length === 0) return;
-    this.pendingLocalRemovalsForNextPush = removals;
-    log(`[wc-blockchain] remembered local removals count=${removals.length}`);
+  async createFeeSpend(
+    fee: bigint,
+    concurrentSpendCoinId: string,
+  ): Promise<WalletSpendBundle | null> {
+    if (fee <= 0n) return null;
+    const changePuzzleHash = this.blockchainAddressData.puzzleHash;
+    if (!changePuzzleHash) {
+      log('[wc-blockchain] createFeeSpend skipped: no change puzzle hash yet');
+      return null;
+    }
+    const coinId = concurrentSpendCoinId.startsWith('0x')
+      ? concurrentSpendCoinId
+      : `0x${normalizeHexString(concurrentSpendCoinId)}`;
+    try {
+      // push=false so the wallet signs the fee spend (auto_sign_txs) but does
+      // not broadcast it. We aggregate it into the protocol bundle ourselves and
+      // push the combined bundle. ASSERT_CONCURRENT_SPEND binds this fee spend to
+      // a coin our protocol bundle spends, so it can never be mined on its own.
+      const response = await rpc.sendTransaction({
+        walletId: 1n,
+        amount: 1n,
+        address: encodePuzzleHashToBech32m(changePuzzleHash),
+        fee,
+        push: false,
+        allowUnsynced: true,
+        extraConditions: [{ opcode: 64n, args: { coin_id: coinId } }],
+      });
+      const record =
+        (response as any)?.transactions?.[0] ?? (response as any)?.transaction ?? undefined;
+      // The wallet returns camelCase over WalletConnect; normalize into the
+      // canonical snake_case coinset shape the aggregator and removal code use.
+      const rawBundle = record?.spendBundle ?? record?.spend_bundle;
+      const spendBundle = normalizeWalletSpendBundle(rawBundle);
+      if (!spendBundle) {
+        log('[wc-blockchain] createFeeSpend: response had no signed spend bundle');
+        return null;
+      }
+      log(
+        `[wc-blockchain] createFeeSpend ok fee=${fee} bind=${coinId} coinSpends=${spendBundle.coin_spends.length}`,
+      );
+      return spendBundle;
+    } catch (e) {
+      log(`[wc-blockchain] createFeeSpend failed: ${collectErrorText(e)}`);
+      return null;
+    }
   }
 
   async getBalance(): Promise<bigint> {

--- a/front-end/src/hooks/RealBlockchainInterface.ts
+++ b/front-end/src/hooks/RealBlockchainInterface.ts
@@ -44,16 +44,19 @@ function remoteWalletStorageKey(fingerprint: string): string {
 
 function loadCachedChangeAddress(fingerprint: string): string | null {
   try {
-    const puzzleHash = localStorage.getItem(changeAddressStorageKey(fingerprint));
-    return puzzleHash && /^[0-9a-f]{64}$/i.test(puzzleHash) ? puzzleHash.toLowerCase() : null;
+    const address = localStorage.getItem(changeAddressStorageKey(fingerprint));
+    // Keep the full bech32m address (with its network HRP), not just the puzzle
+    // hash: the fee spend re-uses it verbatim. Validate it still decodes to a
+    // 32-byte puzzle hash so stale/foreign values are treated as a cache miss.
+    return address && decodeBech32mPuzzleHash(address) ? address : null;
   } catch {
     return null;
   }
 }
 
-function saveCachedChangeAddress(fingerprint: string, puzzleHash: string): void {
+function saveCachedChangeAddress(fingerprint: string, address: string): void {
   try {
-    localStorage.setItem(changeAddressStorageKey(fingerprint), puzzleHash.toLowerCase());
+    localStorage.setItem(changeAddressStorageKey(fingerprint), address);
   } catch {
     // Best-effort cache; a miss only means we ask the wallet again.
   }
@@ -317,19 +320,19 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
         throw new Error('no fingerprint set in walletconnect');
       }
 
-      let puzzleHash = loadCachedChangeAddress(fingerprint);
-      if (!puzzleHash) {
-        const addr = await rpc.getNextAddress({ walletId: 1n, newAddress: true });
-        puzzleHash = decodeBech32mPuzzleHash(addr);
-        if (!puzzleHash) {
-          throw new Error(`failed to decode change address: ${addr}`);
-        }
-        saveCachedChangeAddress(fingerprint, puzzleHash);
-        log(`[wc-blockchain] address resolved: ${addr} → ${puzzleHash}`);
+      let address = loadCachedChangeAddress(fingerprint);
+      if (address) {
+        log(`[wc-blockchain] address restored from cache → ${address}`);
       } else {
-        log(`[wc-blockchain] address restored from cache → ${puzzleHash}`);
+        address = await rpc.getNextAddress({ walletId: 1n, newAddress: true });
+        saveCachedChangeAddress(fingerprint, address);
+        log(`[wc-blockchain] address resolved: ${address}`);
       }
-      this.blockchainAddressData = { puzzleHash };
+      const puzzleHash = decodeBech32mPuzzleHash(address);
+      if (!puzzleHash) {
+        throw new Error(`failed to decode change address: ${address}`);
+      }
+      this.blockchainAddressData = { puzzleHash, address };
       this.ensureRemoteWallet(fingerprint);
       await this.waitForRemoteWallet(epoch);
       if (epoch !== this.monitoringEpoch || !walletConnectState.getSession()) {
@@ -451,9 +454,9 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
     concurrentSpendCoinId: string,
   ): Promise<WalletSpendBundle | null> {
     if (fee <= 0n) return null;
-    const changePuzzleHash = this.blockchainAddressData.puzzleHash;
-    if (!changePuzzleHash) {
-      log('[wc-blockchain] createFeeSpend skipped: no change puzzle hash yet');
+    const { puzzleHash: changePuzzleHash, address: changeAddress } = this.blockchainAddressData;
+    if (!changePuzzleHash || !changeAddress) {
+      log('[wc-blockchain] createFeeSpend skipped: no change address yet');
       return null;
     }
     const coinId = concurrentSpendCoinId.startsWith('0x')
@@ -464,10 +467,13 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
       // not broadcast it. We aggregate it into the protocol bundle ourselves and
       // push the combined bundle. ASSERT_CONCURRENT_SPEND binds this fee spend to
       // a coin our protocol bundle spends, so it can never be mined on its own.
+      // Use the wallet's own address string verbatim: send_transaction validates
+      // the address HRP against its network, so a re-encoded mainnet (xch) prefix
+      // would be rejected on testnet (txch), unlike the inert to_address on push.
       const response = await rpc.sendTransaction({
         walletId: 1n,
         amount: 1n,
-        address: encodePuzzleHashToBech32m(changePuzzleHash),
+        address: changeAddress,
         fee,
         push: false,
         allowUnsynced: true,
@@ -480,16 +486,19 @@ export class RealBlockchainInterface implements InternalBlockchainInterface {
       const rawBundle = record?.spendBundle ?? record?.spend_bundle;
       const spendBundle = normalizeWalletSpendBundle(rawBundle);
       if (!spendBundle) {
-        log('[wc-blockchain] createFeeSpend: response had no signed spend bundle');
-        return null;
+        throw new Error('wallet returned no signed spend bundle for the fee');
       }
       log(
         `[wc-blockchain] createFeeSpend ok fee=${fee} bind=${coinId} coinSpends=${spendBundle.coin_spends.length}`,
       );
       return spendBundle;
     } catch (e) {
-      log(`[wc-blockchain] createFeeSpend failed: ${collectErrorText(e)}`);
-      return null;
+      // Propagate the real reason (RPC error, missing signed bundle) so the
+      // caller's user-facing warning is accurate rather than always blaming
+      // insufficient balance.
+      const text = collectErrorText(e);
+      log(`[wc-blockchain] createFeeSpend failed: ${text}`);
+      throw e instanceof Error ? e : new Error(text);
     }
   }
 

--- a/front-end/src/hooks/SessionController.ts
+++ b/front-end/src/hooks/SessionController.ts
@@ -722,20 +722,29 @@ export class SessionController implements PollingGameSession {
       let appliedFee = 0n;
       if (fee > 0n && protocolBundle && this.wc && blockchain.rpc.createFeeSpend) {
         const bindCoinId = await this.computeBindCoinId(protocolBundle);
-        const feeSpend = bindCoinId ? await blockchain.rpc.createFeeSpend(fee, bindCoinId) : null;
+        let feeSpend: unknown = null;
+        let feeSpendError: string | undefined;
+        if (bindCoinId) {
+          try {
+            feeSpend = await blockchain.rpc.createFeeSpend(fee, bindCoinId);
+          } catch (e) {
+            feeSpendError = extractErrorMessage(e);
+          }
+        }
         if (feeSpend) {
           bundleToSubmit = this.wc.aggregate_coinset_spend_bundles(
             jsonStringify([protocolBundle, feeSpend]),
           );
           appliedFee = fee;
         } else {
-          // The wallet couldn't produce a signed fee spend (most commonly
-          // insufficient funds, but also an unsynced wallet or RPC failure).
-          // Submitting without a fee keeps the game progressing, but the user
-          // must know their configured fee was dropped for this transaction.
+          // The wallet couldn't produce a signed fee spend. Submitting without a
+          // fee keeps the game progressing, but the user must know their
+          // configured fee was dropped, and why (the real reason from the wallet
+          // when available, rather than a blanket "insufficient balance" guess).
+          const reason = feeSpendError ?? 'the wallet could not build a signed fee spend';
           const warning =
-            'Configured fee was not applied: the wallet could not fund it ' +
-            '(most likely insufficient balance). The transaction was submitted without a fee.';
+            `Configured fee was not applied: ${reason}. ` +
+            'The transaction was submitted without a fee.';
           log(`[wasm] submitTransaction: fee spend unavailable; ${warning}`);
           this.rxjsEmitter?.next({ type: 'error', error: warning });
         }

--- a/front-end/src/hooks/SessionController.ts
+++ b/front-end/src/hooks/SessionController.ts
@@ -729,7 +729,15 @@ export class SessionController implements PollingGameSession {
           );
           appliedFee = fee;
         } else {
-          log('[wasm] submitTransaction: fee spend unavailable; submitting with zero fee');
+          // The wallet couldn't produce a signed fee spend (most commonly
+          // insufficient funds, but also an unsynced wallet or RPC failure).
+          // Submitting without a fee keeps the game progressing, but the user
+          // must know their configured fee was dropped for this transaction.
+          const warning =
+            'Configured fee was not applied: the wallet could not fund it ' +
+            '(most likely insufficient balance). The transaction was submitted without a fee.';
+          log(`[wasm] submitTransaction: fee spend unavailable; ${warning}`);
+          this.rxjsEmitter?.next({ type: 'error', error: warning });
         }
       }
 

--- a/front-end/src/hooks/SessionController.ts
+++ b/front-end/src/hooks/SessionController.ts
@@ -17,7 +17,14 @@ import {
   requireWasmResult,
 } from '../types/ChiaGaming';
 import { BlockchainPoller, PollingGameSession } from './BlockchainPoller';
-import { spend_bundle_to_clvm, coerceToBytes } from '../util';
+import {
+  spend_bundle_to_clvm,
+  coerceToBytes,
+  coinIdFromBytes,
+  toUint8,
+  normalizeHexString,
+  encodeU64AsClvmHex,
+} from '../util';
 import { log, diagStack } from '../services/log';
 import { integersToBigInt, jsonStringify } from '../util/jsonSafe';
 import { flushSessionSave } from './save';
@@ -621,15 +628,12 @@ export class SessionController implements PollingGameSession {
         console.warn(
           '[wasm] createOfferForIds returned offer string; decoding via bech32 WASM path',
         );
-        const localSpendBundle = this.wc?.convert_offer_to_coinset_org(bundle);
-        await blockchain.rpc.rememberLocalRemovals?.(localSpendBundle);
         if (!this.cradle) {
           log('[wasm] handleNeedCoinSpend: cradle gone after wallet RPC; dropping');
           return;
         }
         this.processResult(this.cradle.provide_offer_bech32(bundle));
       } else {
-        await blockchain.rpc.rememberLocalRemovals?.(bundle);
         if (!this.cradle) {
           log('[wasm] handleNeedCoinSpend: cradle gone after wallet RPC; dropping');
           return;
@@ -678,6 +682,23 @@ export class SessionController implements PollingGameSession {
     this.kickSystem(1);
   }
 
+  // Coin id of the first coin the protocol bundle spends, used to bind a wallet
+  // fee spend via ASSERT_CONCURRENT_SPEND. Mirrors RealBlockchainInterface's
+  // coin-string construction so the two agree on coin ids.
+  private async computeBindCoinId(protocolBundle: unknown): Promise<string | undefined> {
+    const coinSpends = (protocolBundle as { coin_spends?: Array<{ coin?: unknown }> })?.coin_spends;
+    const coin = Array.isArray(coinSpends) ? (coinSpends[0]?.coin as any) : undefined;
+    if (!coin || coin.parent_coin_info === undefined || coin.puzzle_hash === undefined) {
+      return undefined;
+    }
+    const amount = typeof coin.amount === 'bigint' ? coin.amount : BigInt(coin.amount ?? 0);
+    const coinStringHex =
+      `${normalizeHexString(coin.parent_coin_info)}` +
+      `${normalizeHexString(coin.puzzle_hash)}` +
+      `${encodeU64AsClvmHex(amount)}`;
+    return coinIdFromBytes(toUint8(coinStringHex));
+  }
+
   private async submitTransactionNow(tx: SpendBundle) {
     const blockchain = this.blockchain;
     if (!blockchain) return;
@@ -686,18 +707,38 @@ export class SessionController implements PollingGameSession {
       // here (e.g. from the wasm connection) rejected the submit queue
       // unhandled.  Keep it inside the try so every failure path is captured.
       const blob = spend_bundle_to_clvm(tx);
-      const spendBundle = this.wc?.convert_spend_to_coinset_org(blob);
+      const protocolBundle = this.wc?.convert_spend_to_coinset_org(blob);
       const fee = this.getFee();
       log(`[wasm] submitTransaction blobLen=${blob.length}`);
       if (!this.rewardPuzzleHash) {
         throw new Error('submitTransactionNow: rewardPuzzleHash is not set');
       }
+
+      // Build the fee spend per attempt (never baked into the Rust-retained
+      // bundle) and aggregate it into the protocol bundle so a single pushed
+      // bundle carries a signature covering both. Any failure to obtain the fee
+      // spend falls back to a zero-fee submission rather than blocking the spend.
+      let bundleToSubmit: unknown = protocolBundle;
+      let appliedFee = 0n;
+      if (fee > 0n && protocolBundle && this.wc && blockchain.rpc.createFeeSpend) {
+        const bindCoinId = await this.computeBindCoinId(protocolBundle);
+        const feeSpend = bindCoinId ? await blockchain.rpc.createFeeSpend(fee, bindCoinId) : null;
+        if (feeSpend) {
+          bundleToSubmit = this.wc.aggregate_coinset_spend_bundles(
+            jsonStringify([protocolBundle, feeSpend]),
+          );
+          appliedFee = fee;
+        } else {
+          log('[wasm] submitTransaction: fee spend unavailable; submitting with zero fee');
+        }
+      }
+
       await blockchain.rpc.spend(
         blob,
-        spendBundle,
+        bundleToSubmit,
         this.rewardPuzzleHash,
         'submitTransaction',
-        fee || undefined,
+        appliedFee || undefined,
       );
     } catch (e) {
       const message = extractErrorMessage(e);

--- a/front-end/src/hooks/WalletConnectRpc.ts
+++ b/front-end/src/hooks/WalletConnectRpc.ts
@@ -23,6 +23,7 @@ import {
   GetPuzzleAndSolutionResponse,
 } from '../types/rpc/GetPuzzleAndSolution';
 import { PushTransactionsRequest, PushTransactionsResponse } from '../types/rpc/PushTransactions';
+import { SendTransactionRequest, SendTransactionResponse } from '../types/rpc/SendTransaction';
 import { SelectCoinsRequest, SelectCoinsResponse } from '../types/rpc/SelectCoins';
 import {
   GetFullNodePeerCountRequest,
@@ -293,6 +294,10 @@ async function pushTransactions(data: PushTransactionsRequest) {
   return await request<PushTransactionsResponse>(ChiaMethod.PushTransactions, data);
 }
 
+async function sendTransaction(data: SendTransactionRequest) {
+  return await request<SendTransactionResponse>(ChiaMethod.SendTransaction, data);
+}
+
 async function createNewRemoteWallet(data: CreateNewRemoteWalletRequest) {
   return await request<CreateNewRemoteWalletResponse>(ChiaMethod.CreateNewRemoteWallet, data);
 }
@@ -321,6 +326,7 @@ export const rpc = {
   getHeightInfo,
   createOfferForIds,
   pushTransactions,
+  sendTransaction,
   createNewRemoteWallet,
   registerRemoteCoins,
   getCoinRecordsByNames,

--- a/front-end/src/lib/tests/message_protocol.transport.test.ts
+++ b/front-end/src/lib/tests/message_protocol.transport.test.ts
@@ -15,9 +15,13 @@ import {
   enc,
   mockRpc,
   setActiveBlob,
+  submitTransaction,
   testSpendBundle,
+  transactionSubmitQueue,
   wasmResult,
 } from './message_protocol.harness';
+import { jsonStringify } from '../../util/jsonSafe';
+import { coinIdFromBytes, toUint8 } from '../../util';
 import {
   protocolIdentitiesReady,
   setProtocolIds,
@@ -841,6 +845,97 @@ describe('WASM wallet funding requests', () => {
     );
     expect(cradle.provide_coin_spend_bundle).toHaveBeenCalledWith(
       JSON.stringify(testSpendBundle('coin-spend')),
+    );
+  });
+});
+
+describe('wallet fee attachment on submission', () => {
+  const protocolBundle = {
+    coin_spends: [
+      {
+        coin: {
+          parent_coin_info: `0x${'aa'.repeat(32)}`,
+          puzzle_hash: `0x${'bb'.repeat(32)}`,
+          amount: 100n,
+        },
+        puzzle_reveal: '0x80',
+        solution: '0x80',
+      },
+    ],
+    aggregated_signature: '0xproto',
+  };
+
+  function attachWc(blob: SessionController, aggregate: jest.Mock) {
+    (blob as unknown as { wc: unknown }).wc = {
+      convert_spend_to_coinset_org: () => protocolBundle,
+      aggregate_coinset_spend_bundles: aggregate,
+    };
+  }
+
+  it('aggregates a wallet fee spend into the submitted bundle', async () => {
+    const feeSpend = {
+      coin_spends: [
+        {
+          coin: {
+            parent_coin_info: `0x${'99'.repeat(32)}`,
+            puzzle_hash: `0x${'88'.repeat(32)}`,
+            amount: 1000n,
+          },
+          puzzle_reveal: '0x80',
+          solution: '0x80',
+        },
+      ],
+      aggregated_signature: '0xfee',
+    };
+    const aggregated = { coin_spends: [], aggregated_signature: '0xcombined' };
+    const createFeeSpend = jest.fn().mockResolvedValue(feeSpend);
+    const spend = jest.fn().mockResolvedValue('ok');
+    const aggregate = jest.fn().mockReturnValue(aggregated);
+    const blockchain = new BlockchainPoller({ ...mockRpc, createFeeSpend, spend }, 60000);
+    const { blob } = createReadyBlob();
+    setActiveBlob(blob);
+    blob.blockchain = blockchain;
+    blob.getFee = () => 10n;
+    attachWc(blob, aggregate);
+
+    submitTransaction(blob, testSpendBundle('coin'));
+    await transactionSubmitQueue(blob);
+
+    // Fee spend bound to the coin id of the protocol bundle's first coin spend.
+    const bindCoinId = await coinIdFromBytes(toUint8(`${'aa'.repeat(32)}${'bb'.repeat(32)}64`));
+    expect(createFeeSpend).toHaveBeenCalledWith(10n, bindCoinId);
+    expect(aggregate).toHaveBeenCalledWith(jsonStringify([protocolBundle, feeSpend]));
+    expect(spend).toHaveBeenCalledWith(
+      expect.any(String),
+      aggregated,
+      '11'.repeat(32),
+      'submitTransaction',
+      10n,
+    );
+  });
+
+  it('submits with zero fee when the wallet cannot build a fee spend', async () => {
+    const createFeeSpend = jest.fn().mockResolvedValue(null);
+    const spend = jest.fn().mockResolvedValue('ok');
+    const aggregate = jest.fn();
+    const blockchain = new BlockchainPoller({ ...mockRpc, createFeeSpend, spend }, 60000);
+    const { blob } = createReadyBlob();
+    setActiveBlob(blob);
+    blob.blockchain = blockchain;
+    blob.getFee = () => 10n;
+    attachWc(blob, aggregate);
+
+    submitTransaction(blob, testSpendBundle('coin'));
+    await transactionSubmitQueue(blob);
+
+    expect(createFeeSpend).toHaveBeenCalled();
+    expect(aggregate).not.toHaveBeenCalled();
+    expect(spend).toHaveBeenCalledWith(
+      expect.any(String),
+      protocolBundle,
+      '11'.repeat(32),
+      'submitTransaction',
+      undefined,
     );
   });
 });

--- a/front-end/src/lib/tests/message_protocol.transport.test.ts
+++ b/front-end/src/lib/tests/message_protocol.transport.test.ts
@@ -947,4 +947,40 @@ describe('wallet fee attachment on submission', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatch(/fee was not applied/i);
   });
+
+  it('surfaces the real wallet error in the warning when the fee spend fails', async () => {
+    const createFeeSpend = jest.fn().mockRejectedValue(new Error('Internal error (code=-32603)'));
+    const spend = jest.fn().mockResolvedValue('ok');
+    const aggregate = jest.fn();
+    const blockchain = new BlockchainPoller({ ...mockRpc, createFeeSpend, spend }, 60000);
+    const { blob } = createReadyBlob();
+    setActiveBlob(blob);
+    blob.blockchain = blockchain;
+    blob.getFee = () => 10n;
+    attachWc(blob, aggregate);
+
+    const errors: string[] = [];
+    const subscription = blob.getObservable().subscribe((event) => {
+      if (event.type === 'error') errors.push(event.error);
+    });
+
+    submitTransaction(blob, testSpendBundle('coin'));
+    await transactionSubmitQueue(blob);
+    subscription.unsubscribe();
+
+    expect(createFeeSpend).toHaveBeenCalled();
+    expect(aggregate).not.toHaveBeenCalled();
+    // Zero-fee fallback still submits the protocol bundle.
+    expect(spend).toHaveBeenCalledWith(
+      expect.any(String),
+      protocolBundle,
+      '11'.repeat(32),
+      'submitTransaction',
+      undefined,
+    );
+    // The warning carries the actual wallet reason, not a blanket balance guess.
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/fee was not applied/i);
+    expect(errors[0]).toContain('Internal error (code=-32603)');
+  });
 });

--- a/front-end/src/lib/tests/message_protocol.transport.test.ts
+++ b/front-end/src/lib/tests/message_protocol.transport.test.ts
@@ -914,7 +914,7 @@ describe('wallet fee attachment on submission', () => {
     );
   });
 
-  it('submits with zero fee when the wallet cannot build a fee spend', async () => {
+  it('submits with zero fee and warns the user when the wallet cannot build a fee spend', async () => {
     const createFeeSpend = jest.fn().mockResolvedValue(null);
     const spend = jest.fn().mockResolvedValue('ok');
     const aggregate = jest.fn();
@@ -925,8 +925,14 @@ describe('wallet fee attachment on submission', () => {
     blob.getFee = () => 10n;
     attachWc(blob, aggregate);
 
+    const errors: string[] = [];
+    const subscription = blob.getObservable().subscribe((event) => {
+      if (event.type === 'error') errors.push(event.error);
+    });
+
     submitTransaction(blob, testSpendBundle('coin'));
     await transactionSubmitQueue(blob);
+    subscription.unsubscribe();
 
     expect(createFeeSpend).toHaveBeenCalled();
     expect(aggregate).not.toHaveBeenCalled();
@@ -937,5 +943,8 @@ describe('wallet fee attachment on submission', () => {
       'submitTransaction',
       undefined,
     );
+    // The user is warned that their configured fee was dropped for this tx.
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/fee was not applied/i);
   });
 });

--- a/front-end/src/lib/tests/real_blockchain_interface.test.ts
+++ b/front-end/src/lib/tests/real_blockchain_interface.test.ts
@@ -546,7 +546,9 @@ describe('RealBlockchainInterface', () => {
       address: encodePuzzleHashToBech32m(puzzleHash, 'txch'),
     };
     mockSendTransaction.mockRejectedValue(new Error('wallet not synced'));
-    await expect(blockchain.createFeeSpend(10n, 'cd'.repeat(32))).rejects.toThrow('wallet not synced');
+    await expect(blockchain.createFeeSpend(10n, 'cd'.repeat(32))).rejects.toThrow(
+      'wallet not synced',
+    );
   });
 
   it('returns null when the change address is not resolved yet', async () => {

--- a/front-end/src/lib/tests/real_blockchain_interface.test.ts
+++ b/front-end/src/lib/tests/real_blockchain_interface.test.ts
@@ -6,6 +6,7 @@ jest.mock('../../hooks/WalletConnectRpc', () => ({
     getCoinRecordsByNames: jest.fn(),
     getWallets: jest.fn(),
     pushTransactions: jest.fn(),
+    sendTransaction: jest.fn(),
     registerRemoteCoins: jest.fn(),
     selectCoins: jest.fn(),
     getFullNodePeerCount: jest.fn(async () => 1n),
@@ -53,6 +54,7 @@ const mockGetNextAddress = rpc.getNextAddress as jest.Mock;
 const mockGetCoinRecordsByNames = rpc.getCoinRecordsByNames as jest.Mock;
 const mockGetWallets = rpc.getWallets as jest.Mock;
 const mockPushTransactions = rpc.pushTransactions as jest.Mock;
+const mockSendTransaction = rpc.sendTransaction as jest.Mock;
 const mockRegisterRemoteCoins = rpc.registerRemoteCoins as jest.Mock;
 const mockSelectCoins = rpc.selectCoins as jest.Mock;
 const mockGetFullNodePeerCount = rpc.getFullNodePeerCount as jest.Mock;
@@ -99,6 +101,7 @@ describe('RealBlockchainInterface', () => {
     mockGetCoinRecordsByNames.mockReset();
     mockGetWallets.mockReset();
     mockPushTransactions.mockReset();
+    mockSendTransaction.mockReset();
     mockRegisterRemoteCoins.mockReset();
     mockSelectCoins.mockReset();
     mockGetFullNodePeerCount.mockReset();
@@ -409,11 +412,13 @@ describe('RealBlockchainInterface', () => {
     ).resolves.toEqual([record]);
   });
 
-  it('uses only local non-ephemeral coins as pushTransactions removal metadata', async () => {
+  it('records non-ephemeral root removals and never asks the wallet to add a fee', async () => {
     const parentCoinInfo = '11'.repeat(32);
     const puzzleHash = '22'.repeat(32);
     const amount = 100n;
-    const rootCoinId = await coinIdFromBytes(toUint8(`${parentCoinInfo}${puzzleHash}64`));
+    // Coin id of the first (root) coin below; the second coin's parent equals
+    // this, making it ephemeral and therefore excluded from removals.
+    const coinAId = await coinIdFromBytes(toUint8(`${parentCoinInfo}${puzzleHash}64`));
     const peerParentCoinInfo = '44'.repeat(32);
     const peerPuzzleHash = '55'.repeat(32);
     const peerAmount = 80n;
@@ -421,30 +426,8 @@ describe('RealBlockchainInterface', () => {
     blockchain.blockchainAddressData = { puzzleHash };
     mockPushTransactions.mockResolvedValue({ success: true });
 
-    await blockchain.rememberLocalRemovals({
-      coin_spends: [
-        {
-          coin: {
-            parent_coin_info: `0x${parentCoinInfo}`,
-            puzzle_hash: `0x${puzzleHash}`,
-            amount,
-          },
-          puzzle_reveal: '0x80',
-          solution: '0x80',
-        },
-        {
-          coin: {
-            parent_coin_info: `0x${rootCoinId}`,
-            puzzle_hash: `0x${'33'.repeat(32)}`,
-            amount: 50n,
-          },
-          puzzle_reveal: '0x80',
-          solution: '0x80',
-        },
-      ],
-      aggregated_signature: '0x00',
-    });
-
+    // The bundle handed to spend is now the (possibly fee-aggregated) bundle
+    // itself; removals are derived from its own non-ephemeral coin spends.
     const submittedBundle = {
       coin_spends: [
         {
@@ -457,8 +440,9 @@ describe('RealBlockchainInterface', () => {
           solution: '0x80',
         },
         {
+          // Ephemeral: parent is the coin spent above.
           coin: {
-            parent_coin_info: `0x${rootCoinId}`,
+            parent_coin_info: `0x${coinAId}`,
             puzzle_hash: `0x${'33'.repeat(32)}`,
             amount: 50n,
           },
@@ -481,22 +465,88 @@ describe('RealBlockchainInterface', () => {
       blockchain.spend('80', submittedBundle, puzzleHash, 'submitTransaction', 10n),
     ).resolves.toEqual({ success: true });
 
-    expect(mockPushTransactions).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fee: 10n,
-        transactions: [
-          expect.objectContaining({
-            removals: [
-              {
-                parent_coin_info: `0x${parentCoinInfo}`,
-                puzzle_hash: `0x${puzzleHash}`,
-                amount,
-              },
-            ],
-          }),
-        ],
-      }),
-    );
+    const call = mockPushTransactions.mock.calls[0][0];
+    // The fee-paying spend is aggregated in by the caller; chia_pushTransactions
+    // must not add its own fee. `fee` is surfaced only as fee_amount for display.
+    expect(call.fee).toBeUndefined();
+    expect(call.transactions[0].fee_amount).toBe(10n);
+    expect(call.transactions[0].removals).toEqual([
+      {
+        parent_coin_info: `0x${parentCoinInfo}`,
+        puzzle_hash: `0x${puzzleHash}`,
+        amount,
+      },
+      {
+        parent_coin_info: `0x${peerParentCoinInfo}`,
+        puzzle_hash: `0x${peerPuzzleHash}`,
+        amount: peerAmount,
+      },
+    ]);
+  });
+
+  it('builds a wallet-signed fee spend bound with ASSERT_CONCURRENT_SPEND', async () => {
+    const puzzleHash = '11'.repeat(32);
+    const blockchain = new RealBlockchainInterface();
+    blockchain.blockchainAddressData = { puzzleHash };
+    // The wallet returns the signed bundle over WalletConnect in camelCase,
+    // including nested coin fields. createFeeSpend must normalize this into the
+    // canonical snake_case coinset shape the aggregator/removal code consume.
+    const walletFeeBundle = {
+      coinSpends: [
+        {
+          coin: {
+            parentCoinInfo: `0x${'99'.repeat(32)}`,
+            puzzleHash: `0x${'88'.repeat(32)}`,
+            amount: 1000n,
+          },
+          puzzleReveal: '0x80',
+          solution: '0x80',
+        },
+      ],
+      aggregatedSignature: '0xfee',
+    };
+    mockSendTransaction.mockResolvedValue({ transactions: [{ spendBundle: walletFeeBundle }] });
+
+    const bindCoinId = 'ab'.repeat(32);
+    const result = await blockchain.createFeeSpend(10n, bindCoinId);
+
+    expect(result).toEqual({
+      coin_spends: [
+        {
+          coin: {
+            parent_coin_info: `0x${'99'.repeat(32)}`,
+            puzzle_hash: `0x${'88'.repeat(32)}`,
+            amount: 1000n,
+          },
+          puzzle_reveal: '0x80',
+          solution: '0x80',
+        },
+      ],
+      aggregated_signature: '0xfee',
+    });
+    expect(mockSendTransaction).toHaveBeenCalledWith({
+      walletId: 1n,
+      amount: 1n,
+      address: encodePuzzleHashToBech32m(puzzleHash),
+      fee: 10n,
+      push: false,
+      allowUnsynced: true,
+      extraConditions: [{ opcode: 64n, args: { coin_id: `0x${bindCoinId}` } }],
+    });
+  });
+
+  it('returns null when the wallet cannot build a fee spend', async () => {
+    const blockchain = new RealBlockchainInterface();
+    blockchain.blockchainAddressData = { puzzleHash: '11'.repeat(32) };
+    mockSendTransaction.mockRejectedValue(new Error('wallet not synced'));
+    await expect(blockchain.createFeeSpend(10n, 'cd'.repeat(32))).resolves.toBeNull();
+  });
+
+  it('does not contact the wallet for a zero fee', async () => {
+    const blockchain = new RealBlockchainInterface();
+    blockchain.blockchainAddressData = { puzzleHash: '11'.repeat(32) };
+    await expect(blockchain.createFeeSpend(0n, 'cd'.repeat(32))).resolves.toBeNull();
+    expect(mockSendTransaction).not.toHaveBeenCalled();
   });
 
   it('uses the provided change puzzle hash in the transaction record', async () => {

--- a/front-end/src/lib/tests/real_blockchain_interface.test.ts
+++ b/front-end/src/lib/tests/real_blockchain_interface.test.ts
@@ -486,8 +486,11 @@ describe('RealBlockchainInterface', () => {
 
   it('builds a wallet-signed fee spend bound with ASSERT_CONCURRENT_SPEND', async () => {
     const puzzleHash = '11'.repeat(32);
+    // The wallet's address carries the network HRP (txch on testnet); createFeeSpend
+    // must forward it verbatim so send_transaction's address validation passes.
+    const address = encodePuzzleHashToBech32m(puzzleHash, 'txch');
     const blockchain = new RealBlockchainInterface();
-    blockchain.blockchainAddressData = { puzzleHash };
+    blockchain.blockchainAddressData = { puzzleHash, address };
     // The wallet returns the signed bundle over WalletConnect in camelCase,
     // including nested coin fields. createFeeSpend must normalize this into the
     // canonical snake_case coinset shape the aggregator/removal code consume.
@@ -527,7 +530,7 @@ describe('RealBlockchainInterface', () => {
     expect(mockSendTransaction).toHaveBeenCalledWith({
       walletId: 1n,
       amount: 1n,
-      address: encodePuzzleHashToBech32m(puzzleHash),
+      address,
       fee: 10n,
       push: false,
       allowUnsynced: true,
@@ -535,11 +538,22 @@ describe('RealBlockchainInterface', () => {
     });
   });
 
-  it('returns null when the wallet cannot build a fee spend', async () => {
+  it('propagates the wallet error when it cannot build a fee spend', async () => {
+    const puzzleHash = '11'.repeat(32);
     const blockchain = new RealBlockchainInterface();
-    blockchain.blockchainAddressData = { puzzleHash: '11'.repeat(32) };
+    blockchain.blockchainAddressData = {
+      puzzleHash,
+      address: encodePuzzleHashToBech32m(puzzleHash, 'txch'),
+    };
     mockSendTransaction.mockRejectedValue(new Error('wallet not synced'));
+    await expect(blockchain.createFeeSpend(10n, 'cd'.repeat(32))).rejects.toThrow('wallet not synced');
+  });
+
+  it('returns null when the change address is not resolved yet', async () => {
+    const blockchain = new RealBlockchainInterface();
+    blockchain.blockchainAddressData = { puzzleHash: '' };
     await expect(blockchain.createFeeSpend(10n, 'cd'.repeat(32))).resolves.toBeNull();
+    expect(mockSendTransaction).not.toHaveBeenCalled();
   });
 
   it('does not contact the wallet for a zero fee', async () => {

--- a/front-end/src/types/ChiaGaming.ts
+++ b/front-end/src/types/ChiaGaming.ts
@@ -237,6 +237,7 @@ export interface WasmConnection {
   drain_submissions: (cid: number) => SpendBundle[];
   resubmit_submitted: (cid: number) => void;
   convert_spend_to_coinset_org: (spend: string) => unknown;
+  aggregate_coinset_spend_bundles: (bundles_json: string) => unknown;
   convert_offer_to_coinset_org: (offer: string) => unknown;
   convert_coinset_to_coin_string: (
     parent_coin_info: string,
@@ -496,7 +497,12 @@ export interface InternalBlockchainInterface {
     source?: string,
     fee?: bigint,
   ): Promise<string>;
-  rememberLocalRemovals?(spendBundle: unknown): void | Promise<void>;
+  // Build a standalone, wallet-signed fee-paying spend bundle bound to the
+  // given coin via ASSERT_CONCURRENT_SPEND. Returns null when the wallet cannot
+  // produce it (unsynced, insufficient funds, RPC unavailable) so the caller can
+  // fall back to a zero-fee submission. Undefined on backends (e.g. the
+  // simulator) that do not support wallet fees.
+  createFeeSpend?(fee: bigint, concurrentSpendCoinId: string): Promise<unknown | null>;
   getAddress(): Promise<BlockchainInboundAddressResult>;
   getBalance(): Promise<bigint>;
   getPuzzleAndSolution(coin: string): Promise<string[] | null>;

--- a/front-end/src/types/ChiaGaming.ts
+++ b/front-end/src/types/ChiaGaming.ts
@@ -473,6 +473,11 @@ export interface BlockchainReport {
 
 export interface BlockchainInboundAddressResult {
   puzzleHash: string;
+  // The wallet-provided bech32m address string carrying the correct network HRP
+  // (e.g. txch on testnet). Used verbatim as the fee-spend destination so the
+  // wallet's send_transaction address validation matches its configured network.
+  // Optional: backends that only surface a puzzle hash may omit it.
+  address?: string;
 }
 
 export interface ConnectionField {
@@ -498,10 +503,11 @@ export interface InternalBlockchainInterface {
     fee?: bigint,
   ): Promise<string>;
   // Build a standalone, wallet-signed fee-paying spend bundle bound to the
-  // given coin via ASSERT_CONCURRENT_SPEND. Returns null when the wallet cannot
-  // produce it (unsynced, insufficient funds, RPC unavailable) so the caller can
-  // fall back to a zero-fee submission. Undefined on backends (e.g. the
-  // simulator) that do not support wallet fees.
+  // given coin via ASSERT_CONCURRENT_SPEND. Returns null when no fee spend is
+  // needed or the wallet address is not resolved yet. Throws when the wallet
+  // fails to produce the spend (unsynced, insufficient funds, RPC error) so the
+  // caller can surface the real reason instead of silently dropping the fee.
+  // Undefined on backends (e.g. the simulator) that do not support wallet fees.
   createFeeSpend?(fee: bigint, concurrentSpendCoinId: string): Promise<unknown | null>;
   getAddress(): Promise<BlockchainInboundAddressResult>;
   getBalance(): Promise<bigint>;

--- a/front-end/src/types/rpc/SendTransaction.ts
+++ b/front-end/src/types/rpc/SendTransaction.ts
@@ -1,0 +1,24 @@
+import { TransactionRecord } from './PushTransactions';
+
+export interface SendTransactionRequest {
+  walletId: bigint;
+  amount: bigint;
+  address: string;
+  fee?: bigint;
+  memos?: string[];
+  // TransactionEndpointRequest fields, honored by the wallet's tx_endpoint.
+  push?: boolean;
+  sign?: boolean;
+  // Parsed by conditions_from_json_dicts; each entry is { opcode, args } where
+  // args matches the driver's streamable field names (e.g. { coin_id } for
+  // ASSERT_CONCURRENT_SPEND).
+  extraConditions?: Array<{ opcode: bigint; args: Record<string, unknown> }>;
+  allowUnsynced?: boolean;
+}
+
+export interface SendTransactionResponse {
+  transactions: TransactionRecord[];
+  transaction: TransactionRecord;
+  transaction_id: string;
+  success?: boolean;
+}

--- a/wasm/src/mod.rs
+++ b/wasm/src/mod.rs
@@ -1429,6 +1429,25 @@ mod gaming_wasm {
         serde_wasm_bindgen::to_value(&spend_bundle_to_coinset_js(&spend)?).into_js()
     }
 
+    /// Aggregate several coinset.org-shaped spend bundles into one.  Coin spends
+    /// are concatenated and the BLS aggregate signatures are summed (BLS
+    /// aggregation is point addition), so passing our pre-signed protocol bundle
+    /// together with a separately-signed wallet fee spend yields a single bundle
+    /// whose aggregate signature covers both.  Input is a JSON array of
+    /// `CoinsetSpendBundle`.
+    #[wasm_bindgen]
+    pub fn aggregate_coinset_spend_bundles(bundles_json: &str) -> Result<JsValue, JsValue> {
+        let bundles = serde_json::from_str::<Vec<CoinsetSpendBundle>>(bundles_json)
+            .map_err(|e| JsValue::from_str(&format!("bad spend bundle json: {e}")))?;
+        let mut spends = Vec::new();
+        for bundle in bundles.iter() {
+            let converted = coinset_spend_bundle_to_spend_bundle(bundle).into_js()?;
+            spends.extend(converted.spends);
+        }
+        let merged = SpendBundle { name: None, spends };
+        serde_wasm_bindgen::to_value(&spend_bundle_to_coinset_js(&merged)?).into_js()
+    }
+
     #[wasm_bindgen]
     pub fn convert_coinset_to_coin_string(
         parent_coin_info: &str,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the end-to-end transaction submission and fee path through WalletConnect and WASM aggregation; mistakes could drop fees or mis-report removals, though fallbacks and new tests reduce blast radius.
> 
> **Overview**
> **WalletConnect transactions now carry user-configured fees** by building a separate wallet-signed fee spend, merging it with the protocol spend bundle, and pushing a single aggregated bundle—instead of relying on `chia_pushTransactions` to add a fee or on pre-push “local removal” bookkeeping.
> 
> On each submission, `SessionController` asks the wallet (via new **`createFeeSpend`**) for a **`chia_sendTransaction`** with `push: false`, an **`ASSERT_CONCURRENT_SPEND`** tied to the protocol bundle’s first coin, and the cached **bech32m change address** (network HRP preserved for testnet/mainnet validation). WASM **`aggregate_coinset_spend_bundles`** concatenates spends and sums signatures; **`pushTransactions`** no longer receives a `fee` field—`fee_amount` is metadata only, and **removals** are derived from the submitted bundle’s non-ephemeral coins.
> 
> If the wallet cannot produce a fee spend, the game **still submits without a fee** and emits a **user-visible error** with the wallet’s reason. WalletConnect camelCase spend bundles are **normalized** to coinset snake_case before aggregation/removal logic runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49edd3cad5a530b93238049e725f4d6353324bf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->