### PR TITLE
Cloud Wallet "Coming Soon"

### DIFF
--- a/front-end/src/components/Shell.tsx
+++ b/front-end/src/components/Shell.tsx
@@ -4115,13 +4115,12 @@ const Shell = () => {
                   >
                     Link Wallet
                   </Button>
-                  <Button
-                    variant="solid"
-                    fullWidth
-                    onClick={() => handleConnect('cloud', false, true)}
-                  >
-                    Cloud Wallet
-                  </Button>
+                  <div className="flex flex-col gap-1">
+                    <Button variant="solid" fullWidth disabled title="Coming soon">
+                      Cloud Wallet
+                    </Button>
+                    <p className="text-xs text-canvas-text text-center">Coming soon</p>
+                  </div>
                 </div>
                 {connectError ? (
                   <p className="w-full max-w-sm text-sm text-alert-text text-center break-words">


### PR DESCRIPTION
Grey out the button for Cloud Wallet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating on the wallet picker; no changes to connect logic, auth, or session handling elsewhere.
> 
> **Overview**
> The **Choose Connection** flow on the Wallet tab no longer starts a Cloud Wallet session. **Cloud Wallet** is shown as a **disabled** primary button (with tooltip/title **Coming soon**) and a short **Coming soon** caption underneath, instead of calling `handleConnect('cloud', …)`.
> 
> **Link Wallet** and simulator paths are unchanged; this is a product gating change so users cannot enter the Cloud OAuth/setup path from this screen until the feature ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59cb42383893eb93c463994af4b2b9d3edb453a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->